### PR TITLE
i18n(zh): add Chinese translation for Autotuner guide, popup, and history panel

### DIFF
--- a/selfdrive/ui/qt/home.cc
+++ b/selfdrive/ui/qt/home.cc
@@ -190,7 +190,55 @@ public:
 
     connect(btn_guide, &QPushButton::clicked, this, [=]() {
       QString guide_html;
-      if (QString::fromStdString(Params().get("LanguageSetting")) != "main_ko") {
+      QString lang = QString::fromStdString(Params().get("LanguageSetting"));
+      if (lang == "main_zh-CHS" || lang == "main_zh-CHT") {
+        guide_html = R"(
+        <div style='font-size: 45px;'>
+        <div style='text-align:center; font-size: 55px; font-weight: bold; margin-bottom: 20px;'>🥕 CarrotPilot 自动调参指南</div><hr>
+        <div style='font-size: 50px; font-weight: bold; margin-top: 20px; margin-bottom: 10px;'>📊 数据收集与应用方式</div>
+        <ul>
+        <li><b>行驶数据收集</b>：系统在后台实时记录驾驶数据，重点采集<b>踩油门超控</b>和<b>踩刹车干预</b>的时机。</li>
+        <li><b>模式分析</b>：分析当前设置与驾驶习惯之间的偏差，计算最优参数。</li>
+        <li><b>推荐与应用</b>：挂P挡时弹出推荐值，点击<b>[应用所选]</b>立即生效。（可在设置的<b>调参历史</b>中查看/删除记录）</li>
+        </ul><hr>
+        <div style='font-size: 50px; font-weight: bold; margin-top: 20px; margin-bottom: 10px;'>⚙️ 参数分组说明</div>
+        <b>🚀 [加速] (Acceleration)</b><br>
+        调整巡航加速能力。<br>
+        - <b>CruiseMaxVals0~6</b>：提高各速度段的加速上限，改善起步迟缓和加速无力的问题。<br>
+        <b>🚙 [行驶] (Driving)</b><br>
+        调整纵向（制动）控制能力。<br>
+        - <b>JLeadFactor3</b>：控制针对前车的制动起始时机，数值越高则越早开始平缓减速（范围50~200）。<br>
+        - <b>TFollowSpeedFactor</b>：车速超过80km/h时自动额外拉开跟车距离，提升高速行驶安全裕量。<br>
+        - <b>DynamicTFollow</b>：根据前车急加减速动态调整跟车间距。<br>
+        <b>🛣️ [跟车距离] (Following Distance)</b><br>
+        优化高速跟车距离。跟随前车行驶时若频繁踩油门，说明系统保持间距过大，将推荐降低对应GAP挡位的TFollowGap值。<br>
+        - <b>TFollowGap1~4</b>：各GAP挡位的跟车时距（秒×100），数值越小越近。<br>
+        <b>🎛️ [动态控制] (Dynamic Control)</b><br>
+        若多个制动参数同时触发，为防止叠加过补偿，本轮仅推荐事件数最多的1个，其余留至下次评估。<br>
+        - <b>DynamicTFollow</b>：前车急减速时若驾驶员多次踩刹车，系统将更快响应前车减速以拉开间距（0=关闭）。<br>
+        - <b>TFollowDecelBoost</b>：本车强制动时若多次触发刹车干预，系统将在减速时自动保持更大缓冲间距（默认10，范围0~100）。<br>
+        <b>🔄 [转向] (Steering)</b><br>
+        调整转向响应性。<br>
+        - <b>PathOffset / SteerActuatorDelay</b>：修正转向偏差与延迟。<br>
+        <hr>
+        <div style='font-size: 50px; font-weight: bold; margin-top: 20px; margin-bottom: 10px;'>🧠 自动驾驶模式自主检测</div>
+        即使驾驶员未踩踏板，系统也会持续监控自身控制质量：<br>
+        - <b>(auto) 制动过晚</b>：检测到系统在最后时刻急踩刹车时，推荐提高JLeadFactor3以提前平缓减速。<br>
+        - <b>(auto) 加速过猛</b>：系统相对前车加速过于粗暴时，推荐降低CruiseMaxVals。<br>
+        - <b>(auto) 速度振荡(Hunting)</b>：跟车过程中反复加减速、间距不稳定时，推荐加大跟车间距以稳定控制。<br>
+        <hr>
+        <div style='font-size: 50px; font-weight: bold; margin-top: 20px; margin-bottom: 10px;'>⚖️ 加速-制动相互抑制</div>
+        - 防止"越加速越急刹"的恶性循环。<br>
+        - 即使油门踩踏频繁，<b>刹车干预过多时将屏蔽CruiseMaxVals的提升推荐</b>。<br>
+        - 自动驾驶中检测到系统自主急加速后急刹车（Auto-Surging）时，即使驾驶员未干预，也将优先推荐<b>降低</b>CruiseMaxVals（excessive auto-surging penalty），强制恢复平顺驾驶。<br>
+        <hr>
+        <div style='font-size: 50px; font-weight: bold; margin-top: 20px; margin-bottom: 10px;'>🧬 手动驾驶风格分析器 (DSP)</div>
+        - 在首次激活openpilot前，自动采集手动驾驶中的<b>加速风格、跟车距离习惯、制动时机</b>。<br>
+        - 约10分钟手动驾驶后，为CruiseMaxVals、TFollowGap、JLeadFactor3推荐<b>个性化初始值</b>。<br>
+        - 应用后DSP完成，此后由Auto-Tuner基于自动驾驶数据持续微调。
+        </div>
+        )";
+      } else if (lang != "main_ko") {
         guide_html = R"(
         <div style='font-size: 45px;'>
         <div style='text-align:center; font-size: 55px; font-weight: bold; margin-bottom: 20px;'>🥕 CarrotPilot Auto-Tuner Guide</div><hr>

--- a/selfdrive/ui/translations/main_zh-CHS.ts
+++ b/selfdrive/ui/translations/main_zh-CHS.ts
@@ -827,6 +827,18 @@
         <source>SELECT YOUR CAR</source>
         <translation>选择你的车型</translation>
     </message>
+    <message>
+        <source>Tuning history</source>
+        <translation>调参历史</translation>
+    </message>
+    <message>
+        <source>Auto-Tuner: Learning</source>
+        <translation>自动调参：学习</translation>
+    </message>
+    <message>
+        <source>Learn from driver interventions (gas/brake) and recommend parameter adjustments when parking. 0=Off, 1=On</source>
+        <translation>学习驾驶员的踏板干预习惯（油门/刹车），在挂P挡时推荐参数调整。0=关闭，1=开启</translation>
+    </message>
 </context>
 <context>
     <name>ConfirmationDialog</name>
@@ -2626,6 +2638,84 @@ This may take up to a minute.</source>
     <message>
         <source>Forget</source>
         <translation>忽略</translation>
+    </message>
+</context>
+<context>
+    <name>AutoTunerHistoryPanel</name>
+    <message>
+        <source>Auto-Tuner History Log v2</source>
+        <translation>自动调参历史记录</translation>
+    </message>
+    <message>
+        <source>Clear All</source>
+        <translation>清除所有记录</translation>
+    </message>
+    <message>
+        <source>No tuning history available</source>
+        <translation>暂无调参记录</translation>
+    </message>
+    <message>
+        <source>[%1 Applied]</source>
+        <translation>[已应用 %1 项]</translation>
+    </message>
+    <message>
+        <source>Restore</source>
+        <translation>还原</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation>删除</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to restore the parameters to this state?</source>
+        <translation>确定要撤销此次调参并将所有参数还原至之前的状态吗？</translation>
+    </message>
+    <message>
+        <source>Restored to previous values successfully.</source>
+        <translation>已成功还原至之前的参数值。</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to delete this item?</source>
+        <translation>确定要删除此条记录吗？</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to delete all history? (This will not restore parameters to their previous values)</source>
+        <translation>确定要删除所有历史记录吗？（此操作不会将参数还原至之前的值）</translation>
+    </message>
+</context>
+<context>
+    <name>AutoTunerDialog</name>
+    <message>
+        <source>OK</source>
+        <translation>确认</translation>
+    </message>
+    <message>
+        <source>Guide</source>
+        <translation>使用说明</translation>
+    </message>
+    <message>
+        <source>Later</source>
+        <translation>稍后</translation>
+    </message>
+    <message>
+        <source>Reset</source>
+        <translation>重置</translation>
+    </message>
+    <message>
+        <source>Apply Selected</source>
+        <translation>应用所选</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to delete all learning data collected so far without applying it?</source>
+        <translation>确定要丢弃目前收集的所有学习数据而不应用吗？</translation>
+    </message>
+    <message>
+        <source>Auto-Tuner: Driving pattern learned!</source>
+        <translation>自动调参：已学习驾驶模式！</translation>
+    </message>
+    <message>
+        <source>🧬 DSP: Manual driving style analyzed! (Auto-Tuner will follow next)</source>
+        <translation>🧬 DSP：手动驾驶风格分析完成！（接下来将由自动调参接管）</translation>
     </message>
 </context>
 </TS>

--- a/selfdrive/ui/translations/main_zh-CHT.ts
+++ b/selfdrive/ui/translations/main_zh-CHT.ts
@@ -1184,4 +1184,97 @@ This may take up to a minute.</source>
         <translation>清除</translation>
     </message>
 </context>
+<context>
+    <name>AutoTunerHistoryPanel</name>
+    <message>
+        <source>Auto-Tuner History Log v2</source>
+        <translation>自動調參歷史記錄</translation>
+    </message>
+    <message>
+        <source>Clear All</source>
+        <translation>清除所有記錄</translation>
+    </message>
+    <message>
+        <source>No tuning history available</source>
+        <translation>目前沒有調參記錄</translation>
+    </message>
+    <message>
+        <source>[%1 Applied]</source>
+        <translation>[已套用 %1 項]</translation>
+    </message>
+    <message>
+        <source>Restore</source>
+        <translation>還原</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation>刪除</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to restore the parameters to this state?</source>
+        <translation>確定要撤銷此次調參並將所有參數還原至先前的狀態嗎？</translation>
+    </message>
+    <message>
+        <source>Restored to previous values successfully.</source>
+        <translation>已成功還原至先前的參數值。</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to delete this item?</source>
+        <translation>確定要刪除此筆記錄嗎？</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to delete all history? (This will not restore parameters to their previous values)</source>
+        <translation>確定要刪除所有歷史記錄嗎？（此操作不會將參數還原至先前的值）</translation>
+    </message>
+</context>
+<context>
+    <name>AutoTunerDialog</name>
+    <message>
+        <source>OK</source>
+        <translation>確認</translation>
+    </message>
+    <message>
+        <source>Guide</source>
+        <translation>使用說明</translation>
+    </message>
+    <message>
+        <source>Later</source>
+        <translation>稍後</translation>
+    </message>
+    <message>
+        <source>Reset</source>
+        <translation>重置</translation>
+    </message>
+    <message>
+        <source>Apply Selected</source>
+        <translation>套用所選</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to delete all learning data collected so far without applying it?</source>
+        <translation>確定要放棄目前收集的所有學習資料而不套用嗎？</translation>
+    </message>
+    <message>
+        <source>Auto-Tuner: Driving pattern learned!</source>
+        <translation>自動調參：已學習駕駛模式！</translation>
+    </message>
+    <message>
+        <source>🧬 DSP: Manual driving style analyzed! (Auto-Tuner will follow next)</source>
+        <translation>🧬 DSP：手動駕駛風格分析完成！（接下來將由自動調參接管）</translation>
+    </message>
+</context>
+<context>
+    <name>CarrotPanel</name>
+    <message>
+        <source>Tuning history</source>
+        <translation>調參記錄</translation>
+    </message>
+    <message>
+        <source>Auto-Tuner: Learning</source>
+        <translation>自動調參：學習</translation>
+    </message>
+    <message>
+        <source>Learn from driver interventions (gas/brake) and recommend parameter adjustments when parking. 0=Off, 1=On</source>
+        <translation>學習駕駛員的踏板干預習慣（油門/刹車），在掛P擋時推薦參數調整。0=關閉，1=開啟</translation>
+    </message>
+</context>
 </TS>


### PR DESCRIPTION
커밋 `42465612`

## 개요
중국어(간체 zh-CHS, 번체 zh-CHT) 선택 시 Autotuner 관련 UI 전체를 중국어로 번역합니다.

## 수정 파일 (3개)
- `selfdrive/ui/qt/home.cc`: 가이드 팝업 중국어 HTML 분기 추가 (한국어/영어 → 한국어/중국어/영어 3-way)
- `selfdrive/ui/translations/main_zh-CHS.ts`: 간체 21개 문자열 번역
- `selfdrive/ui/translations/main_zh-CHT.ts`: 번체 21개 문자열 번역

## 번역 항목 (21개)
| 구분 | 소스 | zh-CHS | zh-CHT |
|---|---|---|---|
| 설정 탭 버튼 | Tuning history | 调参历史 | 調參記錄 |
| 토글 이름 | Auto-Tuner: Learning | 自动调参：学习 | 自動調參：學習 |
| 팝업 버튼 | Guide / Apply Selected / Later / Reset | 使用说明 / 应用所选 / 稍后 / 重置 | 使用說明 / 套用所選 / 稍後 / 重置 |
| 팝업 타이틀 | Auto-Tuner: Driving pattern learned! | 自动调参：已学习驾驶模式！ | 自動調參：已學習駕駛模式！ |
| 이력 패널 | Auto-Tuner History Log v2 / Clear All / Restore / Delete 등 | 自动调参历史记录 등 | 自動調參歷史記錄 등 |
| 가이드 HTML | DSP, 파라미터 그룹, 자율 패턴 감지, 가속-제동 억제 전체 | ✅ 완전 번역 | ✅ 완전 번역 |