### PR TITLE
feat(autotuner): Auto-Apply logic, driving style profiler, and UI/Tuning Log improvements

### DIFF
--- a/common/params_keys.h
+++ b/common/params_keys.h
@@ -168,6 +168,7 @@ inline static std::unordered_map<std::string, ParamKeyAttributes> keys = {
     {"CarrotLearningPopupReady", {PERSISTENT, BOOL, "0"}},     // Auto-Tuner: 팝업 신호
     {"CarrotLearningClear", {PERSISTENT, BOOL, "0"}},          // Auto-Tuner: 데이터 초기화 신호
     {"CarrotLearningHistory", {PERSISTENT, BYTES, ""}},        // Auto-Tuner: 튜닝 이력 (JSON)
+    {"CarrotLearningPopupSource", {PERSISTENT, STRING, ""}},   // Auto-Tuner: 팝업 발생 소스 ("stop", "timer", "parking", etc.)
     {"CarrotDSPData", {PERSISTENT, BYTES, ""}},                // DSP: 수동 주행 프로파일 데이터 (JSON)
     {"CarrotDSPRecommend", {PERSISTENT, BYTES, ""}},           // DSP: 초기값 추천 (JSON)
     {"CarrotDSPPopupReady", {PERSISTENT, BOOL, "0"}},          // DSP: 팝업 신호

--- a/common/params_keys.h
+++ b/common/params_keys.h
@@ -169,6 +169,7 @@ inline static std::unordered_map<std::string, ParamKeyAttributes> keys = {
     {"CarrotLearningClear", {PERSISTENT, BOOL, "0"}},          // Auto-Tuner: 데이터 초기화 신호
     {"CarrotLearningHistory", {PERSISTENT, BYTES, ""}},        // Auto-Tuner: 튜닝 이력 (JSON)
     {"CarrotLearningPopupSource", {PERSISTENT, STRING, ""}},   // Auto-Tuner: 팝업 발생 소스 ("stop", "timer", "parking", etc.)
+    {"CarrotLearningAutoApply", {PERSISTENT, BOOL, "0"}},      // Auto-Tuner: 추천 파라미터 자동 적용 여부
     {"CarrotDSPData", {PERSISTENT, BYTES, ""}},                // DSP: 수동 주행 프로파일 데이터 (JSON)
     {"CarrotDSPRecommend", {PERSISTENT, BYTES, ""}},           // DSP: 초기값 추천 (JSON)
     {"CarrotDSPPopupReady", {PERSISTENT, BOOL, "0"}},          // DSP: 팝업 신호

--- a/selfdrive/carrot/carrot_functions.py
+++ b/selfdrive/carrot/carrot_functions.py
@@ -660,7 +660,7 @@ class CarrotPlanner:
                         lead_v_kph=leadOne.vLead * CV.MS_TO_KPH if leadOne.status else 0.0,
                         a_ego=a_ego, lead_jlead=leadOne.jLead if leadOne.status else 0.0,
                         v_cruise_kph=v_cruise_kph,
-                        gas_val=carstate.gas, brake_val=carstate.brake)
+                        gas_val=carstate.gas, brake_val=carstate.brake, sm=sm)
 
     # DSP: 수동 주행 성향 프로파일링 (오픈파일럿 미인게이지 상태에서만 수집)
     self.profiler.update(v_ego_kph, engaged, gear_park,

--- a/selfdrive/carrot/carrot_learning.py
+++ b/selfdrive/carrot/carrot_learning.py
@@ -28,6 +28,7 @@ karpathy.md 원칙 준수: 최소 구현, 단일 목적.
 """
 
 import json
+import math
 import numpy as np
 from openpilot.common.params import Params
 from openpilot.common.conversions import Conversions as CV
@@ -159,6 +160,12 @@ class CarrotLearner:
     # 공통: 팝업 후 쿨다운 (중복 발동 방지)
     self._popup_cooldown_sec = 0.0       # 팝업 발동 후 5분 쿨다운
 
+    # Phase 6 (Curve Decel Aggressiveness)
+    self._curve_override_gas_sec = 0.0
+    self._curve_override_brake_sec = 0.0
+    self._curve_override_brake_count = 0
+    self._curve_max_decel = 0.0
+
     self._load()
 
   # ------------------------------------------------------------------
@@ -173,7 +180,7 @@ class CarrotLearner:
              steer_deg: float = 0.0, steer_pressed: bool = False,
              brake_pressed: bool = False, lead_drel: float = 0.0, lead_v_kph: float = 0.0,
              a_ego: float = 0.0, lead_jlead: float = 0.0, v_cruise_kph: float = 0.0,
-             gas_val: float = 0.0, brake_val: float = 0.0):
+             gas_val: float = 0.0, brake_val: float = 0.0, sm=None):
     """
     매 프레임 호출.
     - Phase 1: engaged + gas_pressed → 속도구간 누적
@@ -185,6 +192,8 @@ class CarrotLearner:
     """
     if not self._is_active():
       return
+
+    prev_brake = self._prev_brake
 
     # UI로부터 초기화(Clear) 신호가 오면 내부 메모리를 비움
     if self._params.get_bool("CarrotLearningClear"):
@@ -303,6 +312,49 @@ class CarrotLearner:
       if v_ego_kph >= 80.0 and brake_pressed:
         self._tfollow_speed_brake_acc += _DT
 
+    # ── Phase 6: 가변 곡선 감속 학습 ──────────────────────────────────────────
+    if engaged and sm is not None and sm.alive.get('modelV2', False) and v_ego_kph >= 20.0:
+      modelData = sm['modelV2']
+      if len(modelData.position.x) >= 3:
+        x_pts = np.array(modelData.position.x)
+        y_pts = np.array(modelData.position.y)
+        n_points = len(x_pts)
+        
+        # Calculate maximum curvature along the predicted path
+        max_c = 0.0
+        for i in range(1, n_points - 1):
+          x1, y1 = x_pts[i-1], y_pts[i-1]
+          x2, y2 = x_pts[i], y_pts[i]
+          x3, y3 = x_pts[i+1], y_pts[i+1]
+          
+          dx1, dy1 = x2 - x1, y2 - y1
+          dx2, dy2 = x3 - x2, y3 - y2
+          
+          a_side = math.sqrt(dx1**2 + dy1**2)
+          b_side = math.sqrt(dx2**2 + dy2**2)
+          c_side = math.sqrt((x3 - x1)**2 + (y3 - y1)**2)
+          
+          cross = dx1 * dy2 - dy1 * dx2
+          if a_side * b_side * c_side > 1e-6:
+            curvature = (2.0 * abs(cross)) / (a_side * b_side * c_side)
+            max_c = max(max_c, curvature)
+
+        # Curve detected threshold: max_c > 0.0035 (radius < ~285m)
+        is_curve = (max_c > 0.0035)
+        no_lead = (lead_drel == 0.0 or lead_drel > 80.0) # no close lead car
+        
+        if is_curve and no_lead:
+          if gas_pressed:
+            self._curve_override_gas_sec += _DT
+          elif brake_pressed:
+            self._curve_override_brake_sec += _DT
+            # Track peak deceleration in curve
+            self._curve_max_decel = max(self._curve_max_decel, -a_ego)
+            
+            # Detect unique brake event in curve
+            if not prev_brake:
+              self._curve_override_brake_count += 1
+
     # ── 주행 중 팝업 타이머 업데이트 ──────────────────────────────────
     if engaged and not gear_park:
       self._engaged_elapsed_sec += _DT
@@ -369,6 +421,12 @@ class CarrotLearner:
     self._brake_min_ttc = 999.0
     self._tfollow_min_gap = [999.0] * 4
 
+    # Phase 6 reset
+    self._curve_override_gas_sec = 0.0
+    self._curve_override_brake_sec = 0.0
+    self._curve_override_brake_count = 0
+    self._curve_max_decel = 0.0
+
     self._params.remove("CarrotLearningData")
     self._params.remove("CarrotLearningRecommend")
 
@@ -425,6 +483,12 @@ class CarrotLearner:
       p5 = data.get("phase5", {})
       self._dyn_brake_count = int(p5.get("dyn_brake_count", 0))
       self._decel_brake_count = int(p5.get("decel_brake_count", 0))
+      # Phase 6
+      p6 = data.get("phase6", {})
+      self._curve_override_gas_sec = float(p6.get("curve_override_gas_sec", 0.0))
+      self._curve_override_brake_sec = float(p6.get("curve_override_brake_sec", 0.0))
+      self._curve_override_brake_count = int(p6.get("curve_override_brake_count", 0))
+      self._curve_max_decel = float(p6.get("curve_max_decel", 0.0))
 
       # v3 Override Intensity & Dynamics Restore
       override = data.get("override_dynamics", {})
@@ -466,6 +530,12 @@ class CarrotLearner:
       "phase5": {
         "dyn_brake_count": self._dyn_brake_count,
         "decel_brake_count": self._decel_brake_count,
+      },
+      "phase6": {
+        "curve_override_gas_sec": self._curve_override_gas_sec,
+        "curve_override_brake_sec": self._curve_override_brake_sec,
+        "curve_override_brake_count": self._curve_override_brake_count,
+        "curve_max_decel": self._curve_max_decel,
       },
       "override_dynamics": {
         "gas_max_accel": self._gas_max_accel,
@@ -739,6 +809,37 @@ class CarrotLearner:
       entry["band_kph"] = entry["band_kph"] + f" ※다음세션권고:{','.join(deferred_names)}"
       result[winner_group][winner_name] = entry
 
+    # ── Phase 6: Curve Speed Aggressiveness ─────────────────────────
+    key = "AutoCurveSpeedAggressiveness"
+    current_raw = self._params.get_int(key)
+    if current_raw <= 0:
+      current_raw = 100
+
+    recommended_raw = current_raw
+    reason = ""
+    sec = 0.0
+
+    # Brake overrides (Safety critical - takes priority)
+    if self._curve_override_brake_count >= 3 or self._curve_override_brake_sec >= 5.0:
+      recommended_raw = max(60, current_raw - 10)
+      reason = f"brake overrides (count {self._curve_override_brake_count}, peak decel {self._curve_max_decel:.2f}m/s^2)"
+      sec = self._curve_override_brake_sec
+    elif self._curve_override_gas_sec >= 10.0:
+      recommended_raw = min(150, current_raw + 10)
+      reason = f"gas overrides (acc {self._curve_override_gas_sec:.1f}s)"
+      sec = self._curve_override_gas_sec
+
+    if recommended_raw != current_raw:
+      if "곡선 (Curve)" not in result:
+        result["곡선 (Curve)"] = {}
+      result["곡선 (Curve)"][key] = {
+        "current": current_raw,
+        "recommended": recommended_raw,
+        "reason": reason,
+        "band_kph": "curve deceleration",
+        "sec": sec,
+      }
+
     return {k: v for k, v in result.items() if v}
 
   def apply_recommendations(self):
@@ -781,6 +882,12 @@ class CarrotLearner:
     self._brake_max_decel = 0.0
     self._brake_min_ttc = 999.0
     self._tfollow_min_gap = [999.0] * 4
+
+    # Phase 6 reset
+    self._curve_override_gas_sec = 0.0
+    self._curve_override_brake_sec = 0.0
+    self._curve_override_brake_count = 0
+    self._curve_max_decel = 0.0
 
     # 주행 중 팝업 타이머 리셋 (적용 후 재학습 시작)
     self._engaged_elapsed_sec = 0.0

--- a/selfdrive/carrot/carrot_learning.py
+++ b/selfdrive/carrot/carrot_learning.py
@@ -579,10 +579,31 @@ class CarrotLearner:
     }
 
     # ── Phase 1: CruiseMaxVals ──────────────────────────────────────
+    drive_mode = self._params.get_int("MyDrivingMode") # 1: ECO, 2: SAFE, 3: NORMAL, 4: HIGH
     for i, acc_sec in enumerate(self._gas_acc):
       key = _ACCEL_KEYS[i]
       current_raw = self._params.get_int(key)
       if current_raw <= 0: continue
+
+      # 드라이브 모드별 동적 가속 제한 상한값 설정
+      max_limit = 250
+      if key == "CruiseMaxVals1":
+        if drive_mode in (1, 2):    # ECO, SAFE
+          max_limit = 180
+        elif drive_mode == 3:       # NORMAL
+          max_limit = 200
+        elif drive_mode == 4:       # HIGH
+          max_limit = 250
+      elif key == "CruiseMaxVals2":
+        if drive_mode in (1, 2):    # ECO, SAFE
+          max_limit = 150
+        elif drive_mode in (3, 4):  # NORMAL, HIGH
+          max_limit = 160
+      elif key == "CruiseMaxVals3":
+        if drive_mode in (1, 2):    # ECO, SAFE
+          max_limit = 110
+        elif drive_mode in (3, 4):  # NORMAL, HIGH
+          max_limit = 120
 
       total_dec = self._gas_dec_acc[i] + self._gas_dec_auto_acc[i]
       
@@ -601,17 +622,27 @@ class CarrotLearner:
       current_accel_limit = current_raw / 100.0
       accel_deficit = max_accel - current_accel_limit
 
-      if dampened_acc_sec >= _GAS_THRESHOLD_SEC and not is_auto_surging:
+      recommended_raw = current_raw
+      reason = ""
+      sec = 0.0
+
+      if current_raw > max_limit:
+        # 현재 설정값이 동적 상한선보다 큰 경우 강제 상한 제한으로 하향 조치 트리거
+        recommended_raw = max_limit
+        reason = f"exceeds drive-mode limit ({max_limit})"
+        sec = 0.0
+      elif dampened_acc_sec >= _GAS_THRESHOLD_SEC and not is_auto_surging:
         # 피크 가속도 부족분에 비례하는 가변 증가율 적용 (최소 5%, 최대 25%)
         if accel_deficit > 0.05:
           dynamic_ratio = float(np.clip(accel_deficit / current_accel_limit * 0.8, 0.05, 0.25))
         else:
           dynamic_ratio = _GAS_RECOMMEND_RATIO # 기본 10%
-        recommended_raw = min(250, int(current_raw * (1.0 + dynamic_ratio)))
+        recommended_raw = min(max_limit, int(current_raw * (1.0 + dynamic_ratio)))
         reason = f"gas help (deficit {accel_deficit:.2f}m/s^2, ratio {dynamic_ratio*100:.1f}%)"
         sec = dampened_acc_sec
       elif total_dec >= _GAS_REDUCE_THRESHOLD_SEC or (total_brake_events >= 8 and current_raw > 100) or is_auto_surging:
         recommended_raw = max(50, int(current_raw * (1.0 + _GAS_REDUCE_RATIO)))
+        recommended_raw = min(max_limit, recommended_raw)
         if is_auto_surging:
           reason = "excessive auto-surging penalty"
           sec = self._gas_dec_auto_acc[i] + self._brake_auto_count

--- a/selfdrive/carrot/carrot_learning.py
+++ b/selfdrive/carrot/carrot_learning.py
@@ -191,6 +191,8 @@ class CarrotLearner:
     - gear_park=True → 추천 계산 및 Params 저장
     """
     if not self._is_active():
+      if self._params.get_bool("CarrotLearningPopupReady"):
+        self._params.put_bool("CarrotLearningPopupReady", False)
       return
 
     prev_brake = self._prev_brake

--- a/selfdrive/carrot/carrot_learning.py
+++ b/selfdrive/carrot/carrot_learning.py
@@ -148,6 +148,17 @@ class CarrotLearner:
     self._prev_a_ego = 0.0       # 이전 프레임 가속도
     self._accel_swing_count = 0  # 가감속 반전(Hunting) 카운트
 
+    # ── 주행 중 팝업 타이머 ─────────────────────────────────────────────
+    # Trigger 1: 인게이지 30분 경과 → 즉시 팝업 (주행 중 포함)
+    self._engaged_elapsed_sec = 0.0      # 인게이지 누적 시간
+    self._popup_interval_sec = 1800.0    # 30분 = 1800초
+    # Trigger 2: 5분 주기 추천 체크 → 정차 시 팝업
+    self._check_elapsed_sec = 0.0        # 추천 체크 타이머
+    self._check_interval_sec = 300.0     # 5분마다 체크
+    self._pending_popup = False          # 정차 대기 팝업 플래그
+    # 공통: 팝업 후 쿨다운 (중복 발동 방지)
+    self._popup_cooldown_sec = 0.0       # 팝업 발동 후 5분 쿨다운
+
     self._load()
 
   # ------------------------------------------------------------------
@@ -292,7 +303,38 @@ class CarrotLearner:
       if v_ego_kph >= 80.0 and brake_pressed:
         self._tfollow_speed_brake_acc += _DT
 
-    # 주차 감지 (이전에 주차가 아니었고, 주행을 한 번이라도 한 경우에만 발동)
+    # ── 주행 중 팝업 타이머 업데이트 ──────────────────────────────────
+    if engaged and not gear_park:
+      self._engaged_elapsed_sec += _DT
+      self._check_elapsed_sec += _DT
+
+    # 쿨다운 소모
+    if self._popup_cooldown_sec > 0:
+      self._popup_cooldown_sec -= _DT
+
+    # [Trigger 2-체크] 5분마다 추천사항 확인 → pending 플래그 세팅
+    if self._check_elapsed_sec >= self._check_interval_sec:
+      self._check_elapsed_sec = 0.0
+      if self._has_driven and self._popup_cooldown_sec <= 0:
+        recs = self._calc_recommendations()
+        if recs:
+          self._pending_popup = True
+
+    # [Trigger 2-발동] 정차 시 (v < 3 km/h) pending 팝업 표시
+    if (self._pending_popup and not gear_park
+        and self._has_driven and v_ego_kph < 3.0
+        and self._popup_cooldown_sec <= 0):
+      self._fire_popup(source="stop")
+      self._pending_popup = False
+
+    # [Trigger 1] 인게이지 30분 경과 → 즉시 팝업 (주행 중이라도)
+    if (self._engaged_elapsed_sec >= self._popup_interval_sec
+        and self._has_driven and self._popup_cooldown_sec <= 0):
+      self._fire_popup(source="timer")
+      self._engaged_elapsed_sec = 0.0
+      self._pending_popup = False  # 30분 팝업이 발동하면 pending 취소
+
+    # [Trigger 3] 주차 감지 (이전에 주차가 아니었고, 주행을 한 번이라도 한 경우에만 발동)
     if gear_park and not self._prev_gear_park and self._has_driven:
       self._on_parking()
       self._has_driven = False  # 팝업 후 플래그 초기화
@@ -435,14 +477,24 @@ class CarrotLearner:
     }
     self._params.put("CarrotLearningData", json.dumps(data).encode('utf8'))
 
-  def _on_parking(self):
-    """주차 전환 시: 저장 → 추천 계산 → 팝업 신호"""
+  def _fire_popup(self, source: str = "parking"):
+    """추천 계산 → Params 저장 → 팝업 신호.
+    source: 'parking' | 'stop' | 'timer'
+    """
     self._save()
     recommendations = self._calc_recommendations()
     if not recommendations:
       return
     self._params.put("CarrotLearningRecommend", json.dumps(recommendations).encode('utf8'))
+    self._params.put("CarrotLearningPopupSource", source)
     self._params.put_bool("CarrotLearningPopupReady", True)
+    self._popup_cooldown_sec = 300.0  # 5분 쿨다운 (중복 팝업 방지)
+
+  def _on_parking(self):
+    """주차 전환 시: _fire_popup 호출"""
+    self._fire_popup(source="parking")
+    self._engaged_elapsed_sec = 0.0
+    self._pending_popup = False
 
   def _calc_recommendations(self) -> dict:
     """Phase 1~4 추천값 계산. 추천 없으면 빈 dict 반환."""
@@ -730,8 +782,15 @@ class CarrotLearner:
     self._brake_min_ttc = 999.0
     self._tfollow_min_gap = [999.0] * 4
 
+    # 주행 중 팝업 타이머 리셋 (적용 후 재학습 시작)
+    self._engaged_elapsed_sec = 0.0
+    self._check_elapsed_sec = 0.0
+    self._pending_popup = False
+    self._popup_cooldown_sec = 0.0
+
     self._params.remove("CarrotLearningData")
     self._params.remove("CarrotLearningRecommend")
+    self._params.remove("CarrotLearningPopupSource")
     self._params.put_bool("CarrotLearningPopupReady", False)
 
 

--- a/selfdrive/carrot/carrot_man.py
+++ b/selfdrive/carrot/carrot_man.py
@@ -1008,6 +1008,8 @@ class CarrotMan:
 
   def carrot_curve_speed_params(self):
     self.autoCurveSpeedFactor = self.params.get_int("AutoCurveSpeedFactor")*0.01
+    self.autoCurveSpeedAggressiveness = self.params.get_int("AutoCurveSpeedAggressiveness")*0.01
+    self.autoCurveSpeedLowerLimit = self.params.get_int("AutoCurveSpeedLowerLimit")
 
   def carrot_curve_speed(self, sm):
     self.carrot_curve_speed_params()
@@ -1020,29 +1022,87 @@ class CarrotMan:
     return self.vturn_speed(sm['carState'], sm)
 
   def vturn_speed(self, CS, sm):
-    TARGET_LAT_A = 1.9  # m/s^2
-
     modelData = sm['modelV2']
+    if len(modelData.position.x) < 3:
+      return 250
+
+    x = np.array(modelData.position.x)
+    y = np.array(modelData.position.y)
+
+    # 1. Calculate curvature at each point along the path using Menger curvature
+    n_points = len(x)
+    curvatures = np.zeros(n_points)
+
+    for i in range(1, n_points - 1):
+      # Coordinates of three consecutive points
+      x1, y1 = x[i-1], y[i-1]
+      x2, y2 = x[i], y[i]
+      x3, y3 = x[i+1], y[i+1]
+
+      # Vectors
+      dx1, dy1 = x2 - x1, y2 - y1
+      dx2, dy2 = x3 - x2, y3 - y2
+
+      # Length of sides
+      a = math.sqrt(dx1**2 + dy1**2)
+      b = math.sqrt(dx2**2 + dy2**2)
+      c = math.sqrt((x3 - x1)**2 + (y3 - y1)**2)
+
+      # Cross product (signed area)
+      cross = dx1 * dy2 - dy1 * dx2
+
+      if a * b * c > 1e-6:
+        # Menger curvature = 2 * area / (a * b * c)
+        curvatures[i] = (2.0 * cross) / (a * b * c)
+      else:
+        curvatures[i] = 0.0
+
+    # Apply AutoCurveSpeedFactor to curvatures (sensitivity adjustment)
+    curvatures *= self.autoCurveSpeedFactor
+
+    # 2. Compute safe speed target at each point
+    v_safe = np.zeros(n_points)
     v_ego = max(CS.vEgo, 0.1)
-    # Set the curve sensitivity
-    orientation_rate = np.array(modelData.orientationRate.z) * self.autoCurveSpeedFactor
-    velocity = np.array(modelData.velocity.x)
 
-    # Get the maximum lat accel from the model
-    max_index = np.argmax(np.abs(orientation_rate))
-    curv_direction = np.sign(orientation_rate[max_index])
-    max_pred_lat_acc = np.amax(np.abs(orientation_rate) * velocity)
+    for i in range(n_points):
+      c = abs(curvatures[i])
+      if c < 1e-4:
+        v_safe[i] = 250.0 / 3.6  # No speed limit on straight road
+      else:
+        # Speed-dependent dynamic comfort lateral acceleration limit
+        # At 0 km/h: 2.5 m/s^2, At 100 km/h: 1.4 m/s^2
+        # Base limit: 2.5 m/s^2, Slope: 0.011 m/s^2 per km/h
+        # User aggressiveness multiplier applies to the limit
+        v_approx = v_ego
+        lat_acc_limit = max(1.0, 2.5 - 0.011 * v_approx * 3.6) * self.autoCurveSpeedAggressiveness
 
-    # Get the maximum curve based on the current velocity
-    max_curve = max_pred_lat_acc / (v_ego**2)
+        # turnSpeed = sqrt(a_lat / curvature)
+        v_safe[i] = math.sqrt(lat_acc_limit / c)
 
-    # Set the target lateral acceleration
-    adjusted_target_lat_a = TARGET_LAT_A
+    # 3. Backward Pass integration to calculate the deceleration profile
+    # comfort deceleration limit: autoNaviSpeedDecelRate (default ~1.2 m/s^2)
+    decel_limit = max(0.5, self.carrot_serv.autoNaviSpeedDecelRate)
 
-    # Get the target velocity for the maximum curve
-    #turnSpeed = max(abs(adjusted_target_lat_a / max_curve)**0.5  * 3.6, self.autoCurveSpeedLowerLimit)
-    turnSpeed = max(abs(adjusted_target_lat_a / max_curve)**0.5  * 3.6, 5)
-    turnSpeed = min(turnSpeed, 250)
+    v_target = np.zeros(n_points)
+    v_target[-1] = v_safe[-1]
+
+    for i in range(n_points - 2, -1, -1):
+      dx = x[i+1] - x[i]
+      if dx > 0:
+        # physics formula: v_i^2 = v_f^2 + 2 * a * dx
+        v_target[i] = min(v_safe[i], math.sqrt(v_target[i+1]**2 + 2.0 * decel_limit * dx))
+      else:
+        v_target[i] = v_safe[i]
+
+    # Target speed at current position (i=0)
+    turnSpeed = v_target[0] * 3.6  # Convert to km/h
+    turnSpeed = max(turnSpeed, self.autoCurveSpeedLowerLimit)
+    turnSpeed = min(turnSpeed, 250.0)
+
+    # Find the maximum curvature direction
+    max_idx = np.argmax(np.abs(curvatures))
+    curv_direction = np.sign(curvatures[max_idx]) if abs(curvatures[max_idx]) > 0 else 1.0
+
     return turnSpeed * curv_direction
 
   def carrot_navi_thread(self):

--- a/selfdrive/ui/qt/home.cc
+++ b/selfdrive/ui/qt/home.cc
@@ -498,7 +498,18 @@ void HomeWindow::updateState(const UIState &s) {
       QJsonDocument doc = QJsonDocument::fromJson(raw.toUtf8());
       if (!raw.isEmpty() && doc.isObject()) {
         QJsonObject obj = doc.object();
-        QString msg = tr("Auto-Tuner: Driving pattern learned!");
+
+        // 팝업 소스에 따른 타이틀 메시지 분기
+        QString source = QString::fromStdString(params.get("CarrotLearningPopupSource"));
+        QString msg;
+        if (source == "timer") {
+          msg = tr("Auto-Tuner: 30min update — driving pattern learned!");
+        } else if (source == "stop") {
+          msg = tr("Auto-Tuner: Driving pattern learned!");
+        } else {
+          // parking (default)
+          msg = tr("Auto-Tuner: Driving pattern learned!");
+        }
 
         AutoTunerDialog *dialog = new AutoTunerDialog(msg, obj, this);
         connect(dialog, &QDialog::accepted, [=]() {

--- a/selfdrive/ui/qt/home.cc
+++ b/selfdrive/ui/qt/home.cc
@@ -6,6 +6,8 @@
 #include <QVBoxLayout>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <QJsonArray>
+#include <QTimer>
 
 #include "selfdrive/ui/qt/offroad/experimental_mode.h"
 #include "selfdrive/ui/qt/util.h"
@@ -77,8 +79,14 @@ class AutoTunerDialog : public DialogBase {
 public:
   QMap<QString, QCheckBox*> item_checkboxes;
   QJsonObject recommendations;
+  bool auto_apply_clicked = false;
+  bool is_auto_applied_popup = false;
+  int countdown_seconds = 5;
+  QPushButton *btn_close = nullptr;
+  QTimer *countdown_timer = nullptr;
 
-  explicit AutoTunerDialog(const QString &title_text, const QJsonObject &recs, QWidget *parent = nullptr) : DialogBase(parent), recommendations(recs) {
+  explicit AutoTunerDialog(const QString &title_text, const QJsonObject &recs, bool auto_applied = false, QWidget *parent = nullptr) 
+      : DialogBase(parent), recommendations(recs), is_auto_applied_popup(auto_applied) {
     setWindowFlags(Qt::Popup | Qt::FramelessWindowHint);
     setAttribute(Qt::WA_TranslucentBackground);
     setStyleSheet(R"(
@@ -136,13 +144,6 @@ public:
                                     .arg(info["current"].toInt())
                                     .arg(info["recommended"].toInt());
         
-        QCheckBox *cb = new QCheckBox();
-        cb->setText(item_text);
-        // Qt uses rich text in QCheckBox only if we set it this way or implicitly, but since Qt 5.11 text formats are auto-detected.
-        // If rich text doesn't render in QCheckBox text, we will use a QLabel alongside a checkbox.
-        // Wait, QCheckBox text does not support rich text by default natively in all styles.
-        // Let's create a horizontal layout for each item: Checkbox + QLabel
-        
         QHBoxLayout *item_layout = new QHBoxLayout();
         item_layout->setContentsMargins(0, 0, 0, 15);
         item_layout->setSpacing(20);
@@ -150,6 +151,9 @@ public:
         QCheckBox *item_cb = new QCheckBox();
         item_cb->setChecked(true);
         item_cb->setStyleSheet("QCheckBox::indicator { width: 50px; height: 50px; }");
+        if (is_auto_applied_popup) {
+          item_cb->setEnabled(false);
+        }
         
         QLabel *item_label = new QLabel(item_text);
         item_label->setStyleSheet("font-size: 45px; color: white;");
@@ -166,26 +170,92 @@ public:
     scroll->setWidget(scroll_widget);
     main_layout->addWidget(scroll, 1);
 
+    QString lang = QString::fromStdString(Params().get("LanguageSetting"));
+    QString txt_guide = tr("Guide");
+    QString txt_later = tr("Later");
+    QString txt_reset = tr("Reset");
+    QString txt_apply = tr("Apply Selected");
+    QString txt_auto_apply = tr("Auto Apply");
+    QString txt_close_fmt = tr("Close (%1s)");
+    
+    if (lang == "main_ko") {
+      txt_guide = "가이드";
+      txt_later = "나중에";
+      txt_reset = "초기화";
+      txt_apply = "선택 적용";
+      txt_auto_apply = "자동 적용";
+      txt_close_fmt = "닫기 (%1초)";
+    } else if (lang == "main_zh-CHS" || lang == "main_zh-CHT") {
+      txt_guide = "指南";
+      txt_later = "稍后";
+      txt_reset = "重置";
+      txt_apply = "应用所选";
+      txt_auto_apply = "自动应用";
+      txt_close_fmt = "关闭 (%1秒)";
+    }
+
     QHBoxLayout *btn_layout = new QHBoxLayout();
     
-    QPushButton *btn_guide = new QPushButton(tr("Guide"));
+    QPushButton *btn_guide = new QPushButton(txt_guide);
     btn_guide->setStyleSheet("background-color: #3b5998;");
-    
-    QPushButton *btn_later = new QPushButton(tr("Later"));
-    btn_later->setStyleSheet("background-color: #555555;");
-    
-    QPushButton *btn_clear = new QPushButton(tr("Reset"));
-    btn_clear->setStyleSheet("background-color: #8a1d1d;");
-    
-    QPushButton *btn_apply = new QPushButton(tr("Apply Selected"));
-    btn_apply->setStyleSheet("background-color: #178644;");
-
     btn_layout->addWidget(btn_guide);
-    btn_layout->addWidget(btn_later);
-    btn_layout->addWidget(btn_clear);
-    btn_layout->addWidget(btn_apply);
-    main_layout->addLayout(btn_layout);
 
+    if (is_auto_applied_popup) {
+      btn_close = new QPushButton(txt_close_fmt.arg(countdown_seconds));
+      btn_close->setStyleSheet("background-color: #555555;");
+      btn_layout->addWidget(btn_close);
+
+      countdown_timer = new QTimer(this);
+      connect(countdown_timer, &QTimer::timeout, this, [=]() {
+        countdown_seconds--;
+        if (countdown_seconds <= 0) {
+          countdown_timer->stop();
+          accept();
+        } else {
+          if (btn_close) {
+            btn_close->setText(txt_close_fmt.arg(countdown_seconds));
+          }
+        }
+      });
+      countdown_timer->start(1000);
+
+      connect(btn_close, &QPushButton::clicked, this, &QDialog::accept);
+    } else {
+      QPushButton *btn_later = new QPushButton(txt_later);
+      btn_later->setStyleSheet("background-color: #555555;");
+      
+      QPushButton *btn_clear = new QPushButton(txt_reset);
+      btn_clear->setStyleSheet("background-color: #8a1d1d;");
+      
+      QPushButton *btn_apply = new QPushButton(txt_apply);
+      btn_apply->setStyleSheet("background-color: #178644;");
+      
+      QPushButton *btn_auto_apply = new QPushButton(txt_auto_apply);
+      btn_auto_apply->setStyleSheet("background-color: #0b76a0;");
+
+      btn_layout->addWidget(btn_later);
+      btn_layout->addWidget(btn_clear);
+      btn_layout->addWidget(btn_apply);
+      btn_layout->addWidget(btn_auto_apply);
+
+      connect(btn_later, &QPushButton::clicked, this, &QDialog::reject);
+      
+      connect(btn_clear, &QPushButton::clicked, [=]() {
+        if (ConfirmationDialog::confirm(tr("Are you sure you want to delete all learning data collected so far without applying it?"), tr("Reset"), this)) {
+          Params().putBool("CarrotLearningClear", true);
+          this->reject();
+        }
+      });
+
+      connect(btn_apply, &QPushButton::clicked, this, &QDialog::accept);
+
+      connect(btn_auto_apply, &QPushButton::clicked, this, [=]() {
+        auto_apply_clicked = true;
+        accept();
+      });
+    }
+
+    main_layout->addLayout(btn_layout);
     outer_layout->addWidget(container);
 
     connect(btn_guide, &QPushButton::clicked, this, [=]() {
@@ -346,17 +416,6 @@ public:
       d->exec();
       d->deleteLater();
     });
-
-    connect(btn_later, &QPushButton::clicked, this, &QDialog::reject);
-    
-    connect(btn_clear, &QPushButton::clicked, [=]() {
-      if (ConfirmationDialog::confirm(tr("Are you sure you want to delete all learning data collected so far without applying it?"), tr("Reset"), this)) {
-        Params().putBool("CarrotLearningClear", true);
-        this->reject();
-      }
-    });
-
-    connect(btn_apply, &QPushButton::clicked, this, &QDialog::accept);
   }
 
   QJsonObject getSelectedItems() {
@@ -468,7 +527,7 @@ void HomeWindow::updateState(const UIState &s) {
         QJsonObject dsp_obj = dsp_doc.object();
         QString dsp_msg = tr("🧬 DSP: Manual driving style analyzed! (Auto-Tuner will follow next)");
 
-        AutoTunerDialog *dsp_dialog = new AutoTunerDialog(dsp_msg, dsp_obj, this);
+        AutoTunerDialog *dsp_dialog = new AutoTunerDialog(dsp_msg, dsp_obj, false, this);
         connect(dsp_dialog, &QDialog::accepted, [=]() {
           Params p;
           QJsonObject selected = dsp_dialog->getSelectedItems();
@@ -478,9 +537,7 @@ void HomeWindow::updateState(const UIState &s) {
               for (const QString& key : group_items.keys()) {
                 QJsonObject info = group_items[key].toObject();
                 int recommended = info["recommended"].toInt(0);
-                if (recommended > 0) {
-                  p.put(key.toStdString(), std::to_string(recommended));
-                }
+                p.put(key.toStdString(), std::to_string(recommended));
               }
             }
           }
@@ -508,60 +565,118 @@ void HomeWindow::updateState(const UIState &s) {
       if (!raw.isEmpty() && doc.isObject()) {
         QJsonObject obj = doc.object();
 
-        // 팝업 소스에 따른 타이틀 메시지 분기
-        QString source = QString::fromStdString(params.get("CarrotLearningPopupSource"));
-        QString msg;
-        if (source == "timer") {
-          msg = tr("Auto-Tuner: 30min update — driving pattern learned!");
-        } else if (source == "stop") {
-          msg = tr("Auto-Tuner: Driving pattern learned!");
-        } else {
-          // parking (default)
-          msg = tr("Auto-Tuner: Driving pattern learned!");
-        }
-
-        AutoTunerDialog *dialog = new AutoTunerDialog(msg, obj, this);
-        connect(dialog, &QDialog::accepted, [=]() {
+        bool auto_apply = params.getBool("CarrotLearningAutoApply");
+        if (auto_apply) {
+          // ── [자동 적용 모드] 백그라운드 선적용 + 5초 카운트다운 알림 ──
           Params p;
-          QJsonObject selected = dialog->getSelectedItems();
-          if (!selected.isEmpty()) {
-            QJsonArray history_array;
-            QString history_raw = QString::fromStdString(p.get("CarrotLearningHistory"));
-            if (!history_raw.isEmpty()) {
-              QJsonDocument h_doc = QJsonDocument::fromJson(history_raw.toUtf8());
-              if (h_doc.isArray()) history_array = h_doc.array();
+          QJsonArray history_array;
+          QString history_raw = QString::fromStdString(p.get("CarrotLearningHistory"));
+          if (!history_raw.isEmpty()) {
+            QJsonDocument h_doc = QJsonDocument::fromJson(history_raw.toUtf8());
+            if (h_doc.isArray()) history_array = h_doc.array();
+          }
+
+          QJsonObject history_entry;
+          history_entry["timestamp"] = QDateTime::currentDateTime().toString("yyyy-MM-dd HH:mm");
+          history_entry["changes"] = obj;
+          history_entry["id"] = QString::number(QDateTime::currentMSecsSinceEpoch());
+          history_entry["auto_applied"] = true;
+
+          history_array.prepend(history_entry);
+          while (history_array.size() > 50) history_array.removeLast();
+
+          p.put("CarrotLearningHistory", QJsonDocument(history_array).toJson(QJsonDocument::Compact).toStdString());
+
+          for (const QString& group : obj.keys()) {
+            QJsonObject group_items = obj[group].toObject();
+            for (const QString& key : group_items.keys()) {
+              QJsonObject info = group_items[key].toObject();
+              int recommended = info["recommended"].toInt(0);
+              p.put(key.toStdString(), std::to_string(recommended));
             }
+          }
 
-            QJsonObject history_entry;
-            history_entry["timestamp"] = QDateTime::currentDateTime().toString("yyyy-MM-dd HH:mm");
-            history_entry["changes"] = selected;
-            history_entry["id"] = QString::number(QDateTime::currentMSecsSinceEpoch());
+          QString lang = QString::fromStdString(params.get("LanguageSetting"));
+          QString msg;
+          if (lang == "main_ko") {
+            msg = "🥕 Auto-Tuner: 추천 파라미터가 자동 적용되었습니다!";
+          } else if (lang == "main_zh-CHS" || lang == "main_zh-CHT") {
+            msg = "🥕 Auto-Tuner: 推荐参数已自动应用！";
+          } else {
+            msg = "🥕 Auto-Tuner: Parameters automatically applied!";
+          }
 
-            history_array.prepend(history_entry);
-            while (history_array.size() > 50) history_array.removeLast();
+          AutoTunerDialog *dialog = new AutoTunerDialog(msg, obj, true, this);
+          connect(dialog, &QDialog::accepted, [=]() {
+            Params().putBool("CarrotLearningClear", true);
+            dialog->deleteLater();
+          });
+          connect(dialog, &QDialog::rejected, [=]() {
+            Params().putBool("CarrotLearningClear", true);
+            dialog->deleteLater();
+          });
+          setMainWindow(dialog);
 
-            p.put("CarrotLearningHistory", QJsonDocument(history_array).toJson(QJsonDocument::Compact).toStdString());
+        } else {
+          // ── [수동 적용 모드] 선택적용 vs 자동적용 선택 ──────────────────
+          QString source = QString::fromStdString(params.get("CarrotLearningPopupSource"));
+          QString msg;
+          if (source == "timer") {
+            msg = tr("Auto-Tuner: 30min update — driving pattern learned!");
+          } else if (source == "stop") {
+            msg = tr("Auto-Tuner: Driving pattern learned!");
+          } else {
+            msg = tr("Auto-Tuner: Driving pattern learned!");
+          }
 
-            for (const QString& group : selected.keys()) {
-              QJsonObject group_items = selected[group].toObject();
-              for (const QString& key : group_items.keys()) {
-                QJsonObject info = group_items[key].toObject();
-                int recommended = info["recommended"].toInt(0);
-                if (recommended > 0) {
+          AutoTunerDialog *dialog = new AutoTunerDialog(msg, obj, false, this);
+          connect(dialog, &QDialog::accepted, [=]() {
+            Params p;
+            QJsonObject selected = dialog->getSelectedItems();
+            if (!selected.isEmpty()) {
+              QJsonArray history_array;
+              QString history_raw = QString::fromStdString(p.get("CarrotLearningHistory"));
+              if (!history_raw.isEmpty()) {
+                QJsonDocument h_doc = QJsonDocument::fromJson(history_raw.toUtf8());
+                if (h_doc.isArray()) history_array = h_doc.array();
+              }
+
+              QJsonObject history_entry;
+              history_entry["timestamp"] = QDateTime::currentDateTime().toString("yyyy-MM-dd HH:mm");
+              history_entry["changes"] = selected;
+              history_entry["id"] = QString::number(QDateTime::currentMSecsSinceEpoch());
+              if (dialog->auto_apply_clicked) {
+                history_entry["auto_applied"] = true;
+              }
+
+              history_array.prepend(history_entry);
+              while (history_array.size() > 50) history_array.removeLast();
+
+              p.put("CarrotLearningHistory", QJsonDocument(history_array).toJson(QJsonDocument::Compact).toStdString());
+
+              for (const QString& group : selected.keys()) {
+                QJsonObject group_items = selected[group].toObject();
+                for (const QString& key : group_items.keys()) {
+                  QJsonObject info = group_items[key].toObject();
+                  int recommended = info["recommended"].toInt(0);
                   p.put(key.toStdString(), std::to_string(recommended));
                 }
               }
+
+              if (dialog->auto_apply_clicked) {
+                p.putBool("CarrotLearningAutoApply", true);
+              }
             }
-          }
-          Params().putBool("CarrotLearningClear", true);
-          dialog->deleteLater();
-        });
+            Params().putBool("CarrotLearningClear", true);
+            dialog->deleteLater();
+          });
 
-        connect(dialog, &QDialog::rejected, [=]() {
-          dialog->deleteLater();
-        });
+          connect(dialog, &QDialog::rejected, [=]() {
+            dialog->deleteLater();
+          });
 
-        setMainWindow(dialog);
+          setMainWindow(dialog);
+        }
       }
     }
   }

--- a/selfdrive/ui/qt/home.cc
+++ b/selfdrive/ui/qt/home.cc
@@ -220,6 +220,9 @@ public:
         <b>🔄 [转向] (Steering)</b><br>
         调整转向响应性。<br>
         - <b>PathOffset / SteerActuatorDelay</b>：修正转向偏差与延迟。<br>
+        <b>🏎️ [弯道减速] (Curve Speed)</b><br>
+        基于物理学（最大横向加速度）在弯道前自动降速，防止超速过弯。<br>
+        - <b>AutoCurveSpeedAggressiveness</b>：弯道减速激进程度（60~150%）。值越小越保守（早减速），越大越激进（少减速）。系统通过学习驾驶员在弯道的油门/刹车操作自动优化此参数。<br>
         <hr>
         <div style='font-size: 50px; font-weight: bold; margin-top: 20px; margin-bottom: 10px;'>🧠 自动驾驶模式自主检测</div>
         即使驾驶员未踩踏板，系统也会持续监控自身控制质量：<br>
@@ -268,6 +271,9 @@ public:
         Adjusts handling responsiveness.<br>
         - <b>PathOffset</b>: Compensates for lane drifts.<br>
         - <b>SteerActuatorDelay</b>: Reduces cornering delay.<br>
+        <b>🏎️ [Curve Speed]</b><br>
+        Automatically reduces speed before curves based on physics (max lateral acceleration), preventing overspeed in corners.<br>
+        - <b>AutoCurveSpeedAggressiveness</b>: Controls how aggressively the system slows down for curves (60~150%). Lower = more conservative (earlier braking), Higher = more aggressive (less slowdown). The system learns and self-tunes this parameter based on driver gas/brake interventions in curves.<br>
         <hr>
         <div style='font-size: 50px; font-weight: bold; margin-top: 20px; margin-bottom: 10px;'>🧠 Autonomous Pattern Detection</div>
         Even without your pedal input, the system monitors its own control quality:<br>
@@ -314,6 +320,9 @@ public:
         <b>🔄 [조향] (Steering)</b><br>
         핸들링 반응성을 조정합니다.<br>
         - <b>PathOffset / SteerActuatorDelay</b>: 조향 편차 및 지연 보정.<br>
+        <b>🏎️ [곡선 감속] (Curve Speed)</b><br>
+        물리 이론(최대 횡방향 가속도)을 기반으로 곡선 구간 진입 전에 자동으로 속도를 줄여 안전한 코너링을 지원합니다.<br>
+        - <b>AutoCurveSpeedAggressiveness</b>: 곡선 감속의 적극성을 조절합니다 (60~150%). 값이 낮을수록 보수적(일찍, 많이 감속), 높을수록 적극적(감속 최소화). 주행 중 곡선 구간에서 운전자가 가속/브레이크 페달을 밟는 패턴을 학습하여 자동으로 최적화됩니다.<br>
         <hr>
         <div style='font-size: 50px; font-weight: bold; margin-top: 20px; margin-bottom: 10px;'>🧠 자율 주행 패턴 자동 감지</div>
         운전자가 페달을 밟지 않아도, 시스템은 스스로의 제어 품질을 감시합니다:<br>

--- a/selfdrive/ui/qt/offroad/settings.cc
+++ b/selfdrive/ui/qt/offroad/settings.cc
@@ -703,8 +703,8 @@ AutoTunerHistoryPanel::AutoTunerHistoryPanel(QWidget* parent) : QFrame(parent) {
   header_layout->addStretch();
 
   QPushButton *btn_card_list = new QPushButton(tr("View Card Type"));
-  btn_card_list->setStyleSheet("background-color: #4a4a4a; font-size: 26px; border-radius: 10px; color: white; font-weight: bold;");
-  btn_card_list->setFixedHeight(55);
+  btn_card_list->setStyleSheet("background-color: #4a4a4a; font-size: 52px; border-radius: 10px; color: white; font-weight: bold;");
+  btn_card_list->setFixedHeight(110);
   connect(btn_card_list, &QPushButton::clicked, this, [=]() {
     AutoTunerCardListDialog dlg(this);
     dlg.exec();
@@ -712,16 +712,16 @@ AutoTunerHistoryPanel::AutoTunerHistoryPanel(QWidget* parent) : QFrame(parent) {
   header_layout->addWidget(btn_card_list);
 
   QPushButton *btn_all = new QPushButton(tr("Show All Parameters"));
-  btn_all->setStyleSheet("background-color: #3b5998; font-size: 26px; border-radius: 10px; color: white; font-weight: bold;");
-  btn_all->setFixedHeight(55);
+  btn_all->setStyleSheet("background-color: #3b5998; font-size: 52px; border-radius: 10px; color: white; font-weight: bold;");
+  btn_all->setFixedHeight(110);
   connect(btn_all, &QPushButton::clicked, this, [=]() {
     if (graph_widget) graph_widget->setSelectedParam("");
   });
   header_layout->addWidget(btn_all);
 
   QPushButton *btn_clear = new QPushButton(tr("Clear All Logs"));
-  btn_clear->setStyleSheet("background-color: #bb3333; font-size: 26px; border-radius: 10px; color: white; font-weight: bold;");
-  btn_clear->setFixedHeight(55);
+  btn_clear->setStyleSheet("background-color: #bb3333; font-size: 52px; border-radius: 10px; color: white; font-weight: bold;");
+  btn_clear->setFixedHeight(110);
   connect(btn_clear, &QPushButton::clicked, this, &AutoTunerHistoryPanel::clearAll);
   header_layout->addWidget(btn_clear);
 

--- a/selfdrive/ui/qt/offroad/settings.cc
+++ b/selfdrive/ui/qt/offroad/settings.cc
@@ -12,6 +12,8 @@
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <QPainter>
+#include <QPainterPath>
 
 #include "common/watchdog.h"
 #include "common/util.h"
@@ -465,31 +467,301 @@ void SettingsWindow::setCurrentPanel(int index, const QString &param) {
   nav_btns->buttons()[index]->setChecked(true);
 }
 
+AutoTunerGraphWidget::AutoTunerGraphWidget(QWidget *parent) : QWidget(parent) {
+  setAttribute(Qt::WA_OpaquePaintEvent, false);
+}
+
+void AutoTunerGraphWidget::setData(const QList<QString> &ts, const QMap<QString, QList<double>> &histories, const QMap<QString, QColor> &cols) {
+  timestamps = ts;
+  param_histories = histories;
+  colors = cols;
+  selected_index = -1;
+  update();
+}
+
+void AutoTunerGraphWidget::setSelectedParam(const QString &param) {
+  selected_param = param;
+  update();
+}
+
+void AutoTunerGraphWidget::mousePressEvent(QMouseEvent *event) {
+  if (timestamps.isEmpty()) return;
+  
+  int margin_left = 80;
+  int margin_right = 40;
+  QRect graph_rect = rect().adjusted(margin_left, 80, -margin_right, -40);
+  int steps_x = timestamps.size() - 1;
+  if (steps_x < 1) steps_x = 1;
+
+  int click_x = event->x();
+  int closest_idx = 0;
+  int min_dist = 999999;
+  
+  for (int i = 0; i < timestamps.size(); i++) {
+    int node_x = graph_rect.left() + i * graph_rect.width() / steps_x;
+    int dist = std::abs(click_x - node_x);
+    if (dist < min_dist) {
+      min_dist = dist;
+      closest_idx = i;
+    }
+  }
+
+  if (min_dist < 60) {
+    selected_index = closest_idx;
+  } else {
+    selected_index = -1;
+  }
+  update();
+}
+
+void AutoTunerGraphWidget::paintEvent(QPaintEvent *event) {
+  QPainter painter(this);
+  painter.setRenderHint(QPainter::Antialiasing);
+
+  // Background
+  painter.fillRect(rect(), QColor("#1f1f1f"));
+
+  if (timestamps.isEmpty() || param_histories.isEmpty()) {
+    painter.setPen(QColor("#888888"));
+    painter.setFont(QFont("Arial", 40));
+    painter.drawText(rect(), Qt::AlignCenter, tr("No historical data to display"));
+    return;
+  }
+
+  // Margin - bottom margin reduced to 40 since overlapping labels are removed
+  int margin_left = 80;
+  int margin_right = 40;
+  int margin_top = 80;
+  int margin_bottom = 40;
+
+  QRect graph_rect = rect().adjusted(margin_left, margin_top, -margin_right, -margin_bottom);
+
+  int steps_x = timestamps.size() - 1;
+  if (steps_x < 1) steps_x = 1;
+  
+  // Draw Grid Lines (Vertical & Horizontal)
+  painter.setPen(QPen(QColor("#2d2d2d"), 2, Qt::SolidLine));
+  
+  // X grid lines
+  for (int i = 0; i <= steps_x; i++) {
+    int x = graph_rect.left() + i * graph_rect.width() / steps_x;
+    painter.drawLine(x, graph_rect.top(), x, graph_rect.bottom());
+  }
+
+  // Y grid lines
+  int steps_y = 4;
+  for (int i = 0; i <= steps_y; i++) {
+    int y = graph_rect.top() + i * graph_rect.height() / steps_y;
+    painter.drawLine(graph_rect.left(), y, graph_rect.right(), y);
+  }
+
+  // Draw Line Paths
+  painter.setBrush(Qt::NoBrush);
+  for (const QString &param : param_histories.keys()) {
+    QList<double> values = param_histories[param];
+    if (values.size() != timestamps.size()) continue;
+
+    double min_val = values[0];
+    double max_val = values[0];
+    for (double val : values) {
+      if (val < min_val) min_val = val;
+      if (val > max_val) max_val = val;
+    }
+
+    double diff = max_val - min_val;
+
+    bool is_highlighted = selected_param.isEmpty() || (selected_param == param);
+    int opacity = 255;
+    int line_width = 4;
+    
+    if (!selected_param.isEmpty()) {
+      if (selected_param == param) {
+        opacity = 255;
+        line_width = 8;
+      } else {
+        opacity = 40; // Dim unselected paths
+        line_width = 2;
+      }
+    }
+
+    QColor color = colors.value(param, QColor(Qt::white));
+    color.setAlpha(opacity);
+
+    QPen pen(color, line_width);
+    if (!selected_param.isEmpty() && selected_param != param) {
+      pen.setStyle(Qt::DotLine);
+    } else {
+      pen.setStyle(Qt::SolidLine);
+    }
+    painter.setPen(pen);
+    painter.setBrush(Qt::NoBrush);
+
+    QPainterPath path;
+    for (int i = 0; i < values.size(); i++) {
+      double val = values[i];
+      int x = graph_rect.left() + i * graph_rect.width() / steps_x;
+      int y;
+      if (diff < 1e-5) {
+        y = graph_rect.top() + graph_rect.height() / 2;
+      } else {
+        y = graph_rect.bottom() - (val - min_val) / diff * graph_rect.height();
+      }
+
+      if (i == 0) path.moveTo(x, y);
+      else path.lineTo(x, y);
+    }
+    painter.drawPath(path);
+
+    // Draw Nodes and Value Labels
+    for (int i = 0; i < values.size(); i++) {
+      double val = values[i];
+      int x = graph_rect.left() + i * graph_rect.width() / steps_x;
+      int y;
+      if (diff < 1e-5) {
+        y = graph_rect.top() + graph_rect.height() / 2;
+      } else {
+        y = graph_rect.bottom() - (val - min_val) / diff * graph_rect.height();
+      }
+
+      painter.setBrush(color);
+      painter.setPen(Qt::NoPen);
+      int dot_size = (selected_param == param) ? 16 : 10;
+      painter.drawEllipse(QPoint(x, y), dot_size / 2, dot_size / 2);
+
+      if (is_highlighted && (selected_param == param || timestamps.size() <= 8 || i == 0 || i == values.size() - 1)) {
+        painter.setPen(QColor(is_highlighted ? "#ffffff" : "#aaaaaa"));
+        painter.setFont(QFont("Arial", (selected_param == param) ? 30 : 22, QFont::Bold));
+        QString val_str = QString::number(val, 'g', 4);
+        painter.drawText(QRect(x - 80, y - 48, 160, 40), Qt::AlignCenter, val_str);
+      }
+    }
+  }
+
+  // Draw Vertical Guide Line and Time Tooltip on touch/click
+  if (selected_index >= 0 && selected_index < timestamps.size()) {
+    int x = graph_rect.left() + selected_index * graph_rect.width() / steps_x;
+    
+    // Vertical Guide
+    painter.setPen(QPen(QColor("#ffaa00"), 2.5, Qt::DashLine));
+    painter.drawLine(x, graph_rect.top(), x, graph_rect.bottom());
+
+    // Tooltip Background & Text
+    QString date_str = timestamps[selected_index];
+    painter.setFont(QFont("Arial", 28, QFont::Bold));
+    
+    QFontMetrics fm = painter.fontMetrics();
+    int txt_w = fm.horizontalAdvance(date_str) + 30;
+    int txt_h = 50;
+
+    QRect tooltip_rect(x - txt_w / 2, margin_top - 65, txt_w, txt_h);
+    
+    // Boundary check
+    if (tooltip_rect.left() < 10) tooltip_rect.moveLeft(10);
+    if (tooltip_rect.right() > width() - 10) tooltip_rect.moveRight(width() - 10);
+
+    painter.setBrush(QColor("#2d2d2d"));
+    painter.setPen(QPen(QColor("#ffaa00"), 2));
+    painter.drawRoundedRect(tooltip_rect, 10, 10);
+
+    painter.setPen(QColor("#ffffff"));
+    painter.drawText(tooltip_rect, Qt::AlignCenter, date_str);
+  }
+}
+
 AutoTunerHistoryPanel::AutoTunerHistoryPanel(QWidget* parent) : QFrame(parent) {
-  QVBoxLayout *main_layout = new QVBoxLayout(this);
-  main_layout->setContentsMargins(50, 50, 50, 50);
+  QHBoxLayout *main_layout = new QHBoxLayout(this);
+  main_layout->setContentsMargins(20, 20, 20, 20);
+  main_layout->setSpacing(20);
 
-  QLabel *title = new QLabel(tr("Auto-Tuner History Log v2"));
-  title->setStyleSheet("font-size: 60px; font-weight: bold; margin-bottom: 20px; color: white;");
-  main_layout->addWidget(title);
+  // Left Column: Parameters List
+  QVBoxLayout *left_layout = new QVBoxLayout();
+  left_layout->setSpacing(15);
 
-  QPushButton *btn_clear = new QPushButton(tr("Clear All"));
-  btn_clear->setStyleSheet("background-color: #bb3333; font-size: 45px; padding: 30px; border-radius: 10px; margin-bottom: 30px; color: white; font-weight: bold;");
-  connect(btn_clear, &QPushButton::clicked, this, &AutoTunerHistoryPanel::clearAll);
-  main_layout->addWidget(btn_clear);
+  QLabel *list_title = new QLabel(tr("Parameters"));
+  list_title->setStyleSheet("font-size: 42px; font-weight: bold; color: white;");
+  left_layout->addWidget(list_title);
 
   QScrollArea *scroll = new QScrollArea();
   scroll->setWidgetResizable(true);
   scroll->setFrameShape(QFrame::NoFrame);
+  scroll->setFixedWidth(340);
   scroll->setStyleSheet("QScrollArea { background: transparent; } QWidget { background: transparent; }");
   QScroller::grabGesture(scroll->viewport(), QScroller::LeftMouseButtonGesture);
 
   QWidget *scroll_widget = new QWidget();
-  list_layout = new QVBoxLayout(scroll_widget);
-  list_layout->setSpacing(30);
-  
+  param_list_layout = new QVBoxLayout(scroll_widget);
+  param_list_layout->setContentsMargins(0, 0, 0, 0);
+  param_list_layout->setSpacing(8);
   scroll->setWidget(scroll_widget);
-  main_layout->addWidget(scroll);
+  left_layout->addWidget(scroll, 1);
+
+  // Right Column: Chart + Controls
+  QVBoxLayout *right_layout = new QVBoxLayout();
+  right_layout->setSpacing(20);
+
+  QHBoxLayout *header_layout = new QHBoxLayout();
+  header_layout->addStretch();
+
+  QPushButton *btn_card_list = new QPushButton(tr("View Card Type"));
+  btn_card_list->setStyleSheet("background-color: #4a4a4a; font-size: 26px; border-radius: 10px; color: white; font-weight: bold;");
+  btn_card_list->setFixedHeight(55);
+  connect(btn_card_list, &QPushButton::clicked, this, [=]() {
+    AutoTunerCardListDialog dlg(this);
+    dlg.exec();
+  });
+  header_layout->addWidget(btn_card_list);
+
+  QPushButton *btn_all = new QPushButton(tr("Show All Parameters"));
+  btn_all->setStyleSheet("background-color: #3b5998; font-size: 26px; border-radius: 10px; color: white; font-weight: bold;");
+  btn_all->setFixedHeight(55);
+  connect(btn_all, &QPushButton::clicked, this, [=]() {
+    if (graph_widget) graph_widget->setSelectedParam("");
+  });
+  header_layout->addWidget(btn_all);
+
+  QPushButton *btn_clear = new QPushButton(tr("Clear All Logs"));
+  btn_clear->setStyleSheet("background-color: #bb3333; font-size: 26px; border-radius: 10px; color: white; font-weight: bold;");
+  btn_clear->setFixedHeight(55);
+  connect(btn_clear, &QPushButton::clicked, this, &AutoTunerHistoryPanel::clearAll);
+  header_layout->addWidget(btn_clear);
+
+  right_layout->addLayout(header_layout);
+
+  graph_widget = new AutoTunerGraphWidget(this);
+  graph_widget->setMinimumHeight(600);
+  right_layout->addWidget(graph_widget, 1);
+
+  main_layout->addLayout(left_layout);
+  main_layout->addLayout(right_layout, 1);
+
+  // Palette initialization
+  param_colors.clear();
+  QList<QColor> palette = {
+    QColor("#3b82f6"), // Blue
+    QColor("#10b981"), // Mint
+    QColor("#f59e0b"), // Orange
+    QColor("#8b5cf6"), // Violet
+    QColor("#ec4899"), // Pink
+    QColor("#06b6d4"), // Cyan
+    QColor("#84cc16"), // Lime
+    QColor("#f43f5e"), // Rose
+    QColor("#14b8a6"), // Teal
+    QColor("#a855f7")  // Purple
+  };
+  // Pre-seed common params to keep consistent colors
+  param_colors["CruiseMaxVals0"] = palette[0];
+  param_colors["CruiseMaxVals1"] = palette[1];
+  param_colors["CruiseMaxVals2"] = palette[2];
+  param_colors["CruiseMaxVals3"] = palette[3];
+  param_colors["CruiseMaxVals4"] = palette[4];
+  param_colors["CruiseMaxVals5"] = palette[5];
+  param_colors["CruiseMaxVals6"] = palette[6];
+  param_colors["JLeadFactor3"] = palette[7];
+  param_colors["TFollowGap1"] = palette[8];
+  param_colors["TFollowGap2"] = palette[9];
+  param_colors["TFollowGap3"] = palette[0];
+  param_colors["TFollowGap4"] = palette[1];
+  param_colors["AutoCurveSpeedAggressiveness"] = QColor("#ff5722"); // Highlight curve learning with unique red-orange
 
   refreshHistory();
 }
@@ -500,84 +772,150 @@ void AutoTunerHistoryPanel::showEvent(QShowEvent *event) {
 }
 
 void AutoTunerHistoryPanel::refreshHistory() {
+  // Clear parameter list layout
   QLayoutItem *child;
-  while ((child = list_layout->takeAt(0)) != nullptr) {
+  while ((child = param_list_layout->takeAt(0)) != nullptr) {
     if (child->widget()) delete child->widget();
     delete child;
   }
 
   QString raw = QString::fromStdString(Params().get("CarrotLearningHistory"));
   if (raw.isEmpty()) {
-    QLabel *empty = new QLabel(tr("No tuning history available"));
-    empty->setStyleSheet("font-size: 45px; color: #888888;");
-    list_layout->addWidget(empty);
-    list_layout->addStretch();
+    latest_id = "";
+    if (graph_widget) {
+      graph_widget->setData(QList<QString>(), QMap<QString, QList<double>>(), QMap<QString, QColor>());
+    }
     return;
   }
 
   QJsonArray arr = QJsonDocument::fromJson(raw.toUtf8()).array();
-  for (int i = 0; i < arr.size(); i++) {
+  
+  // Set latest entry info
+  QJsonObject latest_item = arr[0].toObject();
+  latest_id = latest_item["id"].toString();
+
+  // Re-build historical timeline (max 10 points for readable chart)
+  int chart_limit = 10;
+  int n_points = std::min(arr.size(), chart_limit);
+
+  QList<QString> timestamps;
+  QList<QJsonObject> entries;
+  for (int i = n_points - 1; i >= 0; i--) {
     QJsonObject item = arr[i].toObject();
-    QString id = item["id"].toString();
-    QString time_str = item["timestamp"].toString();
-    QJsonObject changes = item["changes"].toObject();
+    timestamps.append(item["timestamp"].toString());
+    entries.append(item);
+  }
 
-    QFrame *row = new QFrame();
-    row->setStyleSheet("background-color: #333333; border-radius: 15px; padding: 20px;");
-    QHBoxLayout *row_layout = new QHBoxLayout(row);
-
-    QString text = QString("<span style='font-size: 35px; color: #aaaaaa;'>%1</span><br>").arg(tr("[%1 Applied]").arg(time_str));
+  // 1. Gather all parameters present in the timeline
+  QSet<QString> param_set;
+  for (const auto& entry : entries) {
+    QJsonObject changes = entry["changes"].toObject();
     for (const QString& group : changes.keys()) {
       QJsonObject g_items = changes[group].toObject();
-      QString short_group;
-      bool is_en = (QString::fromStdString(Params().get("LanguageSetting")) != "main_ko");
-      if (is_en && group.contains("(")) {
-        short_group = group.split("(").last().replace(")", "");
-      } else {
-        short_group = group.split(" ").first(); // e.g. "가속"
-      }
       for (const QString& key : g_items.keys()) {
-        QJsonObject info = g_items[key].toObject();
-        text += QString("<span style='font-size: 40px; color: white;'><span style='color:#aaaaaa;'>[%1]</span> <b>%2</b> <span style='font-size:35px; color:#bbbbbb;'>[%3]</span> &nbsp;:&nbsp; %4 ➔ <span style='color:#00ff00; font-weight:bold;'>%5</span></span><br>")
-                  .arg(short_group)
-                  .arg(key)
-                  .arg(info["band_kph"].toString())
-                  .arg(info["current"].toInt())
-                  .arg(info["recommended"].toInt());
+        param_set.insert(key);
+      }
+    }
+  }
+
+  // 2. Extrapolate timeline values for each parameter
+  QMap<QString, QList<double>> param_histories;
+  QMap<QString, double> last_values;
+
+  for (int t = 0; t < n_points; t++) {
+    QJsonObject changes = entries[t]["changes"].toObject();
+    QMap<QString, double> current_changes;
+    for (const QString& group : changes.keys()) {
+      QJsonObject g_items = changes[group].toObject();
+      for (const QString& key : g_items.keys()) {
+        current_changes[key] = g_items[key].toObject()["recommended"].toDouble();
       }
     }
 
-    QLabel *lbl = new QLabel(text);
-    lbl->setWordWrap(true);
-    row_layout->addWidget(lbl, 1);
-
-    bool is_latest = (i == 0);
-    
-    QPushButton *btn_restore = new QPushButton(tr("Restore"));
-    if (is_latest) {
-      btn_restore->setStyleSheet("background-color: #178644; font-size: 40px; padding: 20px; border-radius: 10px; color: white;");
-    } else {
-      btn_restore->setStyleSheet("background-color: #333333; font-size: 40px; padding: 20px; border-radius: 10px; color: #666666;");
-      btn_restore->setEnabled(false);
+    for (const QString& param : param_set) {
+      if (current_changes.contains(param)) {
+        double val = current_changes[param];
+        last_values[param] = val;
+        param_histories[param].append(val);
+      } else {
+        if (last_values.contains(param)) {
+          param_histories[param].append(last_values[param]);
+        } else {
+          // Find the first occurrence in the future to extract 'current' initial value
+          double initial_val = 0.0;
+          for (int future_t = t; future_t < n_points; future_t++) {
+            QJsonObject f_changes = entries[future_t]["changes"].toObject();
+            bool found = false;
+            for (const QString& group : f_changes.keys()) {
+              QJsonObject fg_items = f_changes[group].toObject();
+              if (fg_items.contains(param)) {
+                initial_val = fg_items[param].toObject()["current"].toDouble();
+                found = true;
+                break;
+              }
+            }
+            if (found) break;
+          }
+          last_values[param] = initial_val;
+          param_histories[param].append(initial_val);
+        }
+      }
     }
-    btn_restore->setFixedSize(200, 120);
-    connect(btn_restore, &QPushButton::clicked, [this, id]() { restoreItem(id); });
-    row_layout->addWidget(btn_restore);
-
-    QPushButton *btn_del = new QPushButton(tr("Delete"));
-    if (is_latest) {
-      btn_del->setStyleSheet("background-color: #555555; font-size: 40px; padding: 20px; border-radius: 10px; color: white;");
-    } else {
-      btn_del->setStyleSheet("background-color: #333333; font-size: 40px; padding: 20px; border-radius: 10px; color: #666666;");
-      btn_del->setEnabled(false);
-    }
-    btn_del->setFixedSize(200, 120);
-    connect(btn_del, &QPushButton::clicked, [this, id]() { deleteItem(id); });
-    row_layout->addWidget(btn_del);
-
-    list_layout->addWidget(row);
   }
-  list_layout->addStretch();
+
+  // Assign colors dynamically for new parameters
+  QList<QColor> palette = {
+    QColor("#3b82f6"), QColor("#10b981"), QColor("#f59e0b"), QColor("#8b5cf6"),
+    QColor("#ec4899"), QColor("#06b6d4"), QColor("#84cc16"), QColor("#f43f5e"),
+    QColor("#14b8a6"), QColor("#a855f7")
+  };
+  int color_idx = 0;
+  for (const QString &param : param_set) {
+    if (!param_colors.contains(param)) {
+      param_colors[param] = palette[color_idx % palette.size()];
+      color_idx++;
+    }
+  }
+
+  // Sort parameter list alphabetically as requested
+  QStringList sorted_params = param_set.toList();
+  sorted_params.sort(Qt::CaseInsensitive);
+
+  // Populate left scroll area with sorted parameter buttons
+  for (const QString &param : sorted_params) {
+    QColor color = param_colors[param];
+    
+    // Custom Parameter list item widget (contains color dot + param name)
+    QPushButton *btn = new QPushButton();
+    btn->setStyleSheet("text-align: left; padding: 0px 15px; border-radius: 10px; background-color: #252525; color: white; font-size: 28px;");
+    btn->setFixedHeight(55);
+    
+    QHBoxLayout *btn_layout = new QHBoxLayout(btn);
+    btn_layout->setContentsMargins(10, 0, 10, 0);
+    btn_layout->setSpacing(15);
+
+    // Color indicator dot
+    QLabel *dot = new QLabel();
+    dot->setFixedSize(20, 20);
+    dot->setStyleSheet(QString("background-color: %1; border-radius: 10px;").arg(color.name()));
+    btn_layout->addWidget(dot);
+
+    // Parameter name
+    QLabel *lbl = new QLabel(param);
+    lbl->setStyleSheet("color: white; font-size: 28px; font-weight: bold; background: transparent;");
+    btn_layout->addWidget(lbl, 1);
+
+    connect(btn, &QPushButton::clicked, this, [=]() {
+      if (graph_widget) graph_widget->setSelectedParam(param);
+    });
+
+    param_list_layout->addWidget(btn);
+  }
+  param_list_layout->addStretch();
+
+  if (graph_widget) {
+    graph_widget->setData(timestamps, param_histories, param_colors);
+  }
 }
 
 void AutoTunerHistoryPanel::restoreItem(const QString& id) {
@@ -589,7 +927,6 @@ void AutoTunerHistoryPanel::restoreItem(const QString& id) {
     for (int i = 0; i < arr.size(); i++) {
       QJsonObject entry = arr[i].toObject();
       if (entry["id"].toString() == id) {
-        // 복구 로직: 이력에 저장된 'current' 값을 다시 Params에 기록
         QJsonObject changes = entry["changes"].toObject();
         for (const QString& group : changes.keys()) {
           QJsonObject g_items = changes[group].toObject();
@@ -636,6 +973,226 @@ void AutoTunerHistoryPanel::clearAll() {
   if (ConfirmationDialog::confirm(tr("Are you sure you want to delete all history? (This will not restore parameters to their previous values)"), tr("Clear All"), this)) {
     Params().remove("CarrotLearningHistory");
     refreshHistory();
+  }
+}
+
+// AutoTunerHistoryDialog implementation
+AutoTunerHistoryDialog::AutoTunerHistoryDialog(QWidget *parent) : DialogBase(parent) {
+  QFrame *container = new QFrame(this);
+  container->setStyleSheet("QFrame { background-color: #1B1B1B; border-radius: 20px; }");
+  QVBoxLayout *main_layout = new QVBoxLayout(container);
+  main_layout->setContentsMargins(30, 30, 30, 30);
+  main_layout->setSpacing(20);
+
+  // Header layout: Title and Close button
+  QHBoxLayout *header_layout = new QHBoxLayout();
+  QLabel *title = new QLabel(tr("Tuning Log"), this);
+  title->setStyleSheet("font-size: 50px; font-weight: bold; color: white;");
+  header_layout->addWidget(title);
+  header_layout->addStretch();
+
+  QPushButton *close_btn = new QPushButton(tr("Close"), this);
+  close_btn->setFixedSize(220, 90);
+  close_btn->setStyleSheet("background-color: #333333; font-size: 36px; border-radius: 10px; color: white;");
+  connect(close_btn, &QPushButton::clicked, this, &AutoTunerHistoryDialog::reject);
+  header_layout->addWidget(close_btn);
+  main_layout->addLayout(header_layout);
+
+  AutoTunerHistoryPanel *panel = new AutoTunerHistoryPanel(this);
+  main_layout->addWidget(panel, 1);
+
+  QVBoxLayout *outer_layout = new QVBoxLayout(this);
+  outer_layout->setContentsMargins(50, 50, 50, 50);
+  outer_layout->addWidget(container);
+}
+
+// AutoTunerCardListDialog implementation
+AutoTunerCardListDialog::AutoTunerCardListDialog(QWidget *parent) : DialogBase(parent) {
+  QFrame *container = new QFrame(this);
+  container->setStyleSheet("QFrame { background-color: #1B1B1B; border-radius: 20px; }");
+  QVBoxLayout *main_layout = new QVBoxLayout(container);
+  main_layout->setContentsMargins(50, 50, 50, 50);
+  main_layout->setSpacing(30);
+
+  // Header layout: Title and Close button
+  QHBoxLayout *header_layout = new QHBoxLayout();
+  QLabel *title = new QLabel(tr("Tuning History Card List"), this);
+  title->setStyleSheet("font-size: 60px; font-weight: bold; color: white;");
+  header_layout->addWidget(title);
+  header_layout->addStretch();
+
+  QPushButton *close_btn = new QPushButton(tr("Close"), this);
+  close_btn->setFixedSize(250, 100);
+  close_btn->setStyleSheet("background-color: #333333; font-size: 40px; border-radius: 10px; color: white;");
+  connect(close_btn, &QPushButton::clicked, this, &AutoTunerCardListDialog::reject);
+  header_layout->addWidget(close_btn);
+  main_layout->addLayout(header_layout);
+
+  // Scroll Area
+  QScrollArea *scroll = new QScrollArea(this);
+  scroll->setWidgetResizable(true);
+  scroll->setFrameShape(QFrame::NoFrame);
+  scroll->setStyleSheet("QScrollArea { background: transparent; } QWidget { background: transparent; }");
+  QScroller::grabGesture(scroll->viewport(), QScroller::LeftMouseButtonGesture);
+
+  QWidget *scroll_widget = new QWidget();
+  list_layout = new QVBoxLayout(scroll_widget);
+  list_layout->setContentsMargins(0, 0, 0, 0);
+  list_layout->setSpacing(20);
+  scroll->setWidget(scroll_widget);
+  main_layout->addWidget(scroll, 1);
+
+  QVBoxLayout *outer_layout = new QVBoxLayout(this);
+  outer_layout->setContentsMargins(100, 100, 100, 100);
+  outer_layout->addWidget(container);
+
+  refreshHistory();
+}
+
+void AutoTunerCardListDialog::refreshHistory() {
+  // Clear parameter list layout
+  QLayoutItem *child;
+  while ((child = list_layout->takeAt(0)) != nullptr) {
+    if (child->widget()) delete child->widget();
+    delete child;
+  }
+
+  QString raw = QString::fromStdString(Params().get("CarrotLearningHistory"));
+  if (raw.isEmpty()) {
+    QLabel *lbl = new QLabel(tr("No historical data to display"), this);
+    lbl->setStyleSheet("font-size: 45px; color: #888888;");
+    lbl->setAlignment(Qt::AlignCenter);
+    list_layout->addWidget(lbl);
+    list_layout->addStretch();
+    return;
+  }
+
+  QJsonArray arr = QJsonDocument::fromJson(raw.toUtf8()).array();
+  for (int i = 0; i < arr.size(); i++) {
+    QJsonObject item = arr[i].toObject();
+    QString id = item["id"].toString();
+    QString time_str = item["timestamp"].toString();
+    QJsonObject changes = item["changes"].toObject();
+
+    QFrame *row = new QFrame();
+    row->setStyleSheet("background-color: #2b2b2b; border-radius: 15px; padding: 25px;");
+    QHBoxLayout *row_layout = new QHBoxLayout(row);
+    row_layout->setContentsMargins(25, 20, 25, 20);
+
+    QString text = QString("<span style='font-size: 35px; color: #aaaaaa;'>%1</span><br>").arg(tr("[%1 Applied]").arg(time_str));
+    for (const QString& group : changes.keys()) {
+      QJsonObject g_items = changes[group].toObject();
+      QString short_group;
+      bool is_ko = (QString::fromStdString(Params().get("LanguageSetting")) == "main_ko");
+      if (!is_ko && group.contains("(")) {
+        short_group = group.split("(").last().replace(")", "");
+      } else {
+        short_group = group.split(" ").first();
+      }
+      for (const QString& key : g_items.keys()) {
+        QJsonObject info = g_items[key].toObject();
+        text += QString("<span style='font-size: 40px; color: white;'><span style='color:#aaaaaa;'>[%1]</span> <b>%2</b> <span style='font-size:35px; color:#bbbbbb;'>[%3]</span> &nbsp;:&nbsp; %4 ➔ <span style='color:#00ff00; font-weight:bold;'>%5</span></span><br>")
+                  .arg(short_group)
+                  .arg(key)
+                  .arg(info["band_kph"].toString())
+                  .arg(info["current"].toInt())
+                  .arg(info["recommended"].toInt());
+      }
+    }
+
+    QLabel *lbl = new QLabel(text);
+    lbl->setWordWrap(true);
+    row_layout->addWidget(lbl, 1);
+
+    bool is_latest = (i == 0);
+
+    QPushButton *btn_restore = new QPushButton(tr("Restore"));
+    if (is_latest) {
+      btn_restore->setStyleSheet("background-color: #178644; font-size: 40px; padding: 20px; border-radius: 10px; color: white; font-weight: bold;");
+    } else {
+      btn_restore->setStyleSheet("background-color: #333333; font-size: 40px; padding: 20px; border-radius: 10px; color: #666666;");
+    }
+    btn_restore->setEnabled(is_latest);
+    btn_restore->setFixedSize(220, 110);
+    connect(btn_restore, &QPushButton::clicked, this, [=]() { restoreItem(id); });
+    row_layout->addWidget(btn_restore);
+
+    QPushButton *btn_del = new QPushButton(tr("Delete"));
+    if (is_latest) {
+      btn_del->setStyleSheet("background-color: #555555; font-size: 40px; padding: 20px; border-radius: 10px; color: white; font-weight: bold;");
+    } else {
+      btn_del->setStyleSheet("background-color: #333333; font-size: 40px; padding: 20px; border-radius: 10px; color: #666666;");
+    }
+    btn_del->setEnabled(is_latest);
+    btn_del->setFixedSize(220, 110);
+    connect(btn_del, &QPushButton::clicked, this, [=]() { deleteItem(id); });
+    row_layout->addWidget(btn_del);
+
+    list_layout->addWidget(row);
+  }
+  list_layout->addStretch();
+}
+
+void AutoTunerCardListDialog::restoreItem(const QString& id) {
+  if (ConfirmationDialog::confirm(tr("Are you sure you want to restore the parameters to this state?"), tr("Restore"), this)) {
+    QString raw = QString::fromStdString(Params().get("CarrotLearningHistory"));
+    QJsonArray arr = QJsonDocument::fromJson(raw.toUtf8()).array();
+    QJsonArray new_arr;
+    
+    for (int i = 0; i < arr.size(); i++) {
+      QJsonObject entry = arr[i].toObject();
+      if (entry["id"].toString() == id) {
+        QJsonObject changes = entry["changes"].toObject();
+        for (const QString& group : changes.keys()) {
+          QJsonObject g_items = changes[group].toObject();
+          for (const QString& key : g_items.keys()) {
+            int prev_val = g_items[key].toObject()["current"].toInt();
+            Params().putInt(key.toStdString(), prev_val);
+          }
+        }
+      } else {
+        new_arr.append(entry);
+      }
+    }
+    
+    if (new_arr.isEmpty()) {
+      Params().remove("CarrotLearningHistory");
+    } else {
+      Params().put("CarrotLearningHistory", QJsonDocument(new_arr).toJson(QJsonDocument::Compact).toStdString());
+    }
+    refreshHistory();
+    
+    // Trigger refresh of parent panel
+    AutoTunerHistoryPanel *p = qobject_cast<AutoTunerHistoryPanel*>(parent());
+    if (p) {
+      p->refreshHistory();
+    }
+    ConfirmationDialog::alert(tr("Restored to previous values successfully."), this);
+  }
+}
+
+void AutoTunerCardListDialog::deleteItem(const QString& id) {
+  if (ConfirmationDialog::confirm(tr("Are you sure you want to delete this item?"), tr("Delete"), this)) {
+    QString raw = QString::fromStdString(Params().get("CarrotLearningHistory"));
+    QJsonArray arr = QJsonDocument::fromJson(raw.toUtf8()).array();
+    QJsonArray new_arr;
+    for (int i = 0; i < arr.size(); i++) {
+      if (arr[i].toObject()["id"].toString() != id) {
+        new_arr.append(arr[i]);
+      }
+    }
+    if (new_arr.isEmpty()) {
+      Params().remove("CarrotLearningHistory");
+    } else {
+      Params().put("CarrotLearningHistory", QJsonDocument(new_arr).toJson(QJsonDocument::Compact).toStdString());
+    }
+    refreshHistory();
+    
+    // Trigger refresh of parent panel
+    AutoTunerHistoryPanel *p = qobject_cast<AutoTunerHistoryPanel*>(parent());
+    if (p) {
+      p->refreshHistory();
+    }
   }
 }
 
@@ -828,15 +1385,6 @@ CarrotPanel::CarrotPanel(QWidget* parent) : QWidget(parent) {
     updateButtonStyles();
   });
 
-  QPushButton* history_btn = new QPushButton(tr("Tuning history"));
-  history_btn->setObjectName("history_btn");
-  QObject::connect(history_btn, &QPushButton::clicked, this, [this]() {
-    this->currentCarrotIndex = 6;
-    this->togglesCarrot(6);
-    updateButtonStyles();
-  });
-
-
   updateButtonStyles();
 
   select_layout->addWidget(start_btn);
@@ -845,7 +1393,6 @@ CarrotPanel::CarrotPanel(QWidget* parent) : QWidget(parent) {
   select_layout->addWidget(latLong_btn);
   select_layout->addWidget(disp_btn);
   select_layout->addWidget(path_btn);
-  select_layout->addWidget(history_btn);
   carrotLayout->addLayout(select_layout, 0);
 
   QWidget* toggles = new QWidget();
@@ -880,6 +1427,25 @@ CarrotPanel::CarrotPanel(QWidget* parent) : QWidget(parent) {
   //cruiseToggles->addItem(new CValueControl("MyHighModeFactor", "DRIVEMODE: HIGH ratio(100%)", "AccelRatio control ratio", 100, 300, 10));
 
   latLongToggles = new ListWidget(this);
+
+  QPushButton* viewHistoryBtn = new QPushButton(tr("View Tuning History"));
+  viewHistoryBtn->setObjectName("viewHistoryBtn");
+  viewHistoryBtn->setStyleSheet(R"(
+    QPushButton {
+      margin-top: 10px; margin-bottom: 20px; padding: 10px; height: 120px; border-radius: 15px;
+      color: #FFFFFF; background-color: #2C2CE2;
+      font-size: 40px; font-weight: bold;
+    }
+    QPushButton:pressed {
+      background-color: #2424FF;
+    }
+  )");
+  connect(viewHistoryBtn, &QPushButton::clicked, this, [=]() {
+    AutoTunerHistoryDialog dlg(this);
+    dlg.exec();
+  });
+  latLongToggles->addItem(viewHistoryBtn);
+
   latLongToggles->addItem(new CValueControl("CarrotLearningActive", tr("Auto-Tuner: Learning"), tr("Learn from driver interventions (gas/brake) and recommend parameter adjustments when parking. 0=Off, 1=On"), 0, 1, 1));
   latLongToggles->addItem(new CValueControl("UseLaneLineSpeed", tr("Laneline mode speed(0)"), tr("Laneline mode, lat_mpc control used"), 0, 200, 5));
   latLongToggles->addItem(new CValueControl("UseLaneLineCurveSpeed", tr("Laneline mode curve speed(0)"), tr("Laneline mode, high speed only"), 0, 200, 5));
@@ -1076,9 +1642,6 @@ CarrotPanel::CarrotPanel(QWidget* parent) : QWidget(parent) {
   content_stack = new QStackedWidget(this);
   content_stack->addWidget(toggles_view);
 
-  AutoTunerHistoryPanel* historyPanel = new AutoTunerHistoryPanel(this);
-  content_stack->addWidget(historyPanel);
-
   carrotLayout->addWidget(content_stack, 1);
 
   homeScreen->setLayout(carrotLayout);
@@ -1089,22 +1652,18 @@ CarrotPanel::CarrotPanel(QWidget* parent) : QWidget(parent) {
 }
 
 void CarrotPanel::togglesCarrot(int widgetIndex) {
-  if (widgetIndex == 6) {
-    content_stack->setCurrentIndex(1);
-  } else {
-    content_stack->setCurrentIndex(0);
-    startToggles->setVisible(widgetIndex == 0);
-    cruiseToggles->setVisible(widgetIndex == 1);
-    speedToggles->setVisible(widgetIndex == 2);
-    latLongToggles->setVisible(widgetIndex == 3);
-    dispToggles->setVisible(widgetIndex == 4);
-    pathToggles->setVisible(widgetIndex == 5);
-  }
+  content_stack->setCurrentIndex(0);
+  startToggles->setVisible(widgetIndex == 0);
+  cruiseToggles->setVisible(widgetIndex == 1);
+  speedToggles->setVisible(widgetIndex == 2);
+  latLongToggles->setVisible(widgetIndex == 3);
+  dispToggles->setVisible(widgetIndex == 4);
+  pathToggles->setVisible(widgetIndex == 5);
 }
 
 void CarrotPanel::updateButtonStyles() {
   QString styleSheet = R"(
-      #start_btn, #cruise_btn, #speed_btn, #latLong_btn, #disp_btn, #path_btn, #history_btn {
+      #start_btn, #cruise_btn, #speed_btn, #latLong_btn, #disp_btn, #path_btn {
         height: 100px;
         font-size: 38px;
         font-weight: 500;
@@ -1112,7 +1671,7 @@ void CarrotPanel::updateButtonStyles() {
         background-color: #393939;
         color: #E4E4E4;
       }
-      #start_btn:pressed, #cruise_btn:pressed, #speed_btn:pressed, #latLong_btn:pressed, #disp_btn:pressed, #path_btn:pressed, #history_btn:pressed {
+      #start_btn:pressed, #cruise_btn:pressed, #speed_btn:pressed, #latLong_btn:pressed, #disp_btn:pressed, #path_btn:pressed {
         background-color: #4a4a4a;
       }
   )";
@@ -1135,9 +1694,6 @@ void CarrotPanel::updateButtonStyles() {
     break;
   case 5:
     styleSheet += "#path_btn { background-color: #33ab4c; }";
-    break;
-  case 6:
-    styleSheet += "#history_btn { background-color: #33ab4c; }";
     break;
   }
 

--- a/selfdrive/ui/qt/offroad/settings.h
+++ b/selfdrive/ui/qt/offroad/settings.h
@@ -156,17 +156,62 @@ private:
   int m_unit;
 };
 
-class AutoTunerHistoryPanel : public QFrame {
+#include <QMap>
+#include <QList>
+#include <QColor>
+
+class AutoTunerGraphWidget : public QWidget {
   Q_OBJECT
 public:
-  explicit AutoTunerHistoryPanel(QWidget* parent = nullptr);
+  explicit AutoTunerGraphWidget(QWidget *parent = nullptr);
+  void setData(const QList<QString> &timestamps, const QMap<QString, QList<double>> &param_histories, const QMap<QString, QColor> &colors);
+  void setSelectedParam(const QString &param);
+
+protected:
+  void paintEvent(QPaintEvent *event) override;
+  void mousePressEvent(QMouseEvent *event) override;
+
+private:
+  QList<QString> timestamps;
+  QMap<QString, QList<double>> param_histories;
+  QMap<QString, QColor> colors;
+  QString selected_param;
+  int selected_index = -1;
+};
+
+class AutoTunerCardListDialog : public DialogBase {
+  Q_OBJECT
+public:
+  explicit AutoTunerCardListDialog(QWidget *parent = nullptr);
 private slots:
   void refreshHistory();
   void deleteItem(const QString& id);
   void restoreItem(const QString& id);
-  void clearAll();
 private:
   QVBoxLayout *list_layout;
+};
+
+class AutoTunerHistoryDialog : public DialogBase {
+  Q_OBJECT
+public:
+  explicit AutoTunerHistoryDialog(QWidget *parent = nullptr);
+};
+
+class AutoTunerHistoryPanel : public QFrame {
+  Q_OBJECT
+public:
+  explicit AutoTunerHistoryPanel(QWidget* parent = nullptr);
+public slots:
+  void refreshHistory();
+private slots:
+  void deleteItem(const QString& id);
+  void restoreItem(const QString& id);
+  void clearAll();
+private:
+  AutoTunerGraphWidget *graph_widget;
+  QVBoxLayout *param_list_layout;
+  QString latest_id;
+  QMap<QString, QColor> param_colors;
 protected:
   void showEvent(QShowEvent *event) override;
 };

--- a/selfdrive/ui/translations/main_ko.ts
+++ b/selfdrive/ui/translations/main_ko.ts
@@ -1535,5 +1535,13 @@ This may take up to a minute.</source>
         <source>Are you sure you want to delete all learning data collected so far without applying it?</source>
         <translation>적용하지 않고 현재까지의 모든 학습 데이터를 삭제하시겠습니까?</translation>
     </message>
+    <message>
+        <source>Auto-Tuner: Driving pattern learned!</source>
+        <translation>오토튜너: 주행 패턴 학습 완료!</translation>
+    </message>
+    <message>
+        <source>Auto-Tuner: 30min update — driving pattern learned!</source>
+        <translation>오토튜너: 30분 업데이트 — 주행 패턴 학습 완료!</translation>
+    </message>
 </context>
 </TS>

--- a/selfdrive/ui/translations/main_zh-CHS.ts
+++ b/selfdrive/ui/translations/main_zh-CHS.ts
@@ -2714,6 +2714,10 @@ This may take up to a minute.</source>
         <translation>自动调参：已学习驾驶模式！</translation>
     </message>
     <message>
+        <source>Auto-Tuner: 30min update — driving pattern learned!</source>
+        <translation>自动调参：30分钟更新 — 已学习驾驶模式！</translation>
+    </message>
+    <message>
         <source>🧬 DSP: Manual driving style analyzed! (Auto-Tuner will follow next)</source>
         <translation>🧬 DSP：手动驾驶风格分析完成！（接下来将由自动调参接管）</translation>
     </message>

--- a/selfdrive/ui/translations/main_zh-CHT.ts
+++ b/selfdrive/ui/translations/main_zh-CHT.ts
@@ -1258,6 +1258,10 @@ This may take up to a minute.</source>
         <translation>自動調參：已學習駕駛模式！</translation>
     </message>
     <message>
+        <source>Auto-Tuner: 30min update — driving pattern learned!</source>
+        <translation>自動調參：30分鐘更新 — 已學習駕駛模式！</translation>
+    </message>
+    <message>
         <source>🧬 DSP: Manual driving style analyzed! (Auto-Tuner will follow next)</source>
         <translation>🧬 DSP：手動駕駛風格分析完成！（接下來將由自動調參接管）</translation>
     </message>


### PR DESCRIPTION
Tuning History 대시보드를 Tuning Log 다이얼로그 형태로 개선하고, 튜닝 서브메뉴 최상단에 튜닝이력 버튼을 배치하여 화면 최적화를 진행했습니다.

주요 포함 내역:
1. autotuner: 주행 중 팝업 트리거 기능 (30분 타이머 및 정차 감지 기능 추가)
2. autotuner: 물리 기반 곡선 감속 및 오토튜너 Phase 6 학습 구현
3. autotuner: Auto-Apply logic, 버그 수정 및 Tuning Log UI 최적화 (대시보드 다이얼로그 전환 및 세로 폭 축소)