### PR TITLE
KIA K7: Add gearStep display using LVR11 for CLUSTER_GEARS

### DIFF
--- a/opendbc_repo/opendbc/car/hyundai/carstate.py
+++ b/opendbc_repo/opendbc/car/hyundai/carstate.py
@@ -356,7 +356,7 @@ class CarState(CarStateBase):
       gear = cp.vl["EMS20"]["HYDROGEN_GEAR_SHIFTER"]
     elif self.CP.flags & HyundaiFlags.CLUSTER_GEARS:
       gear = cp.vl["CLU15"]["CF_Clu_Gear"]
-      ret.gearStep = int(cp.vl["TCU12"]["CUR_GR"])
+      ret.gearStep = cp.vl["LVR11"]["CF_Lvr_GearInf"]
     elif self.CP.flags & HyundaiFlags.TCU_GEARS:
       gear = cp.vl["TCU12"]["CUR_GR"]
     else:

--- a/opendbc_repo/opendbc/car/hyundai/carstate.py
+++ b/opendbc_repo/opendbc/car/hyundai/carstate.py
@@ -356,6 +356,7 @@ class CarState(CarStateBase):
       gear = cp.vl["EMS20"]["HYDROGEN_GEAR_SHIFTER"]
     elif self.CP.flags & HyundaiFlags.CLUSTER_GEARS:
       gear = cp.vl["CLU15"]["CF_Clu_Gear"]
+      ret.gearStep = int(cp.vl["TCU12"]["CUR_GR"])
     elif self.CP.flags & HyundaiFlags.TCU_GEARS:
       gear = cp.vl["TCU12"]["CUR_GR"]
     else:


### PR DESCRIPTION
## Summary
- KIA K7 (2016-2019) CLUSTER_GEARS 경로에서 기어 단수(1~8단) 표시 기능 추가
- `LVR11.CF_Lvr_GearInf` 신호를 사용하여 `gearStep` 값을 읽어옴
- 기존 TCU12는 K7 CAN 버스에 존재하지 않아 LVR11으로 변경하여 정상 동작 확인

## Changes
- `opendbc_repo/opendbc/car/hyundai/carstate.py`: CLUSTER_GEARS 분기에 `ret.gearStep = cp.vl["LVR11"]["CF_Lvr_GearInf"]` 1줄 추가

## Test
- KIA K7 2016-2019 실차 테스트 완료
- CAN 에러 없이 기어 단수 정상 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)