### PR TITLE
HDP 설정 추가

### DIFF
--- a/common/params_keys.h
+++ b/common/params_keys.h
@@ -153,6 +153,7 @@ inline static std::unordered_map<std::string, uint32_t> keys = {
     {"ShowPathColorLane", PERSISTENT},
     {"ShowPlotMode", PERSISTENT},
     {"RecordRoadCam", PERSISTENT },
+    {"HDPuse", PERSISTENT },
 
     {"AutoCruiseControl", PERSISTENT},
     {"CruiseEcoControl", PERSISTENT},

--- a/opendbc_repo/opendbc/car/hyundai/hyundaicanfd.py
+++ b/opendbc_repo/opendbc/car/hyundai/hyundaicanfd.py
@@ -444,7 +444,15 @@ def create_adrv_messages(CP, packer, CAN, frame, CC, CS, hud_control, disp_angle
           cruise_enabled = CC.enabled
           lat_active = CC.latActive
           nav_active = hud_control.activeCarrot > 1
-          hdp_active = cruise_enabled and nav_active
+
+        
+          hdp_use = int(Params().get("HDPuse"))
+
+          hdp_active = False
+          if hdp_use == 1:
+              hdp_active = cruise_enabled and nav_active
+          elif hdp_use == 2:
+              hdp_active = cruise_enabled
 
           values = CS.adrv_info_161
           #print("adrv_info_161 = ", CS.adrv_info_161)

--- a/selfdrive/carrot_settings.json
+++ b/selfdrive/carrot_settings.json
@@ -744,6 +744,19 @@
     },
     {
       "group": "시작",
+      "name": "HDPuse",
+      "title": "HDP 사용(CCNC)",
+      "descr": "1:APN사용시, 2:항상",
+      "egroup": "START",
+      "etitle": "Use HDP(CCNC)",
+      "edescr": "1:While using APN, 2:Always",
+      "min": 0,
+      "max": 2,
+      "default": 0,
+      "unit": 1
+    },
+    {
+      "group": "시작",
       "name": "MapboxStyle",
       "title": "맵박스 스타일",
       "descr": "",

--- a/selfdrive/carrot_settings.json
+++ b/selfdrive/carrot_settings.json
@@ -752,7 +752,7 @@
       "edescr": "1:While using APN, 2:Always",
       "min": 0,
       "max": 2,
-      "default": 0,
+      "default": 1,
       "unit": 1
     },
     {

--- a/selfdrive/ui/qt/offroad/settings.cc
+++ b/selfdrive/ui/qt/offroad/settings.cc
@@ -808,6 +808,7 @@ CarrotPanel::CarrotPanel(QWidget* parent) : QWidget(parent) {
   //startToggles->addItem(new CValueControl("CarrotCountDownSpeed", "NaviCountDown Speed(10)", "", "../assets/offroad/icon_shell.png", 0, 200, 5));
   startToggles->addItem(new CValueControl("MapboxStyle", "Mapbox Style(0)", "", "../assets/offroad/icon_shell.png", 0, 2, 1));
   startToggles->addItem(new CValueControl("RecordRoadCam", "Record Road camera(0)", "1:RoadCam, 2:RoadCam+WideRoadCam", "../assets/offroad/icon_shell.png", 0, 2, 1));
+  startToggles->addItem(new CValueControl("HDPuse", "Use HDP(CCNC)(0)", "1:While Using APN, 2:Always", "../assets/offroad/icon_shell.png", 0, 2, 1));
   startToggles->addItem(new ParamControl("HotspotOnBoot", "Hotspot enabled on boot", "", "../assets/offroad/icon_shell.png", this));
   //startToggles->addItem(new ParamControl("NoLogging", "Disable Logger", "", "../assets/offroad/icon_shell.png", this));
   //startToggles->addItem(new ParamControl("LaneChangeNeedTorque", "LaneChange: Need Torque", "", "../assets/offroad/icon_shell.png", this));

--- a/system/manager/manager.py
+++ b/system/manager/manager.py
@@ -153,6 +153,7 @@ def get_default_params():
     ("MaxTimeOffroadMin", "60"),
     ("DisableDM", "0"),
     ("RecordRoadCam", "0"),
+    ("HDPuse", "1"),
     ("CruiseOnDist", "400"),
     ("HotspotOnBoot", "0"),
     ("CustomSR", "0"),


### PR DESCRIPTION
당근맨 / 콤마 설정 "시작"에 설정을 추가했습니다.
0 : hdp사용 안함.
1 : APN 사용도중에만 hdp 사용
2 : hdp 항상 사용
# HDP 활성화 상태에서는 계기판이 HDP로 고정되어 연비, 구동배분, 공기압 등을 확인할 수 없어 추가합니다.