### PR TITLE
KIA K7: Add gearStep display for CLUSTER_GEARS using LVR11

### DIFF
--- a/opendbc_repo/opendbc/car/hyundai/carstate.py
+++ b/opendbc_repo/opendbc/car/hyundai/carstate.py
@@ -340,6 +340,7 @@ class CarState(CarStateBase):
       gear = cp.vl["EMS20"]["HYDROGEN_GEAR_SHIFTER"]
     elif self.CP.flags & HyundaiFlags.CLUSTER_GEARS:
       gear = cp.vl["CLU15"]["CF_Clu_Gear"]
+      ret.gearStep = cp.vl["LVR11"]["CF_Lvr_GearInf"]
     elif self.CP.flags & HyundaiFlags.TCU_GEARS:
       gear = cp.vl["TCU12"]["CUR_GR"]
     else:

--- a/opendbc_repo/opendbc/car/hyundai/carstate.py
+++ b/opendbc_repo/opendbc/car/hyundai/carstate.py
@@ -340,7 +340,8 @@ class CarState(CarStateBase):
       gear = cp.vl["EMS20"]["HYDROGEN_GEAR_SHIFTER"]
     elif self.CP.flags & HyundaiFlags.CLUSTER_GEARS:
       gear = cp.vl["CLU15"]["CF_Clu_Gear"]
-      ret.gearStep = cp.vl["LVR11"]["CF_Lvr_GearInf"]
+      if self.CP.carFingerprint == CAR.KIA_K7:
+        ret.gearStep = cp.vl["LVR11"]["CF_Lvr_GearInf"]
     elif self.CP.flags & HyundaiFlags.TCU_GEARS:
       gear = cp.vl["TCU12"]["CUR_GR"]
     else:


### PR DESCRIPTION
안녕하세요 당마님 항상 감사합니다.

## Summary
KIA K7 (2016-2019)에서 기어 단수 표시가 되지 않아 수정했습니다.

CLUSTER_GEARS 경로에서 `LVR11.CF_Lvr_GearInf`를 사용하여 gearStep을 표시하도록 추가했습니다.
다른 CLUSTER_GEARS 차량에 영향이 없도록 KIA_K7에서만 적용되게 했습니다.

## Changes
```python
elif self.CP.flags & HyundaiFlags.CLUSTER_GEARS:
    gear = cp.vl["CLU15"]["CF_Clu_Gear"]
    if self.CP.carFingerprint == CAR.KIA_K7:
        ret.gearStep = cp.vl["LVR11"]["CF_Lvr_GearInf"]
```

## Test
- KIA K7 2016-2019 실차 테스트 완료
- CAN 에러 없이 기어 단수 정상 표시 확인