### PR TITLE
fix recording

### DIFF
--- a/selfdrive/ui/qt/screenrecorder/screenrecorder.cc
+++ b/selfdrive/ui/qt/screenrecorder/screenrecorder.cc
@@ -140,18 +140,13 @@ void ScreenRecoder::encoding_thread_func() {
 
       QImage image = popImage.convertToFormat(QImage::Format_RGBA8888);
 
-      try {
-        libyuv::ARGBScale(image.bits(), image.width()*4,
-              image.width(), image.height(),
-              rgb_scale_buffer.get(), dst_width*4,
-              dst_width, dst_height,
-              libyuv::kFilterLinear);
-  
-        encoder->encode_frame_rgba(rgb_scale_buffer.get(), dst_width, dst_height, ((uint64_t)nanos_since_boot() - start_time ));
-      } catch (...) {
-        printf("Encoding failed, skipping frame\n");
-        continue;
-      }
+      libyuv::ARGBScale(image.bits(), image.width()*4,
+            image.width(), image.height(),
+            rgb_scale_buffer.get(), dst_width*4,
+            dst_width, dst_height,
+            libyuv::kFilterLinear);
+
+      encoder->encode_frame_rgba(rgb_scale_buffer.get(), dst_width, dst_height, ((uint64_t)nanos_since_boot() - start_time ));
     }
   }
 }
@@ -172,7 +167,7 @@ void ScreenRecoder::update_screen() {
 
   if(recording) {
 
-    if(milliseconds() - started > 1000*60*3) {
+    if(milliseconds() - started > 1000*60*60) {
       stop();
       start();
       return;


### PR DESCRIPTION
1. 녹화 영상이 3번중 1번 꼴로 누락되는 현상 해결
2. 녹화가 잘 되었다하더라도, 영상의 50%가 누락되는 현상 해결
3. 3분마다 영상을 끊는부분 -> 60분으로 변경
4. 녹화 중 콤마의 프레임이 저하되는 부분 해결된 듯 보임.