### PR TITLE
Kia ev sk3 fix

### DIFF
--- a/opendbc_repo/opendbc/car/hyundai/carcontroller.py
+++ b/opendbc_repo/opendbc/car/hyundai/carcontroller.py
@@ -32,6 +32,13 @@ PRE_OVERRIDE_MAX_TORQUE_DELTA = -10.0
 LOW_SPEED_ANGLE_RATE_RAMP_SPEED = 15.0 * CV.KPH_TO_MS
 MID_SPEED_ANGLE_RATE_LIMIT_SPEED = 40.0 * CV.KPH_TO_MS
 
+# KIA_EV_SK3 note: do NOT toggle/knock the LKAS request bit to coax the MDPS into starting.
+# Field-tested and removed twice: (a) toggling with ToiFlt=1 faults the MDPS; (b) brief clean
+# cuts (ActToi=0/ToiFlt=0) while unlatched turn the MDPS's transient yields into full releases
+# ("more frequent drops"), and hands-off latching at speed happens with a steady request anyway.
+# Keep the request steady; the cluster warning (lkas_noact_frames) covers the unlatched state.
+
+
 vibrate_intervals = [
   (0.0, 0.5),
   (1.0, 1.5),
@@ -138,6 +145,8 @@ class CarController(CarControllerBase):
     self.params = CarControllerParams(CP)
     self.packer = CANPacker(dbc_names[Bus.pt])
     self.angle_limit_counter = 0
+    self.lkas_noact_frames = 0
+    self.mdps_noact_frames = 0
 
     self.accel_last = 0
     self.apply_torque_last = 0
@@ -253,6 +262,14 @@ class CarController(CarControllerBase):
     self.angle_limit_counter, apply_steer_req = common_fault_avoidance(abs(CS.out.steeringAngleDeg) >= MAX_ANGLE, CC.latActive,
                                                                        self.angle_limit_counter, self.max_angle_frames,
                                                                        MAX_ANGLE_CONSECUTIVE_FRAMES)
+    if self.car_fingerprint == CAR.KIA_EV_SK3:
+      # The generic >85deg guard cuts the request 2 frames (with ToiFlt=1) about once per
+      # second while the angle stays large. This MDPS is request-bit sensitive: each cut
+      # drops the whole overlay, causing latch/drop cycling through every turn — while the
+      # >90deg EPS fault the guard prevents has never been observed on this car (overlay
+      # held at 89deg under high torque). Keep the request steady; revert if
+      # steerFaultTemporary starts appearing at deep angles.
+      apply_steer_req = CC.latActive
 
     #apply_angle = apply_std_steer_angle_limits(actuators.steeringAngleDeg, self.apply_angle_last, CS.out.vEgoRaw,
     #                                           CS.out.steeringAngleDeg, CC.latActive, self.params.ANGLE_LIMITS)
@@ -392,8 +409,30 @@ class CarController(CarControllerBase):
 
     self.apply_angle_last = apply_angle
 
+    # KIA_EV_SK3: this MDPS accepts the LKAS overlay start only when the REQUESTED TORQUE is
+    # near zero at its evaluation moment — every observed latch (7/7 in the low-speed toggle
+    # session, hands-off and driver-assisted alike) happened at |torque| <= 9, while steady
+    # torque of 30..409 was refused indefinitely. "Driver grip helps" was a proxy: the driver
+    # limits push our torque to ~0. So while the MDPS is not applying our torque (ToiActive=0,
+    # torque ignored anyway), request with ZERO torque so its next evaluation accepts, then
+    # ramp up from zero after the latch. Request bit stays steadily 1 (no knocking).
+    if self.car_fingerprint == CAR.KIA_EV_SK3 and CC.latActive and \
+       int(round(getattr(CS, "steer_state", 1))) == 0:
+      self.mdps_noact_frames += 1
+    else:
+      self.mdps_noact_frames = 0
+    if self.mdps_noact_frames >= 10 and not angle_control:  # small debounce vs misreads
+      apply_torque = 0
+
     # Hold torque with induced temporary fault when cutting the actuation bit
     torque_fault = CC.latActive and not apply_steer_req
+
+    # cluster "keep hands on wheel" warning while lat is active but the MDPS is not applying
+    if self.car_fingerprint == CAR.KIA_EV_SK3 and CC.latActive and \
+       CS.out.vEgoRaw >= 2.0 and int(round(getattr(CS, "steer_state", 1))) == 0:
+      self.lkas_noact_frames += 1
+    else:
+      self.lkas_noact_frames = 0
 
     self.apply_torque_last = apply_torque
 
@@ -508,7 +547,8 @@ class CarController(CarControllerBase):
           can_sends.append(hyundaican.create_lkas11(self.packer, self.frame, self.CP, apply_torque, apply_steer_req,
                                                     torque_fault, CS.lkas11, sys_warning, sys_state, CC.enabled,
                                                     hud_control.leftLaneVisible, hud_control.rightLaneVisible,
-                                                    left_lane_warning, right_lane_warning, self.is_ldws_car))
+                                                    left_lane_warning, right_lane_warning, self.is_ldws_car,
+                                                    noact_warning=self.lkas_noact_frames >= 100))
         self.lkas11_active = True
 
       if not self.CP.openpilotLongitudinalControl:

--- a/opendbc_repo/opendbc/car/hyundai/carstate.py
+++ b/opendbc_repo/opendbc/car/hyundai/carstate.py
@@ -31,6 +31,13 @@ GearShifter = structs.CarState.GearShifter
 READY_COUNT_OK = 200
 TRAILER_DISCONNECT_GRACE_FRAMES = int(5.0 / DT_CTRL)
 
+# accFaulted (TCS13/TCS.ACCEnable != 0) is otherwise a raw single-frame signal that goes
+# straight to EventName.accFaulted -> IMMEDIATE_DISABLE. On openpilot-long (modded) cars the
+# stock ACC module stays alive on the bus, so a 1-2 frame blip of ACCEnable disengages cruise
+# with no real fault. Require the fault to persist this many carState frames (100Hz -> ~70ms)
+# before reporting it. A genuine persistent ACC fault still disengages within ~70ms.
+ACC_FAULT_DEBOUNCE_FRAMES = 7
+
 
 NUMERIC_TO_TZ = {
     840: "America/New_York",   # 미국 (US) → 동부 시간대
@@ -122,6 +129,8 @@ class CarState(CarStateBase):
 
     self.main_enabled = True if Params().get_int("AutoEngage") == 2 else False
     self.gear_shifter = GearShifter.drive # Gear_init for Nexo ?? unknown 21.02.23.LSW
+
+    self.acc_fault_frames = 0  # debounce counter for accFaulted (see ACC_FAULT_DEBOUNCE_FRAMES)
 
     self.totalDistance = 0.0
     self.speedLimitDistance = 0
@@ -348,7 +357,16 @@ class CarState(CarStateBase):
       ret.parkingBrake = cp.vl["TCS13"]["PBRAKE_ACT"] == 1
       ret.espDisabled = cp.vl["TCS11"]["TCS_PAS"] == 1
       ret.espActive = cp.vl["TCS11"]["ABS_ACT"] == 1
-      ret.accFaulted = cp.vl["TCS13"]["ACCEnable"] != 0  # 0 ACC CONTROL ENABLED, 1-3 ACC CONTROL DISABLED
+      # 0 ACC CONTROL ENABLED, 1-3 ACC CONTROL DISABLED
+      if self.CP.carFingerprint == CAR.KIA_EV_SK3:
+        # KIA_EV_SK3: ACCEnable blips non-zero for 1-2 frames on openpilot-long, debounce it
+        if cp.vl["TCS13"]["ACCEnable"] != 0:
+          self.acc_fault_frames = min(self.acc_fault_frames + 1, ACC_FAULT_DEBOUNCE_FRAMES)
+        else:
+          self.acc_fault_frames = 0
+        ret.accFaulted = self.acc_fault_frames >= ACC_FAULT_DEBOUNCE_FRAMES
+      else:
+        ret.accFaulted = cp.vl["TCS13"]["ACCEnable"] != 0
       ret.brakeLights = bool(cp.vl["TCS13"]["BrakeLight"] or ret.brakePressed)
 
     if self.CP.flags & (HyundaiFlags.HYBRID | HyundaiFlags.EV | HyundaiFlags.FCEV):

--- a/opendbc_repo/opendbc/car/hyundai/hyundaican.py
+++ b/opendbc_repo/opendbc/car/hyundai/hyundaican.py
@@ -26,7 +26,8 @@ def suppress_casper_ev_fca11_fault(values):
 def create_lkas11(packer, frame, CP, apply_torque, steer_req,
                   torque_fault, lkas11, sys_warning, sys_state, enabled,
                   left_lane, right_lane,
-                  left_lane_depart, right_lane_depart, is_ldws_car):
+                  left_lane_depart, right_lane_depart, is_ldws_car,
+                  noact_warning=False):
 
   values = {s: lkas11[s] for s in [
     "CF_Lkas_LdwsActivemode",
@@ -96,6 +97,12 @@ def create_lkas11(packer, frame, CP, apply_torque, steer_req,
 
   if is_ldws_car:
     values["CF_Lkas_LdwsOpt_USM"] = 3
+
+  # Soul EV (KIA_EV_SK3): the MDPS won't start the LKAS overlay hands-off (needs a
+  # grip-and-release arm). Show the stock "keep hands on wheel" cluster warning while
+  # lateral is active but the MDPS is not applying our torque. HUD field only.
+  if noact_warning:
+    values["CF_Lkas_SysWarning"] = 4
 
   values["CF_Lkas_Chksum"] = 0
 

--- a/openpilot/selfdrive/car/cruise.py
+++ b/openpilot/selfdrive/car/cruise.py
@@ -354,8 +354,10 @@ class VCruiseCarrot:
     else:
       self.v_cruise_kph = np.clip(v_cruise_kph, self._cruise_speed_min, self._cruise_speed_max) #max(20, self.v_ego_kph_set) #V_CRUISE_UNSET
       self.v_cruise_cluster_kph = self.v_cruise_kph #V_CRUISE_UNSET
-      #if self.cruise_state_available_last: # 최초 한번이라도 cruiseState.available이 True였다면
-      #  self._lat_enabled = False
+      # KIA_EV_SK3 전용: 크루즈 메인 ON->OFF 전환 순간 상시조향도 함께 종료
+      if self.cruise_state_available_last and self.CP.carFingerprint == "KIA_EV_SK3":
+        self._lat_enabled = False
+        self._add_log("Lateral disabled (main cruise off)")
 
     self.cruise_state_available_last = CS.cruiseState.available
     self.enabled_last = CC.enabled


### PR DESCRIPTION
**Description**

Kia Soul EV(KIA_EV_SK3, 쏘울부스터 EV) 실차에서 확인한 두 가지 문제 수정입니다. 모든 변경은 KIA_EV_SK3 전용으로 게이트되어 있어 다른 차종의 동작에는 영향이 없습니다.

1. **크루즈 간헐 해제 (carstate)**
   롱컨 상태에서 TCS13.ACCEnable이 1~2프레임 non-zero로 튀는 경우가 있는데, 이게 그대로 accFaulted → IMMEDIATE_DISABLE로 이어져 주행 중 크루즈가 이유 없이 풀립니다. 7프레임(~70ms) 지속 시에만 폴트로 판정하도록 디바운스했습니다. 실제 지속 폴트는 여전히 ~70ms 내에 해제됩니다.

2. **조향 개입 시작 실패 / 회전 중 개입 끊김 (carcontroller, hyundaican)**
   이 차의 MDPS는 **요청 토크가 0 부근일 때만** LKAS 개입 시작(CF_Mdps_ToiActive 0→1)을 수용하는 특성이 있습니다. 실차 CAN 계측(sendcan 디코드 + MDPS12 대조)에서 개입 시작 순간 7/7 전부 |CR_Lkas_StrToqReq| ≤ 9였고, 토크 30~409를 유지하는 동안에는 무기한 거부됨을 확인했습니다. 상시조향이 차선 미정렬 상태에서 큰 토크로 요청을 올리면 "미개입 → 횡오차 적분 → 토크 포화 → 계속 거부"의 악순환으로 영영 개입하지 못합니다. (운전자가 핸들을 잡으면 개입되는 것처럼 보였던 것은 driver torque limits가 요청 토크를 0으로 낮춰준 대리효과였습니다.)
   - ToiActive=0(토크가 어차피 무시되는 상태) 동안 요청비트는 유지한 채 토크를 0으로 송신 → 다음 평가에서 즉시 수용되고, 개입 후 0부터 램프업되어 soft engage 효과도 있습니다.
   - 공통 >85° 요청컷(2프레임, ToiFlt=1)은 이 MDPS에서는 컷마다 개입을 통째로 놓아 회전 내내 개입/해제가 반복됩니다. >90° EPS 폴트는 이 차에서 관측된 바 없어(89°에서 고토크 유지 기록) SK3에 한해 요청을 유지하도록 했습니다.
   - '인게이지 상태인데 미개입'이 1초 이상 지속되면 순정 계기판에 "핸들을 잡으세요"(CF_Lkas_SysWarning=4)를 표시해 운전자가 미개입 상태를 인지할 수 있게 했습니다.

3. **크루즈 메인 버튼 연동 (cruise.py)**
   이 차는 LFA(핸들모양) 버튼이 없어 상시조향을 끌 물리 버튼이 없습니다. 메인 버튼 ON→lat ON(기존 동작)에 대칭으로, 메인 OFF 전환 엣지에서 상시조향도 종료되도록 했습니다.

**Verification**

쏘울부스터 EV(2019) 실차에서 확인했습니다.
- 손뗌 상태 자동 개입 시작: 첫 인게이지, 재인게이지, 정차 후 출발, 저속(16km/h)~고속 모두 정상
- 교차로 좌/우회전 중 개입 유지 (기존: ~1초 주기로 개입/해제 반복)
- 크루즈 간헐 해제 재발 없음 (기존: 주행 중 무작위 해제)
- 계기판 경고 표시/해제, 메인 버튼 연동 정상 동작
- 진단은 sendcan(LKAS11 opTX) 디코드와 MDPS12 응답을 100Hz로 대조하는 방식으로 수행

**Route*