### PR TITLE
토크바 대신 당근 아이콘에 토크 한계 반영

### DIFF
--- a/selfdrive/ui/mici/onroad/hud_renderer.py
+++ b/selfdrive/ui/mici/onroad/hud_renderer.py
@@ -1,10 +1,12 @@
 import json
 import time
+import numpy as np
 import pyray as rl
 from dataclasses import dataclass
 from typing import Optional
 from openpilot.common.constants import CV
-from openpilot.selfdrive.ui.mici.onroad.torque_bar import TorqueBar
+# from openpilot.selfdrive.ui.mici.onroad.torque_bar import TorqueBar # 아이콘에 토크 적용: 토크바 미사용
+from openpilot.selfdrive.ui.mici.onroad import blend_colors
 from openpilot.selfdrive.ui.ui_state import ui_state, UIStatus
 from openpilot.system.ui.lib.application import gui_app, FontWeight
 from openpilot.system.ui.lib.multilang import tr
@@ -15,6 +17,7 @@ from openpilot.common.filter_simple import FirstOrderFilter
 from cereal import log
 from openpilot.common.params import Params
 from datetime import datetime
+from opendbc.car import ACCELERATION_DUE_TO_GRAVITY
 
 EventName = log.OnroadEvent.EventName
 
@@ -24,6 +27,7 @@ KM_TO_MILE = 0.621371
 CRUISE_DISABLED_CHAR = '–'
 
 SET_SPEED_PERSISTENCE = 2.5  # seconds
+DEFAULT_MAX_LAT_ACCEL = 3.0  # m/s^2
 
 @dataclass(frozen=True)
 class SetSpeedOverrideState:
@@ -180,7 +184,8 @@ class HudRenderer(Widget):
     self._font_display: rl.Font = gui_app.font(FontWeight.DISPLAY)
 
     self._turn_intent = TurnIntent()
-    self._torque_bar = TorqueBar()
+    # self._torque_bar = TorqueBar() # 아이콘에 토크 적용: 토크바 미사용
+    self._torque_filter = FirstOrderFilter(0, 0.1, 1 / gui_app.target_fps) # 아이콘에 토크 적용: LowPassFilter
 
     # 휠 당근 휠로 변경
     self._txt_wheel: rl.Texture = gui_app.texture('icons_mici/carrot_wheel.png', 50, 50) # 당근 휠
@@ -243,10 +248,30 @@ class HudRenderer(Widget):
     speed_conversion = CV.MS_TO_KPH if ui_state.is_metric else CV.MS_TO_MPH
     self.speed = max(0.0, v_ego * speed_conversion)
 
+    # 토크 상태 계산 (휠 아이콘 크기 조절용) from TorqueBar()
+    if controls_state.lateralControlState.which() == 'angleState':
+      live_parameters = sm['liveParameters']
+      car_control = sm['carControl']
+
+      actual_lateral_accel = controls_state.curvature * car_state.vEgo ** 2
+      desired_lateral_accel = controls_state.desiredCurvature * car_state.vEgo ** 2
+      accel_diff = (desired_lateral_accel - actual_lateral_accel)
+
+      roll_compensation = live_parameters.roll * ACCELERATION_DUE_TO_GRAVITY * np.interp(car_state.vEgo, [5, 15], [0.0, 1.0])
+      lateral_acceleration = actual_lateral_accel - roll_compensation
+      max_lateral_acceleration = ui_state.CP.maxLateralAccel if ui_state.CP else DEFAULT_MAX_LAT_ACCEL
+
+      if car_control.latActive:
+        self._torque_filter.update(float(np.clip((lateral_acceleration + accel_diff) / max_lateral_acceleration, -1.0, 1.0)))
+      else:
+        self._torque_filter.update(0.0)
+    else:
+      self._torque_filter.update(float(-sm['carOutput'].actuatorsOutput.torque))
+
   def _render(self, rect: rl.Rectangle) -> None:
     """Render HUD elements to the screen."""
 
-    self._torque_bar.render(rect)
+    # self._torque_bar.render(rect) # 아이콘에 토크 적용: 토크바 미사용
 
     # bottom-left panel (speed_bg)
     self._draw_set_speed(rect)
@@ -273,20 +298,30 @@ class HudRenderer(Widget):
   def _draw_steering_wheel_icon(self, wheel_txt, pos_x: int, pos_y: int) -> None:
     rotation = -ui_state.sm['carState'].steeringAngleDeg
 
-    turn_intent_margin = 25
+    torque_val = abs(self._torque_filter.x)
+    # 토크가 0.5 넘어가면 휠 아이콘을 서서히 1.5배까지 키우기
+    scale = float(np.interp(torque_val, [0.5, 1.0], [1.0, 1.5]))
+    scaled_width = wheel_txt.width * scale
+    scaled_height = wheel_txt.height * scale
+
+    turn_intent_margin = 25 * scale
     self._turn_intent.render(rl.Rectangle(
-      pos_x - wheel_txt.width / 2 - turn_intent_margin,
-      pos_y - wheel_txt.height / 2 - turn_intent_margin,
-      wheel_txt.width + turn_intent_margin * 2,
-      wheel_txt.height + turn_intent_margin * 2,
+      pos_x - scaled_width / 2 - turn_intent_margin,
+      pos_y - scaled_height / 2 - turn_intent_margin,
+      scaled_width + turn_intent_margin * 2,
+      scaled_height + turn_intent_margin * 2,
     ))
 
     src_rect = rl.Rectangle(0, 0, wheel_txt.width, wheel_txt.height)
-    dest_rect = rl.Rectangle(pos_x, pos_y, wheel_txt.width, wheel_txt.height)
-    origin = (wheel_txt.width / 2, wheel_txt.height / 2)
+    dest_rect = rl.Rectangle(pos_x, pos_y, scaled_width, scaled_height)
+    origin = (scaled_width / 2, scaled_height / 2)
 
     if ui_state.lat_active:
-      wheel_color = rl.Color(0, 255, 0, int(self._wheel_alpha_filter.x))
+      # 토크 정도에 따라 녹색 -> 주황색 블렌딩
+      green_color = rl.Color(0, 255, 0, int(self._wheel_alpha_filter.x))
+      orange_color = rl.Color(255, 115, 0, int(self._wheel_alpha_filter.x))
+      blend_factor = float(np.clip((torque_val - 0.75) * 4.0, 0.0, 1.0))
+      wheel_color = blend_colors(green_color, orange_color, blend_factor)
     else:
       wheel_color = rl.Color(230, 230, 230, int(self._wheel_alpha_filter.x))
 

--- a/selfdrive/ui/mici/onroad/hud_renderer.py
+++ b/selfdrive/ui/mici/onroad/hud_renderer.py
@@ -261,7 +261,7 @@ class HudRenderer(Widget):
       lateral_acceleration = actual_lateral_accel - roll_compensation
       max_lateral_acceleration = ui_state.CP.maxLateralAccel if ui_state.CP else DEFAULT_MAX_LAT_ACCEL
 
-      if True or car_control.latActive:
+      if car_control.latActive:
         self._torque_filter.update(float(np.clip((lateral_acceleration + accel_diff) / max_lateral_acceleration, -1.0, 1.0)))
       else:
         self._torque_filter.update(0.0)

--- a/selfdrive/ui/mici/onroad/hud_renderer.py
+++ b/selfdrive/ui/mici/onroad/hud_renderer.py
@@ -261,7 +261,7 @@ class HudRenderer(Widget):
       lateral_acceleration = actual_lateral_accel - roll_compensation
       max_lateral_acceleration = ui_state.CP.maxLateralAccel if ui_state.CP else DEFAULT_MAX_LAT_ACCEL
 
-      if car_control.latActive:
+      if True or car_control.latActive:
         self._torque_filter.update(float(np.clip((lateral_acceleration + accel_diff) / max_lateral_acceleration, -1.0, 1.0)))
       else:
         self._torque_filter.update(0.0)


### PR DESCRIPTION
# Description

C4(mici)의 화면 HUD_Render 중 하단 토크바가 삭제되었습니다.
- 이제 당근 아이콘이 역할을 대신합니다.
  - 조향 토크 한계에 가까워지면 당근 아이콘이 점차 커집니다.
  - 조향 토크 한계에 가까워지면 당근 아이콘이 점차 주황색으로 변합니다.