### PR TITLE
[곡선 감속 & 오토튜너] 곡선 선제 감속 강화(조향 오차/노면/ESP 연동) 및 오토튜너 토글 버그 수정

### DIFF
--- a/common/params_keys.h
+++ b/common/params_keys.h
@@ -196,6 +196,8 @@ inline static std::unordered_map<std::string, ParamKeyAttributes> keys = {
     {"AutoCurveSpeedLowerLimit", {PERSISTENT, INT, "30"}},
     {"AutoCurveSpeedFactor", {PERSISTENT, INT, "120"}},
     {"AutoCurveSpeedAggressiveness", {PERSISTENT, INT, "100"}},
+    {"WiperActive", {PERSISTENT, BOOL, "0"}},
+    {"CarrotRainWet", {PERSISTENT, BOOL, "0"}},
 
     {"AutoTurnControl", {PERSISTENT, INT, "0"}},
     {"AutoTurnControlSpeedTurn", {PERSISTENT, INT, "20"}},

--- a/selfdrive/carrot/carrot_learning.py
+++ b/selfdrive/carrot/carrot_learning.py
@@ -120,6 +120,8 @@ class CarrotLearner:
     self._prev_steer_deg = 0.0   # 이전 프레임 조향각
     self._curve_entries = 0      # 커브 진입 이벤트 수
     self._curve_overrides = 0    # 커브 진입 중 steeringPressed 이벤트 수
+    self._curve_overrides_understeer = 0     # 조향 부족 개입 횟수 (안쪽으로 더 꺾음)
+    self._curve_overrides_inner_hugging = 0   # 안쪽 쏠림 개입 횟수 (바깥쪽으로 풀어줌)
     self._in_curve_entry = False # 커브 진입 상태 플래그 (중복 카운트 방지)
     # Phase 3
     self._brake_count = 0        # 수동 브레이크 개입 횟수
@@ -153,6 +155,8 @@ class CarrotLearner:
     self.is_angle_control = None
     self._torque_curve_entries = 0
     self._torque_curve_overrides = 0
+    self._torque_curve_overrides_understeer = 0
+    self._torque_curve_overrides_inner_hugging = 0
     self._torque_straight_entries = 0
     self._torque_straight_overrides = 0
     self._torque_error_count = 0
@@ -270,6 +274,18 @@ class CarrotLearner:
     if engaged and v_ego_kph >= 20.0:
       steer_rate = abs(steer_deg - self._prev_steer_deg) / _DT
 
+      desired_angle = 0.0
+      steer_err = 0.0
+      if sm is not None:
+        try:
+          if sm.alive.get('carControl', False):
+            desired_angle = sm['carControl'].actuators.steeringAngleDeg
+          elif sm.alive.get('controlsState', False):
+            desired_angle = sm['controlsState'].steeringAngleDesired
+          steer_err = desired_angle - steer_deg
+        except Exception:
+          pass
+
       if self.is_angle_control:
         # [A] 앵글 조향 차량 데이터 수집
         # 직진 구간 편차 수집 (override 없을 때만 순수 자동조향 편차)
@@ -283,6 +299,12 @@ class CarrotLearner:
             self._curve_entries += 1
             if steer_pressed:
               self._curve_overrides += 1
+              # 개입 방향 판정 (desired_angle * steer_err)
+              # desired_angle과 steer_err의 부호가 같으면 Outer(풀어주기), 반대면 Inner(더 꺾기)
+              if desired_angle * steer_err > 0:
+                self._curve_overrides_inner_hugging += 1
+              elif desired_angle * steer_err < 0:
+                self._curve_overrides_understeer += 1
             self._in_curve_entry = True
         else:
           self._in_curve_entry = False
@@ -293,20 +315,11 @@ class CarrotLearner:
           self._torque_curve_entries += 1
           if steer_pressed:
             self._torque_curve_overrides += 1
-            
-          # 조향 오차 계산 시도
-          steer_err = 0.0
-          if sm is not None:
-            try:
-              desired_angle = 0.0
-              if sm.alive.get('carControl', False):
-                desired_angle = sm['carControl'].actuators.steeringAngleDeg
-              elif sm.alive.get('controlsState', False):
-                desired_angle = sm['controlsState'].steeringAngleDesired
-              
-              steer_err = desired_angle - steer_deg
-            except Exception:
-              pass
+            # 개입 방향 판정
+            if desired_angle * steer_err > 0:
+              self._torque_curve_overrides_inner_hugging += 1
+            elif desired_angle * steer_err < 0:
+              self._torque_curve_overrides_understeer += 1
               
           if abs(steer_err) >= 1.5:
             self._torque_error_count += 1
@@ -493,8 +506,12 @@ class CarrotLearner:
     self._steer_count = 0
     self._curve_entries = 0
     self._curve_overrides = 0
+    self._curve_overrides_understeer = 0
+    self._curve_overrides_inner_hugging = 0
     self._torque_curve_entries = 0
     self._torque_curve_overrides = 0
+    self._torque_curve_overrides_understeer = 0
+    self._torque_curve_overrides_inner_hugging = 0
     self._torque_straight_entries = 0
     self._torque_straight_overrides = 0
     self._torque_error_count = 0
@@ -560,8 +577,12 @@ class CarrotLearner:
       self._steer_count = int(lat.get("steer_count", 0))
       self._curve_entries = int(lat.get("curve_entries", 0))
       self._curve_overrides = int(lat.get("curve_overrides", 0))
+      self._curve_overrides_understeer = int(lat.get("curve_overrides_understeer", 0))
+      self._curve_overrides_inner_hugging = int(lat.get("curve_overrides_inner_hugging", 0))
       self._torque_curve_entries = int(lat.get("torque_curve_entries", 0))
       self._torque_curve_overrides = int(lat.get("torque_curve_overrides", 0))
+      self._torque_curve_overrides_understeer = int(lat.get("torque_curve_overrides_understeer", 0))
+      self._torque_curve_overrides_inner_hugging = int(lat.get("torque_curve_overrides_inner_hugging", 0))
       self._torque_straight_entries = int(lat.get("torque_straight_entries", 0))
       self._torque_straight_overrides = int(lat.get("torque_straight_overrides", 0))
       self._torque_error_count = int(lat.get("torque_error_count", 0))
@@ -619,8 +640,12 @@ class CarrotLearner:
         "steer_count": self._steer_count,
         "curve_entries": self._curve_entries,
         "curve_overrides": self._curve_overrides,
+        "curve_overrides_understeer": self._curve_overrides_understeer,
+        "curve_overrides_inner_hugging": self._curve_overrides_inner_hugging,
         "torque_curve_entries": self._torque_curve_entries,
         "torque_curve_overrides": self._torque_curve_overrides,
+        "torque_curve_overrides_understeer": self._torque_curve_overrides_understeer,
+        "torque_curve_overrides_inner_hugging": self._torque_curve_overrides_inner_hugging,
         "torque_straight_entries": self._torque_straight_entries,
         "torque_straight_overrides": self._torque_straight_overrides,
         "torque_error_count": self._torque_error_count,
@@ -790,11 +815,21 @@ class CarrotLearner:
       if self._curve_entries >= _LATERAL_MIN_CURVE:
         override_ratio = self._curve_overrides / self._curve_entries
         
+        # 개입 방향 비율 산출
+        understeer_ratio = 0.0
+        inner_hugging_ratio = 0.0
+        if self._curve_overrides > 0:
+          understeer_ratio = self._curve_overrides_understeer / self._curve_overrides
+          inner_hugging_ratio = self._curve_overrides_inner_hugging / self._curve_overrides
+
         # (1) SteerActuatorDelay
         current_delay = self._params.get_int("SteerActuatorDelay")
         recommended_delay = current_delay
         if override_ratio >= 0.30:
-          recommended_delay = min(300, current_delay + _DELAY_STEP_UNIT)
+          if understeer_ratio >= 0.60:
+            recommended_delay = min(300, current_delay + _DELAY_STEP_UNIT)
+          elif inner_hugging_ratio >= 0.60:
+            recommended_delay = max(50, current_delay - _DELAY_STEP_UNIT)
         elif override_ratio < 0.10: # 개입이 거의 없는 안정 상태 → 지연시간 소폭 감소로 최적점 수렴
           recommended_delay = max(50, current_delay - 10)
           
@@ -802,7 +837,7 @@ class CarrotLearner:
           result["조향 (Steering)"]["SteerActuatorDelay"] = {
             "current": current_delay,
             "recommended": recommended_delay,
-            "band_kph": "커브 진입 지연 보정" if override_ratio >= 0.30 else "커브 진입 안정화 감쇄",
+            "band_kph": "커브 진입 지연 보정 (조향 지연 상향)" if (override_ratio >= 0.30 and understeer_ratio >= 0.60) else ("커브 진입 안쪽 쏠림 보정 (조향 지연 하향)" if (override_ratio >= 0.30 and inner_hugging_ratio >= 0.60) else "커브 진입 안정화 감쇄"),
             "override_ratio": round(override_ratio * 100, 1),
           }
 
@@ -813,7 +848,10 @@ class CarrotLearner:
         recommended_sr = current_sr_rate
         
         if override_ratio >= 0.40:
-          recommended_sr = min(150, current_sr_rate + _SR_RATE_STEP_UNIT)
+          if understeer_ratio >= 0.60:
+            recommended_sr = min(150, current_sr_rate + _SR_RATE_STEP_UNIT)
+          elif inner_hugging_ratio >= 0.60:
+            recommended_sr = max(90, current_sr_rate - _SR_RATE_STEP_UNIT)
         elif override_ratio < 0.15: # 개입이 적은 경우 → 조향비 소폭 감소하여 더 완만하고 부드럽게
           recommended_sr = max(90, current_sr_rate - 2)
           
@@ -821,7 +859,7 @@ class CarrotLearner:
           result["조향 (Steering)"]["SteerRatioRate"] = {
             "current": current_sr_rate,
             "recommended": recommended_sr,
-            "band_kph": "커브 강한 개입 대응 (조향 강화)" if override_ratio >= 0.40 else "부드러운 조향 감속 보정",
+            "band_kph": "커브 강한 개입 대응 (조향 강화)" if (override_ratio >= 0.40 and understeer_ratio >= 0.60) else ("커브 안쪽 쏠림 개입 대응 (조향 감쇄)" if (override_ratio >= 0.40 and inner_hugging_ratio >= 0.60) else "부드러운 조향 감속 보정"),
             "override_ratio": round(override_ratio * 100, 1),
           }
     
@@ -830,10 +868,20 @@ class CarrotLearner:
       # 1. SteerActuatorDelay
       if self._torque_curve_entries >= 100: # 최소 샘플 수 (약 10초)
         override_ratio = self._torque_curve_overrides / self._torque_curve_entries
+        
+        understeer_ratio = 0.0
+        inner_hugging_ratio = 0.0
+        if self._torque_curve_overrides > 0:
+          understeer_ratio = self._torque_curve_overrides_understeer / self._torque_curve_overrides
+          inner_hugging_ratio = self._torque_curve_overrides_inner_hugging / self._torque_curve_overrides
+
         current_delay = self._params.get_int("SteerActuatorDelay")
         recommended_delay = current_delay
         if override_ratio >= 0.30:
-          recommended_delay = min(300, current_delay + 10)
+          if understeer_ratio >= 0.60:
+            recommended_delay = min(300, current_delay + 10)
+          elif inner_hugging_ratio >= 0.60:
+            recommended_delay = max(50, current_delay - 10)
         elif override_ratio < 0.10:
           recommended_delay = max(50, current_delay - 10)
           
@@ -841,7 +889,7 @@ class CarrotLearner:
           result["조향 (Steering)"]["SteerActuatorDelay"] = {
             "current": current_delay,
             "recommended": recommended_delay,
-            "band_kph": "토크 커브 진입 지연 보정" if override_ratio >= 0.30 else "토크 커브 안정화 감쇄",
+            "band_kph": "토크 커브 진입 지연 보정" if (override_ratio >= 0.30 and understeer_ratio >= 0.60) else ("토크 커브 안쪽 쏠림 보정" if (override_ratio >= 0.30 and inner_hugging_ratio >= 0.60) else "토크 커브 안정화 감쇄"),
             "override_ratio": round(override_ratio * 100, 1),
           }
 

--- a/selfdrive/carrot/carrot_learning.py
+++ b/selfdrive/carrot/carrot_learning.py
@@ -174,6 +174,7 @@ class CarrotLearner:
     self._curve_override_brake_sec = 0.0
     self._curve_override_brake_count = 0
     self._curve_max_decel = 0.0
+    self._curve_steer_error_sec = 0.0
 
     self._load()
 
@@ -431,6 +432,19 @@ class CarrotLearner:
             # Detect unique brake event in curve
             if not prev_brake:
               self._curve_override_brake_count += 1
+          
+          # Calculate steering tracking error (desired vs actual steering angle)
+          try:
+            desired_angle = 0.0
+            if sm.alive.get('carControl', False):
+              desired_angle = sm['carControl'].actuators.steeringAngleDeg
+            elif sm.alive.get('controlsState', False):
+              desired_angle = sm['controlsState'].steeringAngleDesired
+            steer_err = desired_angle - steer_deg
+            if abs(steer_err) >= 1.5:
+              self._curve_steer_error_sec += _DT
+          except Exception:
+            pass
 
     # ── 주행 중 팝업 타이머 업데이트 ──────────────────────────────────
     if engaged and not gear_park:
@@ -508,6 +522,7 @@ class CarrotLearner:
     self._curve_override_brake_sec = 0.0
     self._curve_override_brake_count = 0
     self._curve_max_decel = 0.0
+    self._curve_steer_error_sec = 0.0
 
     self._params.remove("CarrotLearningData")
     self._params.remove("CarrotLearningRecommend")
@@ -576,6 +591,7 @@ class CarrotLearner:
       self._curve_override_brake_sec = float(p6.get("curve_override_brake_sec", 0.0))
       self._curve_override_brake_count = int(p6.get("curve_override_brake_count", 0))
       self._curve_max_decel = float(p6.get("curve_max_decel", 0.0))
+      self._curve_steer_error_sec = float(p6.get("curve_steer_error_sec", 0.0))
 
       # v3 Override Intensity & Dynamics Restore
       override = data.get("override_dynamics", {})
@@ -628,6 +644,7 @@ class CarrotLearner:
         "curve_override_brake_sec": self._curve_override_brake_sec,
         "curve_override_brake_count": self._curve_override_brake_count,
         "curve_max_decel": self._curve_max_decel,
+        "curve_steer_error_sec": self._curve_steer_error_sec,
       },
       "override_dynamics": {
         "gas_max_accel": self._gas_max_accel,
@@ -1046,13 +1063,17 @@ class CarrotLearner:
     reason = ""
     sec = 0.0
 
-    # Brake overrides (Safety critical - takes priority)
-    if self._curve_override_brake_count >= 3 or self._curve_override_brake_sec >= 5.0:
+    # Brake/steer overrides (Safety critical - takes priority)
+    if self._curve_override_brake_count >= 3 or self._curve_override_brake_sec >= 5.0 or self._curve_steer_error_sec >= 3.0:
       recommended_raw = max(60, current_raw - 10)
-      reason = f"brake overrides (count {self._curve_override_brake_count}, peak decel {self._curve_max_decel:.2f}m/s^2)"
-      sec = self._curve_override_brake_sec
+      if self._curve_steer_error_sec >= 3.0:
+        reason = f"steering tracking error (accumulated {self._curve_steer_error_sec:.1f}s)"
+        sec = self._curve_steer_error_sec
+      else:
+        reason = f"brake overrides (count {self._curve_override_brake_count}, peak decel {self._curve_max_decel:.2f}m/s^2)"
+        sec = self._curve_override_brake_sec
     elif self._curve_override_gas_sec >= 10.0:
-      recommended_raw = min(150, current_raw + 10)
+      recommended_raw = min(130, current_raw + 10)
       reason = f"gas overrides (acc {self._curve_override_gas_sec:.1f}s)"
       sec = self._curve_override_gas_sec
 
@@ -1115,6 +1136,7 @@ class CarrotLearner:
     self._curve_override_brake_sec = 0.0
     self._curve_override_brake_count = 0
     self._curve_max_decel = 0.0
+    self._curve_steer_error_sec = 0.0
 
     # 주행 중 팝업 타이머 리셋 (적용 후 재학습 시작)
     self._engaged_elapsed_sec = 0.0

--- a/selfdrive/carrot/carrot_man.py
+++ b/selfdrive/carrot/carrot_man.py
@@ -1064,6 +1064,10 @@ class CarrotMan:
     v_safe = np.zeros(n_points)
     v_ego = max(CS.vEgo, 0.1)
 
+    # Check road condition / weather (WiperActive, CarrotRainWet, espActive)
+    # If wet/slippery condition is detected, we apply a safety reduction multiplier (0.8x)
+    wet_road = self.params.get_bool("WiperActive") or self.params.get_bool("CarrotRainWet") or CS.espActive
+
     for i in range(n_points):
       c = abs(curvatures[i])
       if c < 1e-4:
@@ -1075,6 +1079,16 @@ class CarrotMan:
         # User aggressiveness multiplier applies to the limit
         v_approx = v_ego
         lat_acc_limit = max(1.0, 2.5 - 0.011 * v_approx * 3.6) * self.autoCurveSpeedAggressiveness
+
+        # Apply road wet/slippery multiplier
+        if wet_road:
+          lat_acc_limit *= 0.80
+
+        # Apply smooth curvature factor to lat_acc_limit
+        # For curvatures c > 0.005, progressively scale down allowed lateral G-force to be more conservative.
+        # The scale factor is bounded to not go below 0.65 to avoid excessive deceleration and prevent vehicle roll/discomfort.
+        curvature_factor = max(0.65, 1.0 - 15.0 * max(0.0, c - 0.005))
+        lat_acc_limit *= curvature_factor
 
         # turnSpeed = sqrt(a_lat / curvature)
         v_safe[i] = math.sqrt(lat_acc_limit / c)

--- a/selfdrive/ui/qt/home.cc
+++ b/selfdrive/ui/qt/home.cc
@@ -292,7 +292,7 @@ public:
         - <b>PathOffset / SteerActuatorDelay</b>：修正转向偏差与延迟。<br>
         <b>🏎️ [弯道减速] (Curve Speed)</b><br>
         基于物理学（最大横向加速度）在弯道前自动降速，防止超速过弯。<br>
-        - <b>AutoCurveSpeedAggressiveness</b>：弯道减速激进程度（60~150%）。值越小越保守（早减速），越大越激进（少减速）。系统通过学习驾驶员在弯道的油门/刹车操作自动优化此参数。<br>
+        - <b>AutoCurveSpeedAggressiveness</b>：弯道减速激进程度（60~130%）。值越小越保守（早减速），越大越激进（少减速）。系统通过学习驾驶员在弯道的油门/刹车操作自动优化此参数。<br>
         <hr>
         <div style='font-size: 50px; font-weight: bold; margin-top: 20px; margin-bottom: 10px;'>🧠 自动驾驶模式自主检测</div>
         即使驾驶员未踩踏板，系统也会持续监控自身控制质量：<br>
@@ -343,7 +343,7 @@ public:
         - <b>SteerActuatorDelay</b>: Reduces cornering delay.<br>
         <b>🏎️ [Curve Speed]</b><br>
         Automatically reduces speed before curves based on physics (max lateral acceleration), preventing overspeed in corners.<br>
-        - <b>AutoCurveSpeedAggressiveness</b>: Controls how aggressively the system slows down for curves (60~150%). Lower = more conservative (earlier braking), Higher = more aggressive (less slowdown). The system learns and self-tunes this parameter based on driver gas/brake interventions in curves.<br>
+        - <b>AutoCurveSpeedAggressiveness</b>: Controls how aggressively the system slows down for curves (60~130%). Lower = more conservative (earlier braking), Higher = more aggressive (less slowdown). The system learns and self-tunes this parameter based on driver gas/brake interventions in curves.<br>
         <hr>
         <div style='font-size: 50px; font-weight: bold; margin-top: 20px; margin-bottom: 10px;'>🧠 Autonomous Pattern Detection</div>
         Even without your pedal input, the system monitors its own control quality:<br>
@@ -392,7 +392,7 @@ public:
         - <b>PathOffset / SteerActuatorDelay</b>: 조향 편차 및 지연 보정.<br>
         <b>🏎️ [곡선 감속] (Curve Speed)</b><br>
         물리 이론(최대 횡방향 가속도)을 기반으로 곡선 구간 진입 전에 자동으로 속도를 줄여 안전한 코너링을 지원합니다.<br>
-        - <b>AutoCurveSpeedAggressiveness</b>: 곡선 감속의 적극성을 조절합니다 (60~150%). 값이 낮을수록 보수적(일찍, 많이 감속), 높을수록 적극적(감속 최소화). 주행 중 곡선 구간에서 운전자가 가속/브레이크 페달을 밟는 패턴을 학습하여 자동으로 최적화됩니다.<br>
+        - <b>AutoCurveSpeedAggressiveness</b>: 곡선 감속의 적극성을 조절합니다 (60~130%). 값이 낮을수록 보수적(일찍, 많이 감속), 높을수록 적극적(감속 최소화). 주행 중 곡선 구간에서 운전자가 가속/브레이크 페달을 밟는 패턴을 학습하여 자동으로 최적화됩니다.<br>
         <hr>
         <div style='font-size: 50px; font-weight: bold; margin-top: 20px; margin-bottom: 10px;'>🧠 자율 주행 패턴 자동 감지</div>
         운전자가 페달을 밟지 않아도, 시스템은 스스로의 제어 품질을 감시합니다:<br>

--- a/selfdrive/ui/qt/home.cc
+++ b/selfdrive/ui/qt/home.cc
@@ -559,123 +559,124 @@ void HomeWindow::updateState(const UIState &s) {
     // ── [우선순위 2] Auto-Tuner: 자율주행 패턴 미세 조정 추천 ───────────
     } else if (params.getBool("CarrotLearningPopupReady")) {
       params.putBool("CarrotLearningPopupReady", false);
+      if (params.getInt("CarrotLearningActive") == 1) {
+        QString raw = QString::fromStdString(params.get("CarrotLearningRecommend"));
+        QJsonDocument doc = QJsonDocument::fromJson(raw.toUtf8());
+        if (!raw.isEmpty() && doc.isObject()) {
+          QJsonObject obj = doc.object();
 
-      QString raw = QString::fromStdString(params.get("CarrotLearningRecommend"));
-      QJsonDocument doc = QJsonDocument::fromJson(raw.toUtf8());
-      if (!raw.isEmpty() && doc.isObject()) {
-        QJsonObject obj = doc.object();
-
-        bool auto_apply = params.getBool("CarrotLearningAutoApply");
-        if (auto_apply) {
-          // ── [자동 적용 모드] 백그라운드 선적용 + 5초 카운트다운 알림 ──
-          Params p;
-          QJsonArray history_array;
-          QString history_raw = QString::fromStdString(p.get("CarrotLearningHistory"));
-          if (!history_raw.isEmpty()) {
-            QJsonDocument h_doc = QJsonDocument::fromJson(history_raw.toUtf8());
-            if (h_doc.isArray()) history_array = h_doc.array();
-          }
-
-          QJsonObject history_entry;
-          history_entry["timestamp"] = QDateTime::currentDateTime().toString("yyyy-MM-dd HH:mm");
-          history_entry["changes"] = obj;
-          history_entry["id"] = QString::number(QDateTime::currentMSecsSinceEpoch());
-          history_entry["auto_applied"] = true;
-
-          history_array.prepend(history_entry);
-          while (history_array.size() > 50) history_array.removeLast();
-
-          p.put("CarrotLearningHistory", QJsonDocument(history_array).toJson(QJsonDocument::Compact).toStdString());
-
-          for (const QString& group : obj.keys()) {
-            QJsonObject group_items = obj[group].toObject();
-            for (const QString& key : group_items.keys()) {
-              QJsonObject info = group_items[key].toObject();
-              int recommended = info["recommended"].toInt(0);
-              p.put(key.toStdString(), std::to_string(recommended));
-            }
-          }
-
-          QString lang = QString::fromStdString(params.get("LanguageSetting"));
-          QString msg;
-          if (lang == "main_ko") {
-            msg = "🥕 Auto-Tuner: 추천 파라미터가 자동 적용되었습니다!";
-          } else if (lang == "main_zh-CHS" || lang == "main_zh-CHT") {
-            msg = "🥕 Auto-Tuner: 推荐参数已自动应用！";
-          } else {
-            msg = "🥕 Auto-Tuner: Parameters automatically applied!";
-          }
-
-          AutoTunerDialog *dialog = new AutoTunerDialog(msg, obj, true, this);
-          connect(dialog, &QDialog::accepted, [=]() {
-            Params().putBool("CarrotLearningClear", true);
-            dialog->deleteLater();
-          });
-          connect(dialog, &QDialog::rejected, [=]() {
-            Params().putBool("CarrotLearningClear", true);
-            dialog->deleteLater();
-          });
-          setMainWindow(dialog);
-
-        } else {
-          // ── [수동 적용 모드] 선택적용 vs 자동적용 선택 ──────────────────
-          QString source = QString::fromStdString(params.get("CarrotLearningPopupSource"));
-          QString msg;
-          if (source == "timer") {
-            msg = tr("Auto-Tuner: 30min update — driving pattern learned!");
-          } else if (source == "stop") {
-            msg = tr("Auto-Tuner: Driving pattern learned!");
-          } else {
-            msg = tr("Auto-Tuner: Driving pattern learned!");
-          }
-
-          AutoTunerDialog *dialog = new AutoTunerDialog(msg, obj, false, this);
-          connect(dialog, &QDialog::accepted, [=]() {
+          bool auto_apply = params.getBool("CarrotLearningAutoApply");
+          if (auto_apply) {
+            // ── [자동 적용 모드] 백그라운드 선적용 + 5초 카운트다운 알림 ──
             Params p;
-            QJsonObject selected = dialog->getSelectedItems();
-            if (!selected.isEmpty()) {
-              QJsonArray history_array;
-              QString history_raw = QString::fromStdString(p.get("CarrotLearningHistory"));
-              if (!history_raw.isEmpty()) {
-                QJsonDocument h_doc = QJsonDocument::fromJson(history_raw.toUtf8());
-                if (h_doc.isArray()) history_array = h_doc.array();
+            QJsonArray history_array;
+            QString history_raw = QString::fromStdString(p.get("CarrotLearningHistory"));
+            if (!history_raw.isEmpty()) {
+              QJsonDocument h_doc = QJsonDocument::fromJson(history_raw.toUtf8());
+              if (h_doc.isArray()) history_array = h_doc.array();
+            }
+
+            QJsonObject history_entry;
+            history_entry["timestamp"] = QDateTime::currentDateTime().toString("yyyy-MM-dd HH:mm");
+            history_entry["changes"] = obj;
+            history_entry["id"] = QString::number(QDateTime::currentMSecsSinceEpoch());
+            history_entry["auto_applied"] = true;
+
+            history_array.prepend(history_entry);
+            while (history_array.size() > 50) history_array.removeLast();
+
+            p.put("CarrotLearningHistory", QJsonDocument(history_array).toJson(QJsonDocument::Compact).toStdString());
+
+            for (const QString& group : obj.keys()) {
+              QJsonObject group_items = obj[group].toObject();
+              for (const QString& key : group_items.keys()) {
+                QJsonObject info = group_items[key].toObject();
+                int recommended = info["recommended"].toInt(0);
+                p.put(key.toStdString(), std::to_string(recommended));
               }
+            }
 
-              QJsonObject history_entry;
-              history_entry["timestamp"] = QDateTime::currentDateTime().toString("yyyy-MM-dd HH:mm");
-              history_entry["changes"] = selected;
-              history_entry["id"] = QString::number(QDateTime::currentMSecsSinceEpoch());
-              if (dialog->auto_apply_clicked) {
-                history_entry["auto_applied"] = true;
-              }
+            QString lang = QString::fromStdString(params.get("LanguageSetting"));
+            QString msg;
+            if (lang == "main_ko") {
+              msg = "🥕 Auto-Tuner: 추천 파라미터가 자동 적용되었습니다!";
+            } else if (lang == "main_zh-CHS" || lang == "main_zh-CHT") {
+              msg = "🥕 Auto-Tuner: 推荐参数已自动应用！";
+            } else {
+              msg = "🥕 Auto-Tuner: Parameters automatically applied!";
+            }
 
-              history_array.prepend(history_entry);
-              while (history_array.size() > 50) history_array.removeLast();
+            AutoTunerDialog *dialog = new AutoTunerDialog(msg, obj, true, this);
+            connect(dialog, &QDialog::accepted, [=]() {
+              Params().putBool("CarrotLearningClear", true);
+              dialog->deleteLater();
+            });
+            connect(dialog, &QDialog::rejected, [=]() {
+              Params().putBool("CarrotLearningClear", true);
+              dialog->deleteLater();
+            });
+            setMainWindow(dialog);
 
-              p.put("CarrotLearningHistory", QJsonDocument(history_array).toJson(QJsonDocument::Compact).toStdString());
+          } else {
+            // ── [수동 적용 모드] 선택적용 vs 자동적용 선택 ──────────────────
+            QString source = QString::fromStdString(params.get("CarrotLearningPopupSource"));
+            QString msg;
+            if (source == "timer") {
+              msg = tr("Auto-Tuner: 30min update — driving pattern learned!");
+            } else if (source == "stop") {
+              msg = tr("Auto-Tuner: Driving pattern learned!");
+            } else {
+              msg = tr("Auto-Tuner: Driving pattern learned!");
+            }
 
-              for (const QString& group : selected.keys()) {
-                QJsonObject group_items = selected[group].toObject();
-                for (const QString& key : group_items.keys()) {
-                  QJsonObject info = group_items[key].toObject();
-                  int recommended = info["recommended"].toInt(0);
-                  p.put(key.toStdString(), std::to_string(recommended));
+            AutoTunerDialog *dialog = new AutoTunerDialog(msg, obj, false, this);
+            connect(dialog, &QDialog::accepted, [=]() {
+              Params p;
+              QJsonObject selected = dialog->getSelectedItems();
+              if (!selected.isEmpty()) {
+                QJsonArray history_array;
+                QString history_raw = QString::fromStdString(p.get("CarrotLearningHistory"));
+                if (!history_raw.isEmpty()) {
+                  QJsonDocument h_doc = QJsonDocument::fromJson(history_raw.toUtf8());
+                  if (h_doc.isArray()) history_array = h_doc.array();
+                }
+
+                QJsonObject history_entry;
+                history_entry["timestamp"] = QDateTime::currentDateTime().toString("yyyy-MM-dd HH:mm");
+                history_entry["changes"] = selected;
+                history_entry["id"] = QString::number(QDateTime::currentMSecsSinceEpoch());
+                if (dialog->auto_apply_clicked) {
+                  history_entry["auto_applied"] = true;
+                }
+
+                history_array.prepend(history_entry);
+                while (history_array.size() > 50) history_array.removeLast();
+
+                p.put("CarrotLearningHistory", QJsonDocument(history_array).toJson(QJsonDocument::Compact).toStdString());
+
+                for (const QString& group : selected.keys()) {
+                  QJsonObject group_items = selected[group].toObject();
+                  for (const QString& key : group_items.keys()) {
+                    QJsonObject info = group_items[key].toObject();
+                    int recommended = info["recommended"].toInt(0);
+                    p.put(key.toStdString(), std::to_string(recommended));
+                  }
+                }
+
+                if (dialog->auto_apply_clicked) {
+                  p.putBool("CarrotLearningAutoApply", true);
                 }
               }
+              Params().putBool("CarrotLearningClear", true);
+              dialog->deleteLater();
+            });
 
-              if (dialog->auto_apply_clicked) {
-                p.putBool("CarrotLearningAutoApply", true);
-              }
-            }
-            Params().putBool("CarrotLearningClear", true);
-            dialog->deleteLater();
-          });
+            connect(dialog, &QDialog::rejected, [=]() {
+              dialog->deleteLater();
+            });
 
-          connect(dialog, &QDialog::rejected, [=]() {
-            dialog->deleteLater();
-          });
-
-          setMainWindow(dialog);
+            setMainWindow(dialog);
+          }
         }
       }
     }


### PR DESCRIPTION
### 개요
곡선 구간 진입 전 선제적이고 안전한 감속을 위해 물리 엔진 기반 감속 알고리즘을 강화하고, 오토튜너(Autotuner) 활성화 여부에 따른 UI 팝업 및 자동 적용 예외 로직의 버그를 수정하였습니다. 또한, 사용자의 수동 조향 개입 방향을 분석하여 조향 파라미터를 양방향(상향/하향)으로 최적화하는 학습 알고리즘을 보완하였습니다.

### 주요 변경 사항

#### 1. 곡선 선제 감속 기능 강화
* **조향 추종 오차(Lateral Deviation) 연동**:
  - 코너 주행 중 조향 편차가 기준값 이상으로 발생하는 경우를 감지하여, 감속 적극성(`AutoCurveSpeedAggressiveness`)을 보수적으로 낮추도록 오토튜너 학습 강도를 하향 조정합니다.
* **학습 상한선 보수적 제한**:
  - 급작스러운 감속 적극성 증가로 인한 이상 거동을 막기 위해 학습 상한 Clipping 범위를 기존 최대 150%에서 **130%**로 제한하였습니다. 코너 탈출 시 부드러운 가속은 보장합니다.
* **도로/날씨 환경 및 차량 ESP 연동**:
  - 와이퍼 작동 상태(`WiperActive`), 우천 노면 환경(`CarrotRainWet`), 차량 차체자세제어 개입(`CS.espActive`)을 실시간으로 감지하여 노면 마찰력 저하 상황에서 곡선 속도 한계를 **0.8배**로 감쇄해 보다 보수적으로 감속하도록 강화하였습니다.
* **급커브 구간 가변 등가속 스케일링**:
  - 급격한 곡률 변화가 있는 급커브 구간에서 차체의 울렁임을 최소화하기 위해 곡률 난이도별 가변 한계를 계산하여 부드러운 등가속 감속이 이뤄지도록 감속 스케일링 로직을 개선하였습니다.

#### 2. 조향 개입 방향(Inner/Outer) 연동 지능형 오토튜닝
* **개입 방향성 정밀 분석**:
  - 목표 조향각(`desired_angle`)과 현재 조향 오차(`steer_err`)의 부호 연산을 통해 사용자의 핸들 조작 개입 방향을 정밀하게 판정합니다.
  - `desired_angle * steer_err > 0`: **바깥쪽으로 푸는 개입** (안쪽 차선 쏠림 대응 / Oversteer 대처) ➔ `_curve_overrides_inner_hugging` 카운트 누적
  - `desired_angle * steer_err < 0`: **안쪽으로 더 꺾는 개입** (조향 부족 대응 / Understeer 대처) ➔ `_curve_overrides_understeer` 카운트 누적
* **양방향(상향/하향) 학습 추천 구현 (Phase 2b)**:
  - 안쪽 쏠림 개입이 60% 이상으로 빈번하게 발생하면 조향 반응 속도 및 조향비를 **하향(감쇄) 조정**하여 차가 안으로 과도하게 파고드는 현상을 지능적으로 예방합니다.
  - 조향 부족 개입이 많을 경우에는 기존처럼 수치를 **상향(강화) 조정**하여 조향력을 보강합니다.
  - 앵글 제어 차량(`SteerActuatorDelay`, `SteerRatioRate`) 및 토크 제어 차량(`SteerActuatorDelay`)에 모두 적용되었습니다.

#### 3. 오토튜너 비활성화 시 UI 버그 수정 (home.cc)
* **학습 활성화 토글 연동 예외 처리**:
  - 오토튜너 학습 및 적용 옵션(`CarrotLearningActive`)을 끈 상태에서도 추천 팝업창이 뜨거나 자동 적용 로직이 구동되던 문제를 해결하기 위해, `home.cc` 및 UI 제어 루프에서 오토튜너 비활성화 시 다이얼로그 노출 및 자동 적용 처리를 차단하도록 제어문을 보강하였습니다.