### PR TITLE
LaneLineCheck 옵션: 차선변경 판단 및 HUD 색상 연동

### DIFF
--- a/common/params_keys.h
+++ b/common/params_keys.h
@@ -278,6 +278,7 @@ inline static std::unordered_map<std::string, ParamKeyAttributes> keys = {
     {"LaneChangeNeedTorque", {PERSISTENT, INT, "0"}},
     {"LaneChangeDelay", {PERSISTENT, INT, "0"}},
     {"LaneChangeBsd", {PERSISTENT, INT, "0"}},
+    {"LaneLineCheck", {PERSISTENT, INT, "0"}},
     {"MaxAngleFrames", {PERSISTENT, INT, "89"}},
 
     {"SoftHoldMode", {PERSISTENT, INT, "0"}},

--- a/opendbc_repo/opendbc/car/hyundai/hyundaicanfd.py
+++ b/opendbc_repo/opendbc/car/hyundai/hyundaicanfd.py
@@ -644,6 +644,9 @@ def create_ccnc_messages(CP, packer, CAN, frame, CC, CS, hud_control,
   ret = []
 
   md = CS.MD
+  if not hasattr(create_ccnc_messages, '_lane_line_check') or frame % 100 == 0:
+    create_ccnc_messages._lane_line_check = Params().get_int("LaneLineCheck")
+  lane_line_check = create_ccnc_messages._lane_line_check
   desire, lane_changing = _get_desire_and_lane_changing(md)
 
   if CP.flags & HyundaiFlags.CAMERA_SCC.value:
@@ -743,14 +746,22 @@ def create_ccnc_messages(CP, packer, CAN, frame, CC, CS, hud_control,
         values["LANELINE_CURVATURE_DIRECTION"] = 1 if curvature < 0 and lat_active else 0
 
         lane_color = 6 if md is not None and md.meta.laneChangeAvailableLeft else 2
-        lane_color = 4 if CS.out.leftLaneLine >= 20 or CS.out.leftBlindspot else lane_color
+        if lane_line_check >= 1:
+          lane_line_warn_left = CS.out.leftLaneLine % 10 not in (0, 5)   # 실선이면 주황
+        else:
+          lane_line_warn_left = CS.out.leftLaneLine >= 20                  # 노란색이면 주황
+        lane_color = 4 if lane_line_warn_left or CS.out.leftBlindspot else lane_color
         if hud_control.leftLaneDepart:
           values["LANELINE_LEFT"] = 4 if (frame // 50) % 2 == 0 else 1
         else:
           values["LANELINE_LEFT"] = lane_color if hud_control.leftLaneVisible else 0
 
         lane_color = 6 if md is not None and md.meta.laneChangeAvailableRight else 2
-        lane_color = 4 if CS.out.rightLaneLine >= 20 or CS.out.rightBlindspot else lane_color
+        if lane_line_check >= 1:
+          lane_line_warn_right = CS.out.rightLaneLine % 10 not in (0, 5)
+        else:
+          lane_line_warn_right = CS.out.rightLaneLine >= 20
+        lane_color = 4 if lane_line_warn_right or CS.out.rightBlindspot else lane_color
         if hud_control.rightLaneDepart:
           values["LANELINE_RIGHT"] = 4 if (frame // 50) % 2 == 0 else 1
         else:

--- a/selfdrive/carrot_settings.json
+++ b/selfdrive/carrot_settings.json
@@ -1653,17 +1653,17 @@
       "group": "조향일반",
       "name": "LaneLineCheck",
       "title": "차선변경 차선판단",
-      "descr": "0: 색상+타입(노란선차단)\n1: 타입만(점선/실선)",
+      "descr": "0: 색상+타입(노란선차단)\n1: 타입만(점선/실선)\n2: 타입만+실선토크override",
       "egroup": "LAT",
       "etitle": "LaneChange LineCheck",
-      "edescr": "0: Color+Type(block yellow), 1: Type only(dashed/solid)",
+      "edescr": "0: Color+Type(block yellow), 1: Type only, 2: Type+torque override solid",
       "min": 0,
-      "max": 1,
+      "max": 2,
       "default": 0,
       "unit": 1,
       "cgroup": "转向",
       "ctitle": "变道车道判断",
-      "cdescr": "0: 颜色+类型(黄线阻止), 1: 仅类型(虚线/实线)"
+      "cdescr": "0: 颜色+类型(黄线阻止), 1: 仅类型(虚线/实线), 2: 仅类型+实线扭矩override"
     },
     {
       "group": "시작",

--- a/selfdrive/carrot_settings.json
+++ b/selfdrive/carrot_settings.json
@@ -1650,6 +1650,22 @@
       "cdescr": "0: BSD 检测 (允许转向力矩), 1: 阻止转向力矩, -1: 忽略 BSD"
     },
     {
+      "group": "조향일반",
+      "name": "LaneLineCheck",
+      "title": "차선변경 차선판단",
+      "descr": "0: 색상+타입(노란선차단)\n1: 타입만(점선/실선)",
+      "egroup": "LAT",
+      "etitle": "LaneChange LineCheck",
+      "edescr": "0: Color+Type(block yellow), 1: Type only(dashed/solid)",
+      "min": 0,
+      "max": 1,
+      "default": 0,
+      "unit": 1,
+      "cgroup": "转向",
+      "ctitle": "变道车道判断",
+      "cdescr": "0: 颜色+类型(黄线阻止), 1: 仅类型(虚线/实线)"
+    },
+    {
       "group": "시작",
       "name": "HapticFeedbackWhenSpeedCamera",
       "title": "핸들햅틱기능사용(0)",

--- a/selfdrive/controls/lib/desire_helper.py
+++ b/selfdrive/controls/lib/desire_helper.py
@@ -57,6 +57,7 @@ class DesireHelper:
     # params
     self.laneChangeNeedTorque = 0
     self.laneChangeBsd = 0
+    self.laneLineCheck = 0
     self.laneChangeDelay = 0.0
     self.modelTurnSpeedFactor = 0.0
     self.model_turn_speed = 200.0
@@ -76,6 +77,7 @@ class DesireHelper:
     if self.frame % 100 == 0:
       self.laneChangeNeedTorque = self.params.get_int("LaneChangeNeedTorque")
       self.laneChangeBsd = self.params.get_int("LaneChangeBsd")
+      self.laneLineCheck = self.params.get_int("LaneLineCheck")
       self.laneChangeDelay = self.params.get_float("LaneChangeDelay") * 0.1
       self.modelTurnSpeedFactor = self.params.get_float("ModelTurnSpeedFactor") * 0.1
 
@@ -191,8 +193,14 @@ class DesireHelper:
     self.right.update_obstacles(v_ego, radarState.leadRight, carstate.rightBlindspot, ignore_bsd, bsd_hold_sec=2.0)
 
     # compute available (include BSD+object)
-    self.left.compute_lane_change_available(lane_line_info_lt_20=(self.left.lane_line_info_raw < 20), ignore_bsd=ignore_bsd)
-    self.right.compute_lane_change_available(lane_line_info_lt_20=(self.right.lane_line_info_raw < 20), ignore_bsd=ignore_bsd)
+    if self.laneLineCheck == 1:
+      left_line_ok = self.left.lane_line_info_mod in (0, 5)
+      right_line_ok = self.right.lane_line_info_mod in (0, 5)
+    else:
+      left_line_ok = self.left.lane_line_info_raw < 20
+      right_line_ok = self.right.lane_line_info_raw < 20
+    self.left.compute_lane_change_available(lane_line_info_lt_20=left_line_ok, ignore_bsd=ignore_bsd)
+    self.right.compute_lane_change_available(lane_line_info_lt_20=right_line_ok, ignore_bsd=ignore_bsd)
 
     self.left.update_triggers()
     self.right.update_triggers()

--- a/selfdrive/controls/lib/desire_helper.py
+++ b/selfdrive/controls/lib/desire_helper.py
@@ -193,7 +193,7 @@ class DesireHelper:
     self.right.update_obstacles(v_ego, radarState.leadRight, carstate.rightBlindspot, ignore_bsd, bsd_hold_sec=2.0)
 
     # compute available (include BSD+object)
-    if self.laneLineCheck == 1:
+    if self.laneLineCheck >= 1:
       left_line_ok = self.left.lane_line_info_mod in (0, 5)
       right_line_ok = self.right.lane_line_info_mod in (0, 5)
     else:
@@ -358,10 +358,16 @@ class DesireHelper:
               # 차선변경 시작 조건:
               # - side.lane_change_available는 BSD+object 포함(요구사항)
               # - 하지만 BSD 중에도 torque override 허용해야 하므로, BSD 분기를 별도로 둠(원본 동작 유지)
-              start_gate = (side.lane_change_available_geom and self.lane_change_delay == 0) or side.lane_line_info_edge_detect
+              # LaneLineCheck=2: 실선에서도 토크 override 허용
+              solid_line_blocked = (self.laneLineCheck >= 2) and (not side.lane_change_available_geom) and \
+                                   (side.lane_available or side.edge_available)
+              start_gate = (side.lane_change_available_geom and self.lane_change_delay == 0) or \
+                           side.lane_line_info_edge_detect or solid_line_blocked
 
               if start_gate:
-                if bsd_active:
+                if solid_line_blocked and not torque_applied:
+                  pass  # 실선: 토크 없으면 대기
+                elif bsd_active:
                   if torque_applied and (not block_lanechange_bsd):
                     self.lane_change_state = LaneChangeState.laneChangeStarting
                 elif self.laneChangeNeedTorque > 0 or self.next_lane_change:

--- a/selfdrive/controls/lib/desire_helper.py
+++ b/selfdrive/controls/lib/desire_helper.py
@@ -365,8 +365,9 @@ class DesireHelper:
                            side.lane_line_info_edge_detect or solid_line_blocked
 
               if start_gate:
-                if solid_line_blocked and not torque_applied:
-                  pass  # 실선: 토크 없으면 대기
+                if solid_line_blocked:
+                  if torque_applied and not (bsd_active and block_lanechange_bsd):
+                    self.lane_change_state = LaneChangeState.laneChangeStarting
                 elif bsd_active:
                   if torque_applied and (not block_lanechange_bsd):
                     self.lane_change_state = LaneChangeState.laneChangeStarting

--- a/selfdrive/ui/qt/offroad/settings.cc
+++ b/selfdrive/ui/qt/offroad/settings.cc
@@ -698,6 +698,7 @@ CarrotPanel::CarrotPanel(QWidget* parent) : QWidget(parent) {
   latLongToggles->addItem(new CValueControl("LaneChangeNeedTorque", tr("LaneChange need torque"), tr("-1:Disable lanechange, 0: no need torque, 1:need torque"), -1, 1, 1));
   latLongToggles->addItem(new CValueControl("LaneChangeDelay", tr("LaneChange delay"), tr("x0.1sec"), 0, 100, 5));
   latLongToggles->addItem(new CValueControl("LaneChangeBsd", tr("LaneChange Bsd"), tr("-1:ignore bsd, 0:BSD detect, 1: block steer torque"), -1, 1, 1));
+  latLongToggles->addItem(new CValueControl("LaneLineCheck", tr("LaneChange LineCheck"), tr("0:Color+Type, 1:Type only(dashed/solid)"), 0, 1, 1));
   latLongToggles->addItem(new CValueControl("CustomSR", tr("LAT: SteerRatiox0.1(0)"), tr("Custom SteerRatio"), 0, 300, 1));
   latLongToggles->addItem(new CValueControl("SteerRatioRate", tr("LAT: SteerRatioRatex0.01(100)"), tr("SteerRatio apply rate"), 30, 170, 1));
   latLongToggles->addItem(new CValueControl("PathOffset", tr("LAT: PathOffset"), tr("(-)left, (+)right"), -150, 150, 1));

--- a/selfdrive/ui/qt/offroad/settings.cc
+++ b/selfdrive/ui/qt/offroad/settings.cc
@@ -698,7 +698,7 @@ CarrotPanel::CarrotPanel(QWidget* parent) : QWidget(parent) {
   latLongToggles->addItem(new CValueControl("LaneChangeNeedTorque", tr("LaneChange need torque"), tr("-1:Disable lanechange, 0: no need torque, 1:need torque"), -1, 1, 1));
   latLongToggles->addItem(new CValueControl("LaneChangeDelay", tr("LaneChange delay"), tr("x0.1sec"), 0, 100, 5));
   latLongToggles->addItem(new CValueControl("LaneChangeBsd", tr("LaneChange Bsd"), tr("-1:ignore bsd, 0:BSD detect, 1: block steer torque"), -1, 1, 1));
-  latLongToggles->addItem(new CValueControl("LaneLineCheck", tr("LaneChange LineCheck"), tr("0:Color+Type, 1:Type only(dashed/solid)"), 0, 1, 1));
+  latLongToggles->addItem(new CValueControl("LaneLineCheck", tr("LaneChange LineCheck"), tr("0:Color+Type, 1:Type only, 2:Type+torque override solid"), 0, 2, 1));
   latLongToggles->addItem(new CValueControl("CustomSR", tr("LAT: SteerRatiox0.1(0)"), tr("Custom SteerRatio"), 0, 300, 1));
   latLongToggles->addItem(new CValueControl("SteerRatioRate", tr("LAT: SteerRatioRatex0.01(100)"), tr("SteerRatio apply rate"), 30, 170, 1));
   latLongToggles->addItem(new CValueControl("PathOffset", tr("LAT: PathOffset"), tr("(-)left, (+)right"), -150, 150, 1));


### PR DESCRIPTION
## Summary
- **LaneLineCheck 파라미터 추가**: 차선변경 시 차선 판단 기준을 설정하는 옵션 (0=기존/색상, 1=타입만, 2=실선 토크 override 허용)
- **HUD 차선 색상을 LaneLineCheck에 연동**: LaneLineCheck≥1일 때 HUD 주황색 표시를 색상(노란색) 대신 타입(실선/점선) 기준으로 판단하여 차선변경 로직과 일치시킴
- **LaneLineCheck=2 실선 토크 override 버그 수정**

## 동작 정리

| LaneLineCheck | 점선 | 실선 | 노란점선 | 노란실선 | BSD |
|---|---|---|---|---|---|
| **0** (기존) | 초록/흰 | 흰색 | **주황** | **주황** | 주황 |
| **1, 2** | 초록/흰 | **주황** | 초록/흰 | **주황** | 주황 |

## 변경 파일
- `common/params_keys.h` — LaneLineCheck 파라미터 키 등록
- `selfdrive/carrot_settings.json` — 설정 UI 항목 추가
- `selfdrive/ui/qt/offroad/settings.cc` — 설정 메뉴 등록
- `selfdrive/controls/lib/desire_helper.py` — 차선변경 판단 로직
- `opendbc_repo/opendbc/car/hyundai/hyundaicanfd.py` — HUD 차선 색상 표시 로직

## Test plan
- [x] LaneLineCheck=0: 기존 동작과 동일한지 확인 (노란색 차선에서 주황 표시)
- [x] LaneLineCheck=1: 실선에서 주황, 노란점선에서 초록/흰색 표시 확인
- [x] LaneLineCheck=2: 실선에서 토크 override 허용 동작 확인
- [x] BSD 감지 시 항상 주황 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)