### PR TITLE
carrot web: 브랜치 체크아웃 시 모든 remote 지원 (origin 하드코딩 제거)

### DIFF
--- a/selfdrive/carrot/server/core.py
+++ b/selfdrive/carrot/server/core.py
@@ -1000,8 +1000,18 @@ async def _run_tool_job(job: Dict[str, Any]) -> None:
         return
 
       _tool_job_progress(job, message=f"switch {branch}", current=2, total=2)
-      if branch.startswith("origin/"):
-        local_branch = branch.replace("origin/", "", 1)
+
+      # Detect if `branch` is a `<remote>/<name>` ref for any configured remote.
+      rc_remotes, remotes_out = await _tool_capture_exec(["git", "remote"], cwd=repo_dir, timeout=30)
+      known_remotes = remotes_out.split() if rc_remotes == 0 else ["origin"]
+      remote_prefix = None
+      for r in known_remotes:
+        if branch.startswith(f"{r}/"):
+          remote_prefix = r
+          break
+
+      if remote_prefix is not None:
+        local_branch = branch[len(remote_prefix) + 1:]
         script = (
           f"if git rev-parse --verify {shlex.quote(local_branch)} >/dev/null 2>&1; "
           f"then git switch {shlex.quote(local_branch)}; "


### PR DESCRIPTION
## 문제

carrot web의 브랜치 체크아웃 기능에서 `origin/<branch>` 형태만 처리되고 있습니다. `ajouatom/carrot-wip`, `toss/xxx` 같이 다른 remote의 브랜치를 선택하면 체크아웃 실패.

`selfdrive/carrot/server/core.py`의 `git_checkout` 액션:

```python
if branch.startswith("origin/"):
    local_branch = branch.replace("origin/", "", 1)
    script = (... git switch -c <local> --track origin/<local> ...)
else:
    script = (
        f"git switch {branch} || "
        f"git switch -c {branch} --track origin/{branch}"  # <- 다른 remote 브랜치면 여기서 실패
    )
```

예: 사용자가 `toss/carrot-ms`를 선택 → else 분기 → `git switch toss/carrot-ms` 실패 (그런 로컬 브랜치 없음) → `git switch -c toss/carrot-ms --track origin/toss/carrot-ms` 실패 (origin에 그런 브랜치 없음).

사용자가 터미널에서 `git checkout -b carrot-ms toss/carrot-ms` 수동 실행하면 정상 동작.

## 수정

`git remote`로 설정된 모든 remote 이름을 읽어서, 입력 브랜치가 `<known_remote>/<name>` 형태인지 판별. 맞으면 해당 remote 기준으로 tracking:

```python
rc_remotes, remotes_out = await _tool_capture_exec(["git", "remote"], cwd=repo_dir, timeout=30)
known_remotes = remotes_out.split() if rc_remotes == 0 else ["origin"]
remote_prefix = None
for r in known_remotes:
    if branch.startswith(f"{r}/"):
        remote_prefix = r
        break

if remote_prefix is not None:
    local_branch = branch[len(remote_prefix) + 1:]
    script = (... git switch -c <local> --track <remote>/<local> ...)
else:
    # 기존 동작 유지 (접두사 없는 순수 브랜치명 → origin fallback)
```

## 동작

| 입력 | 이전 동작 | 수정 후 |
|------|-----------|---------|
| `origin/master` | ✓ `git switch -c master --track origin/master` | ✓ 동일 |
| `ajouatom/carrot-wip` | ✗ 실패 | ✓ `git switch -c carrot-wip --track ajouatom/carrot-wip` |
| `toss/carrot-ms` | ✗ 실패 | ✓ `git switch -c carrot-ms --track toss/carrot-ms` |
| `master` (접두사 없음) | ✓ | ✓ 동일 |

## 테스트

- [x] 로컬에서 `git remote` 파싱 및 분기 로직 확인
- [ ] 실기기 carrot web에서 다른 remote 브랜치 선택 → 체크아웃 확인