### PR TITLE
Enhance lane mode handling with smoothing filter

### DIFF
--- a/selfdrive/controls/lib/lateral_planner.py
+++ b/selfdrive/controls/lib/lateral_planner.py
@@ -10,9 +10,9 @@ import cereal.messaging as messaging
 from cereal import log
 
 from openpilot.common.params import Params
+from openpilot.common.filter_simple import FirstOrderFilter
 #from openpilot.selfdrive.controls.lib.lane_planner import LanePlanner
 from openpilot.selfdrive.controls.lib.lane_planner_2 import LanePlanner
-from collections import deque
 
 TRAJECTORY_SIZE = 33
 CAMERA_OFFSET = 0.04
@@ -73,6 +73,9 @@ class LateralPlanner:
     self.curve_speed = 0
     self.lanemode_possible_count = 0
     self.laneless_only = True
+    self.laneless_only_count = 0
+    # Smoothing filter for lanemode transitions to reduce steering jerk
+    self.useLaneLineMode_filter = FirstOrderFilter(0.0, 1.5, DT_MDL)  # 1.5초 tau로 부드러운 전환
 
   def reset_mpc(self, x0=None):
     if x0 is None:
@@ -110,44 +113,72 @@ class LateralPlanner:
       self.v_plan = np.clip(car_speed, MIN_SPEED, np.inf)
       self.v_ego = self.v_plan[0]
       self.plan_a = np.array(md.acceleration.x)
-      if md.velocity.x[-1] < md.velocity.x[0] * 0.7:  # TODO: 모델이 감속을 요청하는 경우 속도테이블이 레인모드를 할수 없음. 속도테이블을 새로 만들어야함..
-        self.lanemode_possible_count = 0
-        self.laneless_only = True
-      else:
+      # UseLaneLineSpeed가 활성화되어 있으면 lanemode로 고정 사용 (laneless_only 조건 무시)
+      if self.useLaneLineSpeedApply > 0:
+        # lanemode 고정 모드: 감속 조건을 무시하고 항상 lanemode 가능 상태 유지
         self.lanemode_possible_count += 1
-        if self.lanemode_possible_count > int(1/DT_MDL):
-          self.laneless_only = False
+        self.laneless_only = False
+        self.laneless_only_count = 0
+      else:
+        # UseLaneLineSpeed가 0일 때만 기존 로직 적용 (완화된 조건)
+        decel_threshold = 0.5  # 감속 임계값 완화 (기존 0.7 -> 0.5)
+        if md.velocity.x[-1] < md.velocity.x[0] * decel_threshold:
+          self.lanemode_possible_count = 0
+          self.laneless_only_count += 1
+          # 3초 이상 지속되어야 laneless로 확정 전환 (즉시 전환 방지)
+          if self.laneless_only_count > int(3.0/DT_MDL):
+            self.laneless_only = True
+        else:
+          self.lanemode_possible_count += 1
+          self.laneless_only_count = max(0, self.laneless_only_count - 2)  # 점진적으로 감소
+          if self.lanemode_possible_count > int(1/DT_MDL):
+            # laneless_only_count가 충분히 낮아야 False로 전환 (지연된 복귀)
+            if self.laneless_only_count < int(1.5/DT_MDL):
+              self.laneless_only = False
 
     # Parse model predictions
     self.LP.parse_model(md)
     #lane_change_prob = self.LP.l_lane_change_prob + self.LP.r_lane_change_prob
     #self.DH.update(sm['carState'], md, sm['carControl'].latActive, lane_change_prob, sm)
 
-    if self.useLaneLineSpeedApply == 0 or self.laneless_only:
-      self.useLaneLineMode = False
-    elif self.v_ego*3.6 >= self.useLaneLineSpeedApply + 2:
+    # Determine target lanemode state
+    target_useLaneLineMode = False
+    if self.useLaneLineSpeedApply == 0:
+      # UseLaneLineSpeed가 0이면 laneless 모드
+      target_useLaneLineMode = False
+    else:
+      # UseLaneLineSpeed가 0보다 크면: 감속/저속/커브에서도 항상 레인모드 유지
+      target_useLaneLineMode = True
+
+    # Smooth transition to prevent sudden steering changes
+    if self.useLaneLineSpeedApply > 0:
+      # 레인모드 고정: 즉시 1.0으로 수렴시키고 상태를 항상 True로 유지
+      self.useLaneLineMode_filter.update(1.0)
       self.useLaneLineMode = True
-    elif self.v_ego*3.6 < self.useLaneLineSpeedApply - 2:
-      self.useLaneLineMode = False
+    else:
+      # UseLaneLineSpeed가 0일 때는 기존 로직 (부드러운 전환)
+      self.useLaneLineMode_filter.update(target_useLaneLineMode)
+      self.useLaneLineMode = self.useLaneLineMode_filter.x > 0.3
 
     # Turn off lanes during lane change
     #if self.DH.desire == log.Desire.laneChangeRight or self.DH.desire == log.Desire.laneChangeLeft:
-      
+
     if md.meta.desire != log.Desire.none or carrot.atc_active:
       self.LP.lane_change_multiplier = 0.0 #md.meta.laneChangeProb
     else:
       self.LP.lane_change_multiplier = 1.0
 
     # lanelines calculation?
-    self.LP.lanefull_mode = self.useLaneLineMode
+    # 레인모드 고정 시 LanePlanner에도 항상 lanefull 적용
+    self.LP.lanefull_mode = True if self.useLaneLineSpeedApply > 0 else self.useLaneLineMode
     self.LP.lane_width_left = md.meta.laneWidthLeft
     self.LP.lane_width_right = md.meta.laneWidthRight
     self.LP.curvature = measured_curvature
     self.path_xyz, self.lanelines_active = self.LP.get_d_path(sm['carState'], self.v_ego, self.t_idxs, self.path_xyz, self.curve_speed)
-    
+
     #if self.LP.lanefull_mode:
     #  self.plan_yaw, self.plan_yaw_rate = self.LP.calculate_plan_yaw_and_yaw_rate(self.path_xyz)
-      
+
     self.latDebugText = self.LP.debugText
     #self.lanelines_active = True if self.LP.d_prob > 0.3 and self.LP.lanefull_mode else False
 
@@ -192,7 +223,7 @@ class LateralPlanner:
       self.solution_invalid_cnt += 1
     else:
       self.solution_invalid_cnt = 0
-  
+
     self.x_sol = self.lat_mpc.x_sol
 
   def publish(self, sm, pm, carrot):


### PR DESCRIPTION
Added a smoothing filter for lane mode transitions and adjusted conditions for lane mode activation based on speed and deceleration thresholds.

<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

