### PR TITLE
Fix gear step on Casper EV

### DIFF
--- a/opendbc_repo/opendbc/car/hyundai/carstate.py
+++ b/opendbc_repo/opendbc/car/hyundai/carstate.py
@@ -371,6 +371,8 @@ class CarState(CarStateBase):
     if self.CP.flags & (HyundaiFlags.HYBRID | HyundaiFlags.EV):
       gear = cp.vl["ELECT_GEAR"]["Elect_Gear_Shifter"]
       ret.gearStep = cp.vl["ELECT_GEAR"]["Elect_Gear_Step"]
+      if self.CP.carFingerprint == CAR.HYUNDAI_CASPER_EV:
+        ret.gearStep = 0
     elif self.CP.flags & HyundaiFlags.FCEV:
       gear = cp.vl["EMS20"]["HYDROGEN_GEAR_SHIFTER"]
     elif self.CP.flags & HyundaiFlags.CLUSTER_GEARS:


### PR DESCRIPTION
Fixed an issue where the gear indicator displayed regenerative braking levels instead of the actual gear position on the Hyundai Casper EV.

The Elect_Gear_Step signal on the Casper EV represents the regenerative braking level (1–4) and, in some cases, 7 while cruise control is active with no regenerative braking level shown on the instrument cluster. As a result, the UI displayed numeric values (1, 2, 3, 4, 7) instead of simply showing D.

This change forces gearStep to 0 only for CAR.HYUNDAI_CASPER_EV, ensuring that the gear indicator consistently displays D regardless of the regenerative braking level or cruise control state.

This change is intentionally limited to CAR.HYUNDAI_CASPER_EV, so it does not affect any other vehicle models.

Future Scalability

If the same behavior is confirmed on other vehicles, the condition can be easily extended:

if self.CP.carFingerprint in (
    CAR.HYUNDAI_CASPER_EV,
    CAR.OTHER_VEHICLE,
):
    ret.gearStep = 0

At this time, the change is intentionally scoped to the Hyundai Casper EV because no similar issues have been confirmed on other models.