### PR TITLE
Implement steering reduction filters in LatControlPID

### DIFF
--- a/selfdrive/controls/lib/latcontrol_pid.py
+++ b/selfdrive/controls/lib/latcontrol_pid.py
@@ -3,6 +3,9 @@ import math
 from cereal import log
 from openpilot.selfdrive.controls.lib.latcontrol import LatControl
 from openpilot.common.pid import PIDController
+from openpilot.common.filter_simple import FirstOrderFilter
+
+LaneChangeState = log.LaneChangeState
 
 
 class LatControlPID(LatControl):
@@ -12,6 +15,12 @@ class LatControlPID(LatControl):
                              (CP.lateralTuning.pid.kiBP, CP.lateralTuning.pid.kiV),
                              k_f=CP.lateralTuning.pid.kf, pos_limit=self.steer_max, neg_limit=-self.steer_max)
     self.get_steer_feedforward = CI.get_steer_feedforward_function()
+
+    # Steering pressed 감쇠 필터: 수동 조향 시 자동조향을 부드럽게 완화
+    # 1.0 = 정상, 0.25 = steeringPressed 시 감쇠 (약간의 자동조향 감도 유지)
+    # 차선변경 중일 때는 더 긴 시정수로 부드러운 전환 (nudge 모드 대응)
+    self.steer_pressed_reduction_factor = FirstOrderFilter(1.0, 0.6, 0.01)  # 기본 0.6초 시정수
+    self.steer_pressed_reduction_factor_lc = FirstOrderFilter(1.0, 0.9, 0.01)  # 차선변경 시 0.9초 시정수
 
   def reset(self):
     super().reset()
@@ -38,6 +47,24 @@ class LatControlPID(LatControl):
 
       output_steer = self.pid.update(error, override=CS.steeringPressed,
                                      feedforward=steer_feedforward, speed=CS.vEgo)
+
+      # steeringPressed 상태에서 자동조향을 느슨하게 하여 수동 조향을 부드럽게
+      # 감쇠 계수: 1.0 (정상) -> 0.25 (steeringPressed, 약간의 자동조향 감도 유지)
+      # 차선변경 중일 때는 더 부드러운 전환을 위해 긴 시정수 필터 사용 (nudge 모드 대응)
+      is_lane_changing = False
+      if model_data is not None and hasattr(model_data, 'meta') and hasattr(model_data.meta, 'laneChangeState'):
+        lane_change_state = model_data.meta.laneChangeState
+        # laneChangeStarting(2) 또는 laneChangeFinishing(3) 상태일 때
+        is_lane_changing = lane_change_state in (LaneChangeState.laneChangeStarting, LaneChangeState.laneChangeFinishing)
+
+      target_reduction = 0.25 if CS.steeringPressed else 1.0
+      if is_lane_changing:
+        # 차선변경 중일 때는 더 긴 시정수로 부드러운 전환 (nudge 모드에서 자동조향으로 전환 시)
+        reduction_factor = self.steer_pressed_reduction_factor_lc.update(target_reduction)
+      else:
+        reduction_factor = self.steer_pressed_reduction_factor.update(target_reduction)
+      output_steer = output_steer * reduction_factor
+
       pid_log.active = True
       pid_log.p = float(self.pid.p)
       pid_log.i = float(self.pid.i)


### PR DESCRIPTION
Added first-order filters for steering reduction during manual steering and lane changes.

<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

