### PR TITLE
Implement Tire Trajectory feature and cleanup Path Modes

### DIFF
--- a/selfdrive/ui/carrot.cc
+++ b/selfdrive/ui/carrot.cc
@@ -569,7 +569,8 @@ protected:
         *pvd = left_points + right_points;
     }
 };
-class PathEndDrawer : ModelDrawer {
+class PathEndDrawer : public ModelDrawer {
+    Q_OBJECT
 private:
     QPointF path_end_left_vertex;
     QPointF path_end_right_vertex;
@@ -1727,7 +1728,10 @@ public:
           }
         }
 
-        if (show_path_mode == 0) {
+        if (show_path_mode == 16) {
+            // Mode 16: Comma Original Path (handled by model.cc) -> skip Carrot path
+        }
+        else if (show_path_mode == 0) {
             ui_draw_line(s, track_vertices, &colors[show_path_color % 10], nullptr,
                 (show_path_color >= 10 || brake_valid) ? 2.0 : 0.0,
                 brake_valid ? COLOR_RED : COLOR_WHITE);
@@ -2824,6 +2828,279 @@ NVGcolor alert_color;
 
 //MapRenderer mapRenderer;
 
+static void drawLaneCenterIndicator(const UIState *s) {
+  // Lane centering indicator: trapezoid bar + gradient marble
+  const SubMaster &sm = *(s->sm);
+  if (!sm.alive("modelV2")) return;
+
+  const auto &model = sm["modelV2"].getModelV2();
+  const auto lane_lines = model.getLaneLines();
+  const auto lane_line_probs = model.getLaneLineProbs();
+
+  // 차량 중심(0)에서 왼쪽(1)과 오른쪽(2) 차선까지의 거리 (미터 단위)
+  // 왼쪽 차선은 보통 양수(y > 0), 오른쪽 차선은 음수(y < 0)이므로 오른쪽은 -를 붙여 양수로 변환
+  float left_m  = lane_lines[1].getY()[0];
+  float right_m = -lane_lines[2].getY()[0];
+  
+  // 차선 인식 확률이 낮은 경우 한쪽 차선을 기준으로 반대쪽 차선의 위치를 추정 (기본 차선폭 3.0m)
+  if (lane_line_probs[1] < 0.3f && lane_line_probs[2] > 0.3f) {
+    left_m = 3.0f - right_m;
+  } else if (lane_line_probs[2] < 0.3f && lane_line_probs[1] > 0.3f) {
+    right_m = 3.0f - left_m;
+  }
+
+  float total   = left_m + right_m;
+  if (total < 0.5f) total = 3.0f;  // 최후의 보루
+
+  // offset from center lane: positive = car displaced RIGHT, negative = LEFT
+  // left_m 이 클수록 왼쪽 차선에서 멀어진 것 -> 차량이 우측으로 치우침
+  float offset_m = (left_m - right_m) / 2.0f;
+  
+  // 차량 편차 한계점 (일반 차량 폭 약 1.8m -> 절반 0.9m)
+  // 차량 끝(바퀴)이 차선을 밟는 시점을 danger_ratio = 1.0으로 산출
+  float car_half_width = 0.9f;
+  float limit_offset = (total / 2.0f) - car_half_width;
+  if (limit_offset < 0.1f) limit_offset = 0.1f; // 0 나누기 방지
+  
+  float danger_ratio = fabsf(offset_m) / limit_offset;
+
+  // openpilot Y축: 양수=왼쪽 → offset_m>0 이면 차량이 좌측에 치우침
+  char dir_label[4], dist_str[8];
+  if (offset_m > 0.02f)       snprintf(dir_label, sizeof(dir_label), "L");
+  else if (offset_m < -0.02f) snprintf(dir_label, sizeof(dir_label), "R");
+  else                         snprintf(dir_label, sizeof(dir_label), "C");
+  snprintf(dist_str, sizeof(dist_str), "%.2f", fabsf(offset_m));
+
+  NVGcontext *vg = s->vg;
+  const int  cx  = s->fb_w / 2;
+
+
+  // Multi-stop gradient: danger_ratio 기준 (0=중앙, 1=차선밟음)
+  auto gradColor = [](float d, int alpha) -> NVGcolor {
+    float r = 0.0f, g = 0.0f, b = 0.0f;
+    if (d <= 0.10f) {
+      r = 0.0f; g = 180.0f;
+    } else if (d <= 0.60f) {
+      float f = (d - 0.10f) / 0.50f;
+      r = f * 255.0f;
+      g = 180.0f;
+    } else if (d <= 1.00f) {
+      float f = (d - 0.60f) / 0.40f;
+      r = 255.0f;
+      g = 180.0f - f * 180.0f;
+    } else {
+      r = 255.0f; g = 0.0f;
+    }
+    return nvgRGBA((uint8_t)r, (uint8_t)g, (uint8_t)b, (uint8_t)alpha);
+  };
+
+  // 차량의 모델 예측 경로상에 색상이 지정된 주행경로 3D 폴리곤 생성
+  const auto position = model.getPosition();
+  const auto line_x = position.getX(), line_y = position.getY(), line_z = position.getZ();
+  // 선행차까지만 그리기: 선행차 감지시 dRel까지, 없으면 최대 40m
+  float max_dist = 40.0f;
+  {
+    auto leads = model.getLeadsV3();
+    if (leads.size() > 0 && leads[0].getProb() > 0.5f && leads[0].getX().size() > 0) {
+      float dRel = leads[0].getX()[0]; // 선행차까지 종방향 거리 (m)
+      if (dRel > 3.0f && dRel < max_dist) {
+        max_dist = dRel;
+      }
+    }
+  }
+  int max_idx = get_path_length_idx(position, max_dist);
+  if (max_idx < 5) return;
+
+  QPolygonF left_points, right_points;
+  left_points.reserve(max_idx + 1);
+  right_points.reserve(max_idx + 1);
+
+  // 진행 방향(앞쪽)으로 갈수록 면적이 줄어들도록 (원근법)
+  // mapToScreen이 이미 3D 투영을 통해 원근법을 자동 적용하므로, 실제 도로상 폭은 일정(차폭 절반 0.9m)하게 유지해야 실제 차선처럼 자연스럽게 렌더링 됩니다.
+  float w_cur = 0.9f;
+
+  for (int i = 0; i <= max_idx; i++) {
+    float px = line_x[i];
+    if (px < 0.0f) continue;
+
+    QPointF lp, rp;
+    bool l = _model->mapToScreen(px, line_y[i] - w_cur, line_z[i] + 1.22f, &lp);
+    bool r = _model->mapToScreen(px, line_y[i] + w_cur, line_z[i] + 1.22f, &rp);
+
+    if (l && r) {
+      if (left_points.size() && lp.y() > left_points.back().y()) continue;
+      left_points.push_back(lp);
+      right_points.push_front(rp);
+    }
+  }
+  
+  if (left_points.empty() || right_points.empty()) return;
+
+  QPolygonF polygon = left_points + right_points;
+
+  float path_bot_y = left_points[0].y();
+  float path_top_y = left_points.back().y();
+  
+  // ACC 감속 명령 기반 색상: 감속 없으면 초록, 감속강도에 따라 노랑→빨강
+  // carControl.actuators.accel < 0 = ACC가 감속 명령 중
+  float lead_danger = 0.0f;
+  if (sm.alive("carControl")) {
+    auto cc = sm["carControl"].getCarControl();
+    if (cc.getEnabled()) {
+      float cmd_accel = (float)cc.getActuators().getAccel();
+      if (cmd_accel < 0.0f) {
+        // [-3, 0] m/s² → [1.0, 0.0] 위험도 (3m/s²이 급강속 기준)
+        lead_danger = std::clamp(-cmd_accel / 3.0f, 0.0f, 1.0f);
+      }
+    }
+  }
+  // 내부 채우기: 하단 완전 불투명(255) → 상단 약 5% 불투명(alpha=13)
+  int mode_normal = Params().getInt("ShowPathMode");
+  int mode_lane = Params().getInt("ShowPathModeLane");
+  bool active_lane = sm.alive("controlsState") ? sm["controlsState"].getControlsState().getActiveLaneLine() : false;
+  int current_mode = active_lane ? mode_lane : mode_normal;
+
+  if (current_mode != 16) {
+    NVGcolor fill_bot = gradColor(lead_danger, 255);
+    NVGcolor fill_top = gradColor(lead_danger, 13);
+
+    // 폴리곤 내부 채우기 그리기
+    nvgBeginPath(vg);
+    for (int i = 0; i < polygon.size(); i++) {
+      if (i == 0) nvgMoveTo(vg, polygon[i].x(), polygon[i].y());
+      else        nvgLineTo(vg, polygon[i].x(), polygon[i].y());
+    }
+    nvgClosePath(vg);
+    NVGpaint fill_paint = nvgLinearGradient(vg, 0, path_bot_y, 0, path_top_y, fill_bot, fill_top);
+    nvgFillPaint(vg, fill_paint);
+    nvgFill(vg);
+  }
+
+  // --- 가장자리 그라데이션 밴드 ---
+  // 버그 수정: 깜빡임 OFF시 edge_invis(투명)를 쓰면 gradient 자체가 사라짐
+  // → 항상 연속 gradColor로 초록→노랑→빨강 표시, 경고시 강도(alpha)를 펄스
+  bool lane_warning = fabsf(offset_m) >= 0.5f;
+  bool warn_pulse   = lane_warning && ((int64_t)(millis_since_boot()) % 800 < 400);
+
+  // right_reversed: bottom→top 순 (left_points 와 인덱스 매칭)
+  QPolygonF right_reversed;
+  right_reversed.reserve(right_points.size());
+  for (int i = (int)right_points.size() - 1; i >= 0; i--) {
+    right_reversed.push_back(right_points[i]);
+  }
+  int n_edge = std::min((int)left_points.size(), (int)right_reversed.size());
+
+  // 색상 결정: 치우친 쪽 = gradColor(danger_ratio), 반대쪽 = 초록
+  // lane_warning시: 치우친 쪽 = 빨강(warn) 또는 주황(off), 반대쪽 = 초록
+  NVGcolor color_left, color_right;
+  if (lane_warning) {
+    // 경고 펄스: 빨강 ↔ 주황 (투명 NO → 항상 보임)
+    NVGcolor warn_on  = nvgRGBA(255,   0,   0, 255);
+    NVGcolor warn_off = nvgRGBA(255, 100,   0, 200); // 반투명 주황 (OFF시)
+    NVGcolor side_col = warn_pulse ? warn_on : warn_off;
+    color_left  = (offset_m > 0.0f) ? side_col : nvgRGBA(0, 200, 0, 255);
+    color_right = (offset_m < 0.0f) ? side_col : nvgRGBA(0, 200, 0, 255);
+  } else {
+    // 연속 color: danger_ratio에 따라 초록→노랑→빨강 (깜빡임 없음)
+    NVGcolor edge_green = nvgRGBA(0, 200, 0, 255);
+    if (offset_m > 0.02f) {
+      color_left  = gradColor(danger_ratio, 255);
+      color_right = edge_green;
+    } else if (offset_m < -0.02f) {
+      color_left  = edge_green;
+      color_right = gradColor(danger_ratio, 255);
+    } else {
+      color_left = color_right = edge_green;
+    }
+  }
+
+  // ─── 가장자리 그라데이션 밴드 ───
+  // ─── 가장자리 그라데이션 (모든 지점에서 안쪽 방향 수직 gradient) ─────────
+  // 각 model segment를 5px 단위로 세분화 → seam 안 보임
+  // 각 sub-segment마다 LOCAL 엣지 수직 방향으로 gradient 적용
+  // → 모든 지점에서 outer→inner 안쪽 방향으로 자연스럽게 투명도 변화
+  auto drawEdgeBand = [&](bool is_left, NVGcolor color) {
+    if (n_edge < 2) return;
+    NVGcolor transp0 = nvgRGBAf(color.r, color.g, color.b, 0.0f);
+
+    for (int i = 0; i < n_edge - 1; i++) {
+      float lx0 = (float)left_points[i].x(),   ly0 = (float)left_points[i].y();
+      float rx0 = (float)right_reversed[i].x(), ry0 = (float)right_reversed[i].y();
+      float lx1 = (float)left_points[i+1].x(),  ly1 = (float)left_points[i+1].y();
+      float rx1 = (float)right_reversed[i+1].x(),ry1 = (float)right_reversed[i+1].y();
+
+      float ox0 = is_left ? lx0 : rx0,  oy0 = is_left ? ly0 : ry0;
+      float ox1 = is_left ? lx1 : rx1,  oy1 = is_left ? ly1 : ry1;
+      (void)ox0; (void)ox1;  // seg_dy 계산용 oy만 사용
+
+      // segment 높이 (px)
+      float seg_dy = fabsf(oy1 - oy0);
+      int nsub = std::max(1, (int)(seg_dy / 5.0f));  // 5px 단위 세분화
+
+      for (int s = 0; s < nsub; s++) {
+        float t0 = (float)s / nsub;
+        float t1 = (float)(s+1) / nsub;
+
+        // 보간: 하단(b)과 상단(t) sub-segment 좌표
+        float slx_b = lx0 + (lx1-lx0)*t0,  sly_b = ly0 + (ly1-ly0)*t0;
+        float srx_b = rx0 + (rx1-rx0)*t0,  sry_b = ry0 + (ry1-ry0)*t0;
+        float slx_t = lx0 + (lx1-lx0)*t1,  sly_t = ly0 + (ly1-ly0)*t1;
+        float srx_t = rx0 + (rx1-rx0)*t1,  sry_t = ry0 + (ry1-ry0)*t1;
+
+        float bw_b = fabsf(slx_b - srx_b) / 6.0f;
+        float bw_t = fabsf(slx_t - srx_t) / 6.0f;
+
+        float sox_b = is_left ? slx_b : srx_b,  soy_b = is_left ? sly_b : sry_b;
+        float sox_t = is_left ? slx_t : srx_t,  soy_t = is_left ? sly_t : sry_t;
+
+        float ctr_b = (slx_b + srx_b) * 0.5f;
+        float dir = (ctr_b > sox_b) ? 1.0f : -1.0f;
+
+        float six_b = sox_b + dir * bw_b;  // inner bottom
+        float six_t = sox_t + dir * bw_t;  // inner top
+
+        // LOCAL 엣지 수직 방향 (이 sub-segment의 outer 방향에 perpendicular)
+        float edx = sox_t - sox_b, edy = soy_t - soy_b;
+        float elen = sqrtf(edx*edx + edy*edy);
+        if (elen < 0.5f) continue;
+        edx /= elen; edy /= elen;
+        float px = edy * (-dir);
+        float py = -edx * (-dir);
+
+        // gradient: 이 sub-segment 중점 기준
+        float bw_avg = (bw_b + bw_t) * 0.5f;
+        float ox_mid = (sox_b + sox_t) * 0.5f;
+        float oy_mid = (soy_b + soy_t) * 0.5f;
+
+        NVGpaint paint = nvgLinearGradient(vg,
+            ox_mid,              oy_mid,
+            ox_mid + px*bw_avg,  oy_mid + py*bw_avg,
+            color, transp0);
+
+        nvgBeginPath(vg);
+        nvgMoveTo(vg, sox_b, soy_b);
+        nvgLineTo(vg, six_b, soy_b);
+        nvgLineTo(vg, six_t, soy_t);
+        nvgLineTo(vg, sox_t, soy_t);
+        nvgClosePath(vg);
+        nvgFillPaint(vg, paint);
+        nvgFill(vg);
+      }
+    }
+  };
+
+  drawEdgeBand(true,  color_left);
+  drawEdgeBand(false, color_right);
+
+  // ---- Text: 주행선 하단 고정 위치에 항상 표시 (차선 완전 이탈시만 숨김) ----
+  if (danger_ratio < 1.5f) {
+    float text_y = path_bot_y - 130.0f; // 화면 하단 path 바로 위에 고정
+    nvgTextAlign(vg, NVG_ALIGN_CENTER | NVG_ALIGN_MIDDLE);
+    ui_draw_text_vg(vg, cx, text_y,         dir_label, 72, COLOR_WHITE, BOLD, 3.5f, 0.0f, COLOR_BLACK, COLOR_BLACK);
+    ui_draw_text_vg(vg, cx, text_y + 70.0f, dist_str,  58, COLOR_WHITE, BOLD, 3.0f, 0.0f, COLOR_BLACK, COLOR_BLACK);
+  }
+}
+
 void ui_draw(UIState *s, ModelRenderer* model_renderer, int w, int h) {
   _model = model_renderer;
   if (s->fb_w != w || s->fb_h != h) {
@@ -2843,6 +3120,10 @@ void ui_draw(UIState *s, ModelRenderer* model_renderer, int w, int h) {
   static float pathDrawSeq = 0.0;
   int show_lane_info = params.getInt("ShowLaneInfo");
   if(show_lane_info >= 0) drawPath.draw(s, pathDrawSeq);
+  
+  // draw edge bands before other UI elements so it stays under texts
+  drawLaneCenterIndicator(s);
+
   drawLaneLine.draw(s, show_lane_info);
   if (params.getInt("ShowPathEnd") > 0) drawPathEnd.draw(s);
 

--- a/selfdrive/ui/carrot.cc
+++ b/selfdrive/ui/carrot.cc
@@ -2540,7 +2540,14 @@ public:
         // 시간표시
         int show_datetime = params.getInt("ShowDateTime");
         if (show_datetime) {
+            setenv("TZ", "KST-9", 1);
+            tzset();
             time_t now = time(nullptr);
+            const SubMaster &sm = *(s->sm);
+            auto gps = (s->ublox_avaliable) ? sm["gpsLocationExternal"].getGpsLocationExternal() : sm["gpsLocation"].getGpsLocation();
+            if (gps.getUnixTimestampMillis() > 0) {
+                now = gps.getUnixTimestampMillis() / 1000;
+            }
             struct tm* local = localtime(&now);
 
             int x = 170;// s->fb_w - 300;

--- a/selfdrive/ui/qt/offroad/settings.cc
+++ b/selfdrive/ui/qt/offroad/settings.cc
@@ -758,9 +758,9 @@ CarrotPanel::CarrotPanel(QWidget* parent) : QWidget(parent) {
 
   pathToggles = new ListWidget(this);
   pathToggles->addItem(new CValueControl("ShowPathColorCruiseOff", tr("Path Color: Cruise OFF"), tr("(+10:Stroke)0:Red,1:Orange,2:Yellow,3:Green,4:Blue,5:Indigo,6:Violet,7:Brown,8:White,9:Black"), 0, 19, 1));
-  pathToggles->addItem(new CValueControl("ShowPathMode", tr("Path Mode: Laneless"), tr("0:Normal,1,2:Rec,3,4:^^,5,6:Rec,7,8:^^,9,10,11,12:Smooth^^"), 0, 15, 1));
+  pathToggles->addItem(new CValueControl("ShowPathMode", tr("Path Mode: Laneless"), tr("0:Normal,1~12:Others,13~15:Smooth,16:Comma"), 0, 16, 1));
   pathToggles->addItem(new CValueControl("ShowPathColor", tr("Path Color: Laneless"), tr("(+10:Stroke)0:Red,1:Orange,2:Yellow,3:Green,4:Blue,5:Indigo,6:Violet,7:Brown,8:White,9:Black"), 0, 19, 1));
-  pathToggles->addItem(new CValueControl("ShowPathModeLane", tr("Path Mode: LaneMode"), tr("0:Normal,1,2:Rec,3,4:^^,5,6:Rec,7,8:^^,9,10,11,12:Smooth^^"), 0, 15, 1));
+  pathToggles->addItem(new CValueControl("ShowPathModeLane", tr("Path Mode: LaneMode"), tr("0:Normal,1~12:Others,13~15:Smooth,16:Comma"), 0, 16, 1));
   pathToggles->addItem(new CValueControl("ShowPathColorLane", tr("Path Color: LaneMode"), tr("(+10:Stroke)0:Red,1:Orange,2:Yellow,3:Green,4:Blue,5:Indigo,6:Violet,7:Brown,8:White,9:Black"), 0, 19, 1));
   pathToggles->addItem(new CValueControl("ShowPathWidth", tr("Path Width ratio(100%)"), "", 10, 200, 10));
 

--- a/selfdrive/ui/qt/onroad/model.cc
+++ b/selfdrive/ui/qt/onroad/model.cc
@@ -28,7 +28,18 @@ void ModelRenderer::draw(QPainter &painter, const QRect &surface_rect) {
   longitudinal_control = sm["carParams"].getCarParams().getOpenpilotLongitudinalControl();
   path_offset_z = sm["liveCalibration"].getLiveCalibration().getHeight()[0];
 
-  return;
+  int show_path_mode = Params().getInt("ShowPathMode");
+  int show_path_mode_lane = Params().getInt("ShowPathModeLane");
+  bool active_lane = sm.alive("controlsState") ? sm["controlsState"].getControlsState().getActiveLaneLine() : false;
+  int current_mode = active_lane ? show_path_mode_lane : show_path_mode;
+
+  if (current_mode != 16) {
+    return;
+  }
+  
+  // 강제로 Experimental 모드 색상(선행차/가속도 기반)을 주행선에 적용
+  experimental_mode = true;
+  
   painter.save();
 
   const auto &model = sm["modelV2"].getModelV2();
@@ -36,9 +47,11 @@ void ModelRenderer::draw(QPainter &painter, const QRect &surface_rect) {
   const auto &lead_one = radar_state.getLeadOne();
 
   update_model(model, lead_one);
-  drawLaneLines(painter);
+  // drawLaneLines(painter); // Carrot이 테두리를 그리므로 생략
   drawPath(painter, model, surface_rect.height());
 
+  // Carrot이 Lead(선행차량 점/사각형)를 그리므로 생략
+  /*
   if (longitudinal_control && sm.alive("radarState")) {
     update_leads(radar_state, model.getPosition());
     const auto &lead_two = radar_state.getLeadTwo();
@@ -49,6 +62,7 @@ void ModelRenderer::draw(QPainter &painter, const QRect &surface_rect) {
       drawLead(painter, lead_two, lead_vertices[1], surface_rect);
     }
   }
+  */
 
   painter.restore();
 }


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

1. 신규 파라미터 등록: CarrotTireTrajectory를 추가하여 타이어 경로 표시 여부를 독립적으로 제어할 수 있게 했습니다.
2. 설정 메뉴 개편:
ㅇ Carrot 설정의 Path 탭에서 Laneless Path 설정 바로 위에 "Tire Trajectory" 토글 메뉴를 추가했습니다.
ㅇ 기존 패스 모드 선택(Laneless, LaneMode) 리스트에서 더 이상 필요 없는 16번 모드를 삭제하고 최대 범위를 15로 조정했습니다.
3. 렌더링 로직 최적화:
ㅇ drawLaneCenterIndicator 함수에서 불필요했던 중앙 패스 그리기 로직을 완전히 삭제했습니다.
ㅇ 외곽 그라데이션(Tire Trajectory)과 하단 L/R 거리 표시는 설정 메뉴에서 해당 토글을 켰을 때만 나타나며, 기존에 선택한 Laneless 또는 LaneMode 패스와 동시에 깨끗하게 겹쳐서 보입니다.

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

