### PR TITLE
캐스퍼ev fingerprint 추가 및 버튼 먹통 현상 해소

### DIFF
--- a/opendbc_repo/opendbc/car/hyundai/carstate.py
+++ b/opendbc_repo/opendbc/car/hyundai/carstate.py
@@ -250,11 +250,11 @@ class CarState(CarStateBase):
     prev_cruise_buttons = self.cruise_buttons[-1]
     #self.cruise_buttons.extend(cp.vl_all["CLU11"]["CF_Clu_CruiseSwState"])
     #carrot {{
-    if self.CP.extFlags & HyundaiExtFlags.CRUISE_BUTTON_ALT.value and cp.vl_all["CRUISE_BUTTON_ALT"]["SET_ME_1"] == 1:
-      self.cruise_buttons_alt = True
+    #if self.CP.extFlags & HyundaiExtFlags.CRUISE_BUTTON_ALT.value and cp.vl_all["CRUISE_BUTTON_ALT"]["SET_ME_1"] == 1:
+    #  self.cruise_buttons_alt = True
 
     cruise_button = [Buttons.NONE]
-    if self.cruise_buttons_alt:
+    if self.CP.extFlags & HyundaiExtFlags.CRUISE_BUTTON_ALT.value:
       lfa_button = cp.vl.get("CRUISE_BUTTON_LFA", {}).get("CruiseSwLfa", 0)
       cruise_button = [Buttons.LFA_BUTTON] if lfa_button > 0 else cp.vl_all["CRUISE_BUTTON_ALT"]["CruiseSwState"]
     elif self.CP.extFlags & HyundaiExtFlags.HAS_LFA_BUTTON.value and cp.vl.get("BCM_PO_11", {}).get("LFA_Pressed", 0):
@@ -265,7 +265,7 @@ class CarState(CarStateBase):
     # }} carrot
     prev_main_buttons = self.main_buttons[-1]
     #self.cruise_buttons.extend(cp.vl_all["CLU11"]["CF_Clu_CruiseSwState"])
-    if self.cruise_buttons_alt:
+    if self.CP.extFlags & HyundaiExtFlags.CRUISE_BUTTON_ALT.value:
       self.main_buttons.extend(cp.vl_all["CRUISE_BUTTON_ALT"]["CruiseSwMain"])
     else:
       self.main_buttons.extend(cp.vl_all["CLU11"]["CF_Clu_CruiseSwMain"])

--- a/opendbc_repo/opendbc/car/hyundai/fingerprints.py
+++ b/opendbc_repo/opendbc/car/hyundai/fingerprints.py
@@ -1285,4 +1285,15 @@ FW_VERSIONS = {
     (Ecu.fwdCamera, 0x7c4, None): [
     ],
   },
+  CAR.HYUNDAI_CASPER_EV: {
+    (Ecu.fwdRadar, 0x7d0, None): [
+      b'\xf1\x00AX__ RDR -----      1.00 1.00 99110-GX000         ',
+    ],
+    (Ecu.eps, 0x7d4, None): [
+      b'\xf1\x00AX  MDPS C 1.00 1.01 56300-GX000 4611',
+    ],
+    (Ecu.fwdCamera, 0x7c4, None): [
+      b'\xf1\x00AXE MFC  AT KOR LHD 1.00 1.00 99211-GX000 240615',
+    ],
+  },
 }


### PR DESCRIPTION
1. 캐스퍼ev fingerprint 값 추가

2. carrot2-v8 초기부터 발생한 캐스퍼ev 핸들버튼 먹통 문제 해소

* v8 초기버전때 추가한 아반떼 버튼문제 반영을 원복한 사항으로 병합시 아반떼 버튼문제 재발 가능성 있음.