### PR TITLE
당근웹 대시캠 재생 시 RecordAudio 오디오 보존

### DIFF
--- a/openpilot/selfdrive/carrot/server/features/dashcam/ffmpeg.py
+++ b/openpilot/selfdrive/carrot/server/features/dashcam/ffmpeg.py
@@ -88,8 +88,9 @@ def browser_video(segment: str) -> tuple[str, str]:
   if source_name.endswith(".mp4"):
     return source, "video/mp4"
 
-  # 예전 -an 변환으로 만들어진 무음 캐시와 섞이지 않도록 캐시 종류를 분리
-  out = cache_path("video2", segment, ".mp4")
+  # 주의: 예전 -an 변환으로 캐시된 무음 mp4가 남아있으면 그대로 재생됨 —
+  # 적용 후 기기에서 캐시 디렉토리(cache/dashcam/video)를 한 번 비워줄 것
+  out = cache_path("video", segment, ".mp4")
   if os.path.isfile(out) and os.path.getsize(out) > 0:
     return out, "video/mp4"
 

--- a/openpilot/selfdrive/carrot/server/features/dashcam/ffmpeg.py
+++ b/openpilot/selfdrive/carrot/server/features/dashcam/ffmpeg.py
@@ -88,11 +88,23 @@ def browser_video(segment: str) -> tuple[str, str]:
   if source_name.endswith(".mp4"):
     return source, "video/mp4"
 
-  out = cache_path("video", segment, ".mp4")
+  # 예전 -an 변환으로 만들어진 무음 캐시와 섞이지 않도록 캐시 종류를 분리
+  out = cache_path("video2", segment, ".mp4")
   if os.path.isfile(out) and os.path.getsize(out) > 0:
     return out, "video/mp4"
 
-  result = run_ffmpeg(["-i", source, "-c", "copy", "-an", "-movflags", "+faststart", out], timeout=180.0)
+  # qcamera.ts의 오디오는 loggerd가 AAC로 먹싱하므로(RecordAudio) mp4에 그대로
+  # 복사해도 브라우저에서 재생된다 — 오디오 트랙을 보존한다
+  result = run_ffmpeg(["-i", source, "-c", "copy", "-movflags", "+faststart", out], timeout=180.0)
+  if result.returncode != 0 or not os.path.isfile(out) or os.path.getsize(out) <= 0:
+    try:
+      if os.path.exists(out):
+        os.remove(out)
+    except OSError:
+      pass
+    # 오디오 스트림이 mp4와 호환되지 않는 예외적인 경우엔 기존처럼 오디오 제거로 폴백
+    result = run_ffmpeg(["-i", source, "-c", "copy", "-an", "-movflags", "+faststart", out], timeout=180.0)
+
   if result.returncode == 0 and os.path.isfile(out) and os.path.getsize(out) > 0:
     return out, "video/mp4"
   try:


### PR DESCRIPTION
## 문제
RecordAudio를 켜면 loggerd가 qcamera.ts에 AAC 오디오를 먹싱하는데, 당근웹 대시캠의 브라우저 재생용 ts→mp4 변환이 `-an`으로 오디오를 무조건 제거해서 소리가 전혀 나지 않았습니다.

## 수정 (dashcam/ffmpeg.py, 커밋 2개)
- 기본 변환에서 `-an` 제거 — AAC는 mp4/브라우저 호환이라 `-c copy`로 그대로 보존
- 오디오 스트림이 mp4와 호환되지 않는 예외 케이스만 기존 `-an` 경로로 폴백
- 캐시 종류는 기존 `video` 유지 — 예전에 무음으로 변환·캐시된 세그먼트는 기기에서 `/data/carrot/cache/dashcam/video`를 한 번 비우면 됩니다 (새 로그는 캐시 정리 없이도 소리 남)

## 검증
실기기(C3X)에서 RecordAudio 켜고 주행 후 당근웹 재생으로 오디오 정상 확인했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MWFLdx3B499n31s61xfDKd