### PR TITLE
브랜치 목록 필터에 리모트 브랜치 포함

### DIFF
--- a/selfdrive/carrot/server/core.py
+++ b/selfdrive/carrot/server/core.py
@@ -789,8 +789,9 @@ def _filter_branch_list(branches: list[str]) -> list[str]:
       continue
 
     # local branch: c3-xxx / c4-xxx
-    # remote branch: origin/c3-xxx / origin/c4-xxx
-    if name.startswith(prefix) or name.startswith(f"origin/{prefix}"):
+    # remote branch: origin/c3-xxx, ajouatom/c3-xxx, etc.
+    branch_name = name.split("/", 1)[-1] if "/" in name else name
+    if branch_name.startswith(prefix):
       filtered.append(name)
 
   return sorted(set(filtered))


### PR DESCRIPTION
## Summary
- 브랜치 목록 필터(`_filter_branch_list`)에서 `origin/` 리모트만 통과되던 문제 수정
- `ajouatom/c3-xxx` 등 다른 리모트 브랜치도 prefix 기준으로 필터링되도록 변경

## Test plan
- [x] 웹 UI에서 브랜치 목록 조회 시 origin 외 리모트 브랜치도 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)