### PR TITLE
Restore C3 multi-Panda support

### DIFF
--- a/openpilot/selfdrive/pandad/main.cc
+++ b/openpilot/selfdrive/pandad/main.cc
@@ -16,7 +16,7 @@ int main(int argc, char *argv[]) {
     assert(err == 0);
   }
 
-  std::string serial = (argc > 1) ? argv[1] : "";
-  pandad_main_thread(serial);
+  std::vector<std::string> serials(argv + 1, argv + argc);
+  pandad_main_thread(serials);
   return 0;
 }

--- a/openpilot/selfdrive/pandad/panda.cc
+++ b/openpilot/selfdrive/pandad/panda.cc
@@ -13,7 +13,7 @@
 
 const bool PANDAD_MAXOUT = getenv("PANDAD_MAXOUT") != nullptr;
 
-Panda::Panda(std::string serial) {
+Panda::Panda(std::string serial, uint32_t bus_offset) : bus_offset(bus_offset) {
   try {
     handle = std::make_unique<PandaUsbHandle>(serial);
     LOGW("connected to %s over USB", serial.c_str());
@@ -38,11 +38,13 @@ std::string Panda::hw_serial() {
   return handle->hw_serial;
 }
 
-std::vector<std::string> Panda::list() {
+std::vector<std::string> Panda::list(bool usb_only) {
   std::vector<std::string> serials = PandaUsbHandle::list();
-  for (const auto &s : PandaSpiHandle::list()) {
-    if (std::find(serials.begin(), serials.end(), s) == serials.end()) {
-      serials.push_back(s);
+  if (!usb_only) {
+    for (const auto &s : PandaSpiHandle::list()) {
+      if (std::find(serials.begin(), serials.end(), s) == serials.end()) {
+        serials.push_back(s);
+      }
     }
   }
   return serials;
@@ -187,7 +189,7 @@ void Panda::pack_can_buffer(const capnp::List<cereal::CanData>::Reader &can_data
   for (const auto &cmsg : can_data_list) {
     // check if the message is intended for this panda
     uint8_t bus = cmsg.getSrc();
-    if (bus >= PANDA_BUS_OFFSET) {
+    if (bus < bus_offset || bus >= (bus_offset + PANDA_BUS_OFFSET)) {
       continue;
     }
     auto can_data = cmsg.getDat();
@@ -199,7 +201,7 @@ void Panda::pack_can_buffer(const capnp::List<cereal::CanData>::Reader &can_data
     header.addr = cmsg.getAddress();
     header.extended = (cmsg.getAddress() >= 0x800) ? 1 : 0;
     header.data_len_code = data_len_code;
-    header.bus = bus;
+    header.bus = bus - bus_offset;
     header.checksum = 0;
 
     memcpy(&send_buf[pos], (uint8_t *)&header, sizeof(can_header));
@@ -275,7 +277,7 @@ bool Panda::unpack_can_buffer(uint8_t *data, uint32_t &size, std::vector<can_fra
 
     can_frame &canData = out_vec.emplace_back();
     canData.address = header.addr;
-    canData.src = header.bus;
+    canData.src = header.bus + bus_offset;
     if (header.rejected) {
       canData.src += CAN_REJECTED_BUS_OFFSET;
     }

--- a/openpilot/selfdrive/pandad/panda.h
+++ b/openpilot/selfdrive/pandad/panda.h
@@ -48,16 +48,17 @@ private:
   std::unique_ptr<PandaCommsHandle> handle;
 
 public:
-  Panda(std::string serial);
+  Panda(std::string serial, uint32_t bus_offset=0);
 
   cereal::PandaState::PandaType hw_type = cereal::PandaState::PandaType::UNKNOWN;
+  const uint32_t bus_offset;
 
   bool connected();
   bool comms_healthy();
   std::string hw_serial();
 
   // Static functions
-  static std::vector<std::string> list();
+  static std::vector<std::string> list(bool usb_only=false);
 
   // Panda functionality
   cereal::PandaState::PandaType get_hw_type();
@@ -90,7 +91,7 @@ protected:
   uint8_t receive_buffer[RECV_SIZE + sizeof(can_header) + 64];
   uint32_t receive_buffer_size = 0;
 
-  Panda() {}
+  Panda(uint32_t bus_offset=0) : bus_offset(bus_offset) {}
   void pack_can_buffer(const capnp::List<cereal::CanData>::Reader &can_data_list,
                          std::function<void(uint8_t *, size_t)> write_func);
   bool unpack_can_buffer(uint8_t *data, uint32_t &size, std::vector<can_frame> &out_vec);

--- a/openpilot/selfdrive/pandad/panda_helpers.py
+++ b/openpilot/selfdrive/pandad/panda_helpers.py
@@ -1,0 +1,32 @@
+from collections.abc import Callable
+from typing import Protocol, TypeVar
+
+
+class PandaLike(Protocol):
+  def get_usb_serial(self) -> str: ...
+  def get_type(self) -> bytes: ...
+  def is_internal(self) -> bool: ...
+  def close(self) -> None: ...
+
+
+PandaT = TypeVar("PandaT", bound=PandaLike)
+
+
+def connect_all_pandas(panda_serials: list[str], connector: Callable[[str], PandaT]) -> list[PandaT]:
+  pandas: list[PandaT] = []
+  try:
+    for serial in panda_serials:
+      pandas.append(connector(serial))
+
+    # Keep the peripheral/internal panda first and assign deterministic bus ranges
+    # to any additional pandas.
+    pandas.sort(key=lambda p: (not p.is_internal(), p.get_type(), p.get_usb_serial()))
+    return pandas
+  except Exception:
+    for panda in pandas:
+      panda.close()
+    raise
+
+
+def pandas_include_internal(pandas: list[PandaT]) -> bool:
+  return any(panda.is_internal() for panda in pandas)

--- a/openpilot/selfdrive/pandad/panda_safety.cc
+++ b/openpilot/selfdrive/pandad/panda_safety.cc
@@ -23,15 +23,19 @@ void PandaSafety::updateMultiplexingMode() {
   // Initialize to ELM327 without OBD multiplexing for initial fingerprinting
   if (!initialized_) {
     prev_obd_multiplexing_ = false;
-    panda_->set_safety_model(cereal::CarParams::SafetyModel::ELM327, 1U);
+    for (Panda *panda : pandas_) {
+      panda->set_safety_model(cereal::CarParams::SafetyModel::ELM327, 1U);
+    }
     initialized_ = true;
   }
 
   // Switch between multiplexing modes based on the OBD multiplexing request
   bool obd_multiplexing_requested = params_.getBool("ObdMultiplexingEnabled");
   if (obd_multiplexing_requested != prev_obd_multiplexing_) {
-    const uint16_t safety_param = obd_multiplexing_requested ? 0U : 1U;
-    panda_->set_safety_model(cereal::CarParams::SafetyModel::ELM327, safety_param);
+    for (size_t i = 0; i < pandas_.size(); ++i) {
+      const uint16_t safety_param = (i > 0 || !obd_multiplexing_requested) ? 1U : 0U;
+      pandas_[i]->set_safety_model(cereal::CarParams::SafetyModel::ELM327, safety_param);
+    }
     prev_obd_multiplexing_ = obd_multiplexing_requested;
     params_.putBool("ObdMultiplexingChanged", true);
   }
@@ -61,10 +65,17 @@ void PandaSafety::setSafetyMode(const std::string &params_string) {
   auto safety_configs = car_params.getSafetyConfigs();
   uint16_t alternative_experience = car_params.getAlternativeExperience();
 
-  cereal::CarParams::SafetyModel safety_model = safety_configs[0].getSafetyModel();
-  uint16_t safety_param = safety_configs[0].getSafetyParam();
+  for (size_t i = 0; i < pandas_.size(); ++i) {
+    // Default additional pandas to SILENT if CarParams has no matching config.
+    cereal::CarParams::SafetyModel safety_model = cereal::CarParams::SafetyModel::SILENT;
+    uint16_t safety_param = 0U;
+    if (i < safety_configs.size()) {
+      safety_model = safety_configs[i].getSafetyModel();
+      safety_param = safety_configs[i].getSafetyParam();
+    }
 
-  LOGW("setting safety model: %d, param: %d, alternative experience: %d", (int)safety_model, safety_param, alternative_experience);
-  panda_->set_alternative_experience(alternative_experience);
-  panda_->set_safety_model(safety_model, safety_param);
+    LOGW("Panda %zu: setting safety model: %d, param: %d, alternative experience: %d", i, (int)safety_model, safety_param, alternative_experience);
+    pandas_[i]->set_alternative_experience(alternative_experience);
+    pandas_[i]->set_safety_model(safety_model, safety_param);
+  }
 }

--- a/openpilot/selfdrive/pandad/pandad.cc
+++ b/openpilot/selfdrive/pandad/pandad.cc
@@ -1,5 +1,6 @@
 #include "selfdrive/pandad/pandad.h"
 
+#include <algorithm>
 #include <array>
 #include <bitset>
 #include <cassert>
@@ -23,18 +24,20 @@
 
 ExitHandler do_exit;
 
-bool check_connected(Panda *panda) {
-  if (!panda->connected()) {
-    do_exit = true;
-    return false;
+bool check_all_connected(const std::vector<Panda *> &pandas) {
+  for (Panda *panda : pandas) {
+    if (!panda->connected()) {
+      do_exit = true;
+      return false;
+    }
   }
   return true;
 }
 
-Panda *connect(std::string serial) {
+Panda *connect(std::string serial, uint32_t index) {
   std::unique_ptr<Panda> panda;
   try {
-    panda = std::make_unique<Panda>(serial);
+    panda = std::make_unique<Panda>(serial, index * PANDA_BUS_OFFSET);
   } catch (std::exception &e) {
     return nullptr;
   }
@@ -56,7 +59,7 @@ Panda *connect(std::string serial) {
   return panda.release();
 }
 
-void can_send_thread(Panda *panda, bool fake_send) {
+void can_send_thread(std::vector<Panda *> pandas, bool fake_send) {
   util::set_thread_name("pandad_can_send");
 
   AlignedBuffer aligned_buf;
@@ -66,7 +69,7 @@ void can_send_thread(Panda *panda, bool fake_send) {
   subscriber->setTimeout(100);
 
   // run as fast as messages come in
-  while (!do_exit && check_connected(panda)) {
+  while (!do_exit && check_all_connected(pandas)) {
     std::unique_ptr<Message> msg(subscriber->receive());
     if (!msg) {
       continue;
@@ -77,20 +80,25 @@ void can_send_thread(Panda *panda, bool fake_send) {
 
     // Don't send if older than 1 second
     if ((nanos_since_boot() - event.getLogMonoTime() < 1e9) && !fake_send) {
-      LOGT("sending sendcan to panda: %s", (panda->hw_serial()).c_str());
-      panda->can_send(event.getSendcan());
-      LOGT("sendcan sent to panda: %s", (panda->hw_serial()).c_str());
+      for (Panda *panda : pandas) {
+        LOGT("sending sendcan to panda: %s", (panda->hw_serial()).c_str());
+        panda->can_send(event.getSendcan());
+        LOGT("sendcan sent to panda: %s", (panda->hw_serial()).c_str());
+      }
     } else {
       LOGE("sendcan too old to send: %" PRIu64 ", %" PRIu64, nanos_since_boot(), event.getLogMonoTime());
     }
   }
 }
 
-void can_recv(Panda *panda, PubMaster *pm) {
+void can_recv(const std::vector<Panda *> &pandas, PubMaster *pm) {
   static std::vector<can_frame> raw_can_data;
   {
     raw_can_data.clear();
-    bool comms_healthy = panda->can_receive(raw_can_data);
+    bool comms_healthy = true;
+    for (Panda *panda : pandas) {
+      comms_healthy &= panda->can_receive(raw_can_data);
+    }
 
     MessageBuilder msg;
     auto evt = msg.initEvent();
@@ -161,72 +169,100 @@ void fill_panda_can_state(cereal::PandaState::PandaCanState::Builder &cs, const 
   cs.setCanCoreResetCnt(can_health.can_core_reset_cnt);
 }
 
-std::optional<bool> send_panda_states(PubMaster *pm, Panda *panda, bool is_onroad, bool spoofing_started) {
+std::optional<bool> send_panda_states(PubMaster *pm, const std::vector<Panda *> &pandas, bool is_onroad, bool spoofing_started) {
+  bool ignition_local = false;
+  const uint32_t pandas_cnt = pandas.size();
+
   // build msg
   MessageBuilder msg;
   auto evt = msg.initEvent();
-  auto pss = evt.initPandaStates(1);
+  auto pss = evt.initPandaStates(pandas_cnt);
 
-  auto health_opt = panda->get_state();
-  if (!health_opt) {
-    return std::nullopt;
-  }
+  std::vector<health_t> panda_states;
+  panda_states.reserve(pandas_cnt);
 
-  health_t health = *health_opt;
+  std::vector<std::array<can_health_t, PANDA_CAN_CNT>> panda_can_states;
+  panda_can_states.reserve(pandas_cnt);
 
-  std::array<can_health_t, PANDA_CAN_CNT> can_health{};
-  for (uint32_t i = 0; i < PANDA_CAN_CNT; i++) {
-    auto can_health_opt = panda->get_can_state(i);
-    if (!can_health_opt) {
+  const bool red_panda_comma_three = (pandas.size() == 2) &&
+                                     (pandas[0]->hw_type == cereal::PandaState::PandaType::DOS) &&
+                                     (pandas[1]->hw_type == cereal::PandaState::PandaType::RED_PANDA);
+
+  for (Panda *panda : pandas) {
+    auto health_opt = panda->get_state();
+    if (!health_opt) {
       return std::nullopt;
     }
-    can_health[i] = *can_health_opt;
+
+    health_t health = *health_opt;
+
+    std::array<can_health_t, PANDA_CAN_CNT> can_health{};
+    for (uint32_t i = 0; i < PANDA_CAN_CNT; i++) {
+      auto can_health_opt = panda->get_can_state(i);
+      if (!can_health_opt) {
+        return std::nullopt;
+      }
+      can_health[i] = *can_health_opt;
+    }
+    panda_can_states.push_back(can_health);
+
+    if (spoofing_started) {
+      health.ignition_line_pkt = 1;
+    }
+
+    // A C3's DOS can report false ignition from the harness box. The red panda
+    // is the vehicle-facing ignition source in this two-panda configuration.
+    if (red_panda_comma_three && (panda->hw_type == cereal::PandaState::PandaType::DOS)) {
+      health.ignition_line_pkt = 0;
+    }
+
+    ignition_local |= ((health.ignition_line_pkt != 0) || (health.ignition_can_pkt != 0));
+    panda_states.push_back(health);
   }
 
-  if (spoofing_started) {
-    health.ignition_line_pkt = 1;
-  }
+  for (uint32_t i = 0; i < pandas_cnt; i++) {
+    Panda *panda = pandas[i];
+    const health_t &health = panda_states[i];
 
-  bool ignition_local = ((health.ignition_line_pkt != 0) || (health.ignition_can_pkt != 0));
+    // Make sure CAN buses are live: safety_setter_thread does not work if Panda CAN are silent and there is only one other CAN node
+    if (health.safety_mode_pkt == (uint8_t)(cereal::CarParams::SafetyModel::SILENT)) {
+      panda->set_safety_model(cereal::CarParams::SafetyModel::NO_OUTPUT);
+    }
 
-  // Make sure CAN buses are live: safety_setter_thread does not work if Panda CAN are silent and there is only one other CAN node
-  if (health.safety_mode_pkt == (uint8_t)(cereal::CarParams::SafetyModel::SILENT)) {
-    panda->set_safety_model(cereal::CarParams::SafetyModel::NO_OUTPUT);
-  }
+    bool power_save_desired = !ignition_local;
+    if (health.power_save_enabled_pkt != power_save_desired) {
+      panda->set_power_saving(power_save_desired);
+    }
 
-  bool power_save_desired = !ignition_local;
-  if (health.power_save_enabled_pkt != power_save_desired) {
-    panda->set_power_saving(power_save_desired);
-  }
+    // Set safety mode to NO_OUTPUT when the car is off or we're not onroad.
+    bool should_close_relay = !ignition_local || !is_onroad;
+    if (should_close_relay && (health.safety_mode_pkt != (uint8_t)(cereal::CarParams::SafetyModel::NO_OUTPUT))) {
+      panda->set_safety_model(cereal::CarParams::SafetyModel::NO_OUTPUT);
+    }
 
-  // set safety mode to NO_OUTPUT when car is off or we're not onroad. ELM327 is an alternative if we want to leverage athenad/connect
-  bool should_close_relay = !ignition_local || !is_onroad;
-  if (should_close_relay && (health.safety_mode_pkt != (uint8_t)(cereal::CarParams::SafetyModel::NO_OUTPUT))) {
-    panda->set_safety_model(cereal::CarParams::SafetyModel::NO_OUTPUT);
-  }
+    if (!panda->comms_healthy()) {
+      evt.setValid(false);
+    }
 
-  if (!panda->comms_healthy()) {
-    evt.setValid(false);
-  }
+    auto ps = pss[i];
+    fill_panda_state(ps, panda->hw_type, health);
 
-  auto ps = pss[0];
-  fill_panda_state(ps, panda->hw_type, health);
+    auto cs = std::array{ps.initCanState0(), ps.initCanState1(), ps.initCanState2()};
+    for (uint32_t j = 0; j < PANDA_CAN_CNT; j++) {
+      fill_panda_can_state(cs[j], panda_can_states[i][j]);
+    }
 
-  auto cs = std::array{ps.initCanState0(), ps.initCanState1(), ps.initCanState2()};
-  for (uint32_t j = 0; j < PANDA_CAN_CNT; j++) {
-    fill_panda_can_state(cs[j], can_health[j]);
-  }
+    // Convert faults bitset to capnp list
+    std::bitset<sizeof(health.faults_pkt) * 8> fault_bits(health.faults_pkt);
+    auto faults = ps.initFaults(fault_bits.count());
 
-  // Convert faults bitset to capnp list
-  std::bitset<sizeof(health.faults_pkt) * 8> fault_bits(health.faults_pkt);
-  auto faults = ps.initFaults(fault_bits.count());
-
-  size_t j = 0;
-  for (size_t f = size_t(cereal::PandaState::FaultType::RELAY_MALFUNCTION);
-       f <= size_t(cereal::PandaState::FaultType::HEARTBEAT_LOOP_WATCHDOG); f++) {
-    if (fault_bits.test(f)) {
-      faults.set(j, cereal::PandaState::FaultType(f));
-      j++;
+    size_t j = 0;
+    for (size_t f = size_t(cereal::PandaState::FaultType::RELAY_MALFUNCTION);
+         f <= size_t(cereal::PandaState::FaultType::HEARTBEAT_LOOP_WATCHDOG); f++) {
+      if (fault_bits.test(f)) {
+        faults.set(j, cereal::PandaState::FaultType(f));
+        j++;
+      }
     }
   }
 
@@ -267,8 +303,14 @@ void send_peripheral_state(Panda *panda, PubMaster *pm) {
   pm->send("peripheralState", msg);
 }
 
-void process_panda_state(Panda *panda, PubMaster *pm, bool engaged, bool is_onroad, bool spoofing_started) {
-  auto ignition_opt = send_panda_states(pm, panda, is_onroad, spoofing_started);
+void process_panda_state(const std::vector<Panda *> &pandas, PubMaster *pm, bool engaged, bool is_onroad, bool spoofing_started) {
+  std::vector<std::string> connected_serials;
+  connected_serials.reserve(pandas.size());
+  for (Panda *panda : pandas) {
+    connected_serials.push_back(panda->hw_serial());
+  }
+
+  auto ignition_opt = send_panda_states(pm, pandas, is_onroad, spoofing_started);
   if (!ignition_opt) {
     LOGE("Failed to get ignition_opt");
     return;
@@ -276,13 +318,30 @@ void process_panda_state(Panda *panda, PubMaster *pm, bool engaged, bool is_onro
 
   // check if we should have pandad reconnect
   if (!ignition_opt.value()) {
-    if (!panda->comms_healthy()) {
-      LOGE("Reconnecting, communication to panda not healthy");
+    bool comms_healthy = true;
+    for (Panda *panda : pandas) {
+      comms_healthy &= panda->comms_healthy();
+    }
+
+    if (!comms_healthy) {
+      LOGE("Reconnecting, communication to pandas not healthy");
       do_exit = true;
+    } else if (!is_onroad) {
+      // A C3 red panda can enumerate after its internal DOS. Restart the
+      // wrapper so it can sort and launch the complete set.
+      for (const std::string &serial : Panda::list(true)) {
+        if (!std::count(connected_serials.begin(), connected_serials.end(), serial)) {
+          LOGW("Reconnecting to new panda: %s", serial.c_str());
+          do_exit = true;
+          break;
+        }
+      }
     }
   }
 
-  panda->send_heartbeat(engaged);
+  for (Panda *panda : pandas) {
+    panda->send_heartbeat(engaged);
+  }
 }
 
 void process_peripheral_state(Panda *panda, PubMaster *pm, bool no_fan_control) {
@@ -349,29 +408,30 @@ void process_peripheral_state(Panda *panda, PubMaster *pm, bool no_fan_control) 
   }
 }
 
-void pandad_run(Panda *panda) {
+void pandad_run(std::vector<Panda *> &pandas) {
   const bool no_fan_control = getenv("NO_FAN_CONTROL") != nullptr;
   const bool spoofing_started = getenv("STARTED") != nullptr;
   const bool fake_send = getenv("FAKESEND") != nullptr;
 
   // Start the CAN send thread
-  std::thread send_thread(can_send_thread, panda, fake_send);
+  std::thread send_thread(can_send_thread, pandas, fake_send);
 
   Params params;
   RateKeeper rk("pandad", 100);
   SubMaster sm({"selfdriveState"});
   PubMaster pm({"can", "pandaStates", "peripheralState"});
-  PandaSafety panda_safety(panda);
+  PandaSafety panda_safety(pandas);
+  Panda *peripheral_panda = pandas[0];
   bool engaged = false;
   bool is_onroad = false;
 
   // Main loop: receive CAN data and process states
-  while (!do_exit && check_connected(panda)) {
-    can_recv(panda, &pm);
+  while (!do_exit && check_all_connected(pandas)) {
+    can_recv(pandas, &pm);
 
     // Process peripheral state at 20 Hz
     if (rk.frame() % 5 == 0) {
-      process_peripheral_state(panda, &pm, no_fan_control);
+      process_peripheral_state(peripheral_panda, &pm, no_fan_control);
     }
 
     // Process panda state at 10 Hz
@@ -379,23 +439,25 @@ void pandad_run(Panda *panda) {
       sm.update(0);
       engaged = sm.allAliveAndValid({"selfdriveState"}) && sm["selfdriveState"].getSelfdriveState().getEnabled();
       is_onroad = params.getBool("IsOnroad");
-      process_panda_state(panda, &pm, engaged, is_onroad, spoofing_started);
+      process_panda_state(pandas, &pm, engaged, is_onroad, spoofing_started);
       panda_safety.configureSafetyMode(is_onroad);
     }
 
     // Send out peripheralState at 2Hz
     if (rk.frame() % 50 == 0) {
-      send_peripheral_state(panda, &pm);
+      send_peripheral_state(peripheral_panda, &pm);
     }
 
-    // Forward logs from panda to cloudlog if available
-    std::string log = panda->serial_read();
-    if (!log.empty()) {
-      if (log.find("Register 0x") != std::string::npos) {
-        // Log register divergent faults as errors
-        LOGE("%s", log.c_str());
-      } else {
-        LOGD("%s", log.c_str());
+    // Forward logs from pandas to cloudlog if available
+    for (Panda *panda : pandas) {
+      std::string log = panda->serial_read();
+      if (!log.empty()) {
+        if (log.find("Register 0x") != std::string::npos) {
+          // Log register divergent faults as errors
+          LOGE("%s", log.c_str());
+        } else {
+          LOGD("%s", log.c_str());
+        }
       }
     }
 
@@ -404,38 +466,51 @@ void pandad_run(Panda *panda) {
 
   // Close relay on exit to prevent a fault
   if (is_onroad && !engaged) {
-    if (panda->connected()) {
-      panda->set_safety_model(cereal::CarParams::SafetyModel::NO_OUTPUT);
+    for (Panda *panda : pandas) {
+      if (panda->connected()) {
+        panda->set_safety_model(cereal::CarParams::SafetyModel::NO_OUTPUT);
+      }
     }
   }
 
   send_thread.join();
 }
 
-void pandad_main_thread(std::string serial) {
-  if (serial.empty()) {
-    auto serials = Panda::list();
-
+void pandad_main_thread(std::vector<std::string> serials) {
+  if (serials.empty()) {
+    serials = Panda::list();
     if (serials.empty()) {
       LOGW("no pandas found, exiting");
       return;
     }
-    serial = serials[0];
   }
 
-  LOGW("connecting to panda: %s", serial.c_str());
+  std::string serials_str;
+  for (size_t i = 0; i < serials.size(); i++) {
+    serials_str += serials[i];
+    if (i < serials.size() - 1) {
+      serials_str += ", ";
+    }
+  }
+  LOGW("connecting to pandas: %s", serials_str.c_str());
 
-  Panda *panda = nullptr;
-  while (!do_exit) {
-    panda = connect(serial);
-    if (panda) break;
-    util::sleep_for(100);
+  std::vector<Panda *> pandas;
+  for (size_t i = 0; i < serials.size() && !do_exit; /**/) {
+    Panda *panda = connect(serials[i], i);
+    if (!panda) {
+      util::sleep_for(100);
+      continue;
+    }
+    pandas.push_back(panda);
+    ++i;
   }
 
   if (!do_exit) {
-    LOGW("connected to panda");
-    pandad_run(panda);
+    LOGW("connected to all pandas");
+    pandad_run(pandas);
   }
 
-  delete panda;
+  for (Panda *panda : pandas) {
+    delete panda;
+  }
 }

--- a/openpilot/selfdrive/pandad/pandad.h
+++ b/openpilot/selfdrive/pandad/pandad.h
@@ -1,15 +1,16 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 #include "common/params.h"
 #include "selfdrive/pandad/panda.h"
 
-void pandad_main_thread(std::string serial);
+void pandad_main_thread(std::vector<std::string> serials);
 
 class PandaSafety {
 public:
-  PandaSafety(Panda *panda) : panda_(panda) {}
+  PandaSafety(const std::vector<Panda *> &pandas) : pandas_(pandas) {}
   void configureSafetyMode(bool is_onroad);
 
 private:
@@ -21,6 +22,6 @@ private:
   bool log_once_ = false;
   bool safety_configured_ = false;
   bool prev_obd_multiplexing_ = false;
-  Panda *panda_;
+  std::vector<Panda *> pandas_;
   Params params_;
 };

--- a/openpilot/selfdrive/pandad/pandad.py
+++ b/openpilot/selfdrive/pandad/pandad.py
@@ -11,6 +11,7 @@ from openpilot.common.basedir import BASEDIR
 from openpilot.common.params import Params
 from openpilot.system.hardware import HARDWARE
 from openpilot.common.swaglog import cloudlog
+from openpilot.selfdrive.pandad.panda_helpers import connect_all_pandas, pandas_include_internal
 
 
 def get_expected_signature(panda: Panda) -> bytes:
@@ -29,36 +30,44 @@ def flash_panda(panda_serial: str) -> Panda:
     HARDWARE.recover_internal_panda()
     raise
 
-  fw_signature = get_expected_signature(panda)
-  internal_panda = panda.is_internal()
+  try:
+    fw_signature = get_expected_signature(panda)
+    internal_panda = panda.is_internal()
 
-  panda_version = "bootstub" if panda.bootstub else panda.get_version()
-  panda_signature = b"" if panda.bootstub else panda.get_signature()
-  cloudlog.warning(f"Panda {panda_serial} connected, version: {panda_version}, signature {panda_signature.hex()[:16]}, expected {fw_signature.hex()[:16]}")
+    panda_version = "bootstub" if panda.bootstub else panda.get_version()
+    panda_signature = b"" if panda.bootstub else panda.get_signature()
+    cloudlog.warning(f"Panda {panda_serial} connected, version: {panda_version}, signature {panda_signature.hex()[:16]}, expected {fw_signature.hex()[:16]}")
 
-  if panda.bootstub or panda_signature != fw_signature:
-    cloudlog.info("Panda firmware out of date, update required")
-    panda.flash()
-    cloudlog.info("Done flashing")
+    if panda.bootstub or panda_signature != fw_signature:
+      cloudlog.info("Panda firmware out of date, update required")
+      panda.flash()
+      cloudlog.info("Done flashing")
 
-  if panda.bootstub:
-    bootstub_version = panda.get_version()
-    cloudlog.info(f"Flashed firmware not booting, flashing development bootloader. {bootstub_version=}, {internal_panda=}")
-    if internal_panda:
-      HARDWARE.recover_internal_panda()
-    panda.recover(reset=(not internal_panda))
-    cloudlog.info("Done flashing bootstub")
+    if panda.bootstub:
+      bootstub_version = panda.get_version()
+      cloudlog.info(f"Flashed firmware not booting, flashing development bootloader. {bootstub_version=}, {internal_panda=}")
+      if internal_panda:
+        HARDWARE.recover_internal_panda()
+      panda.recover(reset=(not internal_panda))
+      cloudlog.info("Done flashing bootstub")
 
-  if panda.bootstub:
-    cloudlog.info("Panda still not booting, exiting")
-    raise AssertionError
+    if panda.bootstub:
+      cloudlog.info("Panda still not booting, exiting")
+      raise AssertionError
 
-  panda_signature = panda.get_signature()
-  if panda_signature != fw_signature:
-    cloudlog.info("Version mismatch after flashing, exiting")
-    raise AssertionError
+    panda_signature = panda.get_signature()
+    if panda_signature != fw_signature:
+      cloudlog.info("Version mismatch after flashing, exiting")
+      raise AssertionError
 
-  return panda
+    return panda
+  except Exception:
+    panda.close()
+    raise
+
+
+def flash_all_pandas(panda_serials: list[str]) -> list[Panda]:
+  return connect_all_pandas(panda_serials, flash_panda)
 
 
 def main() -> None:
@@ -80,6 +89,7 @@ def main() -> None:
   no_internal_panda_count = 0
 
   while not do_exit:
+    pandas: list[Panda] = []
     try:
       count += 1
       cloudlog.event("pandad.flash_and_connect", count=count)
@@ -110,35 +120,36 @@ def main() -> None:
 
       cloudlog.info(f"{len(panda_serials)} panda(s) found, connecting - {panda_serials}")
 
-      # Flash the first panda
-      panda_serial = panda_serials[0]
-      panda = flash_panda(panda_serial)
+      # Flash every panda. C3 uses an internal DOS plus a USB red panda, while
+      # C3X/C4 normally have a single internal panda.
+      pandas = flash_all_pandas(panda_serials)
 
       # Ensure internal panda is present if expected
-      if HARDWARE.has_internal_panda() and not panda.is_internal():
+      if HARDWARE.has_internal_panda() and not pandas_include_internal(pandas):
         cloudlog.error("Internal panda is missing, trying again")
         no_internal_panda_count += 1
         continue
       no_internal_panda_count = 0
 
-      # log panda fw version
-      params.put("PandaSignatures", panda.get_signature())
+      panda_serials = [panda.get_usb_serial() for panda in pandas]
+
+      # log panda fw versions
+      params.put("PandaSignatures", b','.join(panda.get_signature() for panda in pandas))
 
       # check health for lost heartbeat
-      health = panda.health()
-      if health["heartbeat_lost"]:
-        params.put_bool("PandaHeartbeatLost", True)
-        cloudlog.event("heartbeat lost", deviceState=health, serial=panda.get_usb_serial())
-      if health["som_reset_triggered"]:
-        params.put_bool("PandaSomResetTriggered", True)
-        cloudlog.event("panda.som_reset_triggered", health=health, serial=panda.get_usb_serial())
+      for panda in pandas:
+        health = panda.health()
+        if health["heartbeat_lost"]:
+          params.put_bool("PandaHeartbeatLost", True)
+          cloudlog.event("heartbeat lost", deviceState=health, serial=panda.get_usb_serial())
+        if health["som_reset_triggered"]:
+          params.put_bool("PandaSomResetTriggered", True)
+          cloudlog.event("panda.som_reset_triggered", health=health, serial=panda.get_usb_serial())
 
-      if first_run:
-        # reset panda to ensure we're in a good state
-        cloudlog.info(f"Resetting panda {panda.get_usb_serial()}")
-        panda.reset(reconnect=True)
-
-      panda.close()
+        if first_run:
+          # reset pandas to ensure they're in a good state
+          cloudlog.info(f"Resetting panda {panda.get_usb_serial()}")
+          panda.reset(reconnect=True)
     # TODO: wrap all panda exceptions in a base panda exception
     except (usb1.USBErrorNoDevice, usb1.USBErrorPipe):
       # a panda was disconnected while setting everything up. let's try again
@@ -150,12 +161,15 @@ def main() -> None:
     except Exception:
       cloudlog.exception("pandad.uncaught_exception")
       continue
+    finally:
+      for panda in pandas:
+        panda.close()
 
     first_run = False
 
     # run pandad with all connected serials as arguments
     os.environ['MANAGER_DAEMON'] = 'pandad'
-    process = subprocess.Popen(["./pandad", panda_serial], cwd=os.path.join(BASEDIR, "openpilot/selfdrive/pandad"))
+    process = subprocess.Popen(["./pandad", *panda_serials], cwd=os.path.join(BASEDIR, "openpilot/selfdrive/pandad"))
     process.wait()
 
 

--- a/openpilot/selfdrive/pandad/tests/test_pandad_canprotocol.cc
+++ b/openpilot/selfdrive/pandad/tests/test_pandad_canprotocol.cc
@@ -9,19 +9,20 @@
 #include "selfdrive/pandad/panda.h"
 
 struct PandaTest : public Panda {
-  PandaTest(int can_list_size, cereal::PandaState::PandaType hw_type);
+  PandaTest(uint32_t bus_offset, int can_list_size, cereal::PandaState::PandaType hw_type);
   void test_can_send();
   void test_can_recv(uint32_t chunk_size = 0);
   void test_chunked_can_recv();
 
   std::map<int, std::string> test_data;
+  std::map<int, uint8_t> test_buses;
   int can_list_size = 0;
   int total_pakets_size = 0;
   MessageBuilder msg;
   capnp::List<cereal::CanData>::Reader can_data_list;
 };
 
-PandaTest::PandaTest(int can_list_size_, cereal::PandaState::PandaType hw_type_) : can_list_size(can_list_size_), Panda() {
+PandaTest::PandaTest(uint32_t bus_offset_, int can_list_size_, cereal::PandaState::PandaType hw_type_) : can_list_size(can_list_size_), Panda(bus_offset_) {
   this->hw_type = hw_type_;
   int data_limit = ((hw_type == cereal::PandaState::PandaType::RED_PANDA) ? std::size(dlc_to_len) : 8);
   // prepare test data
@@ -42,7 +43,9 @@ PandaTest::PandaTest(int can_list_size_, cereal::PandaState::PandaType hw_type_)
     uint32_t id = util::random_int(0, std::size(dlc_to_len) - 1);
     const std::string &dat = test_data[dlc_to_len[id]];
     can.setAddress(i);
-    can.setSrc(util::random_int(0, 2));
+    uint8_t bus = util::random_int(0, 2) + bus_offset;
+    can.setSrc(bus);
+    test_buses[i] = bus;
     can.setDat(kj::ArrayPtr((uint8_t *)dat.data(), dat.size()));
     total_pakets_size += sizeof(can_header) + dat.size();
   }
@@ -67,6 +70,7 @@ void PandaTest::test_can_send() {
     pckt_len = sizeof(can_header) + data_len;
 
     REQUIRE(header.addr == cnt);
+    REQUIRE(header.bus == test_buses[cnt] - bus_offset);
     REQUIRE(test_data.find(data_len) != test_data.end());
     const std::string &dat = test_data[data_len];
     REQUIRE(memcmp(dat.data(), &unpacked_data[pos + sizeof(can_header)], dat.size()) == 0);
@@ -98,6 +102,7 @@ void PandaTest::test_can_recv(uint32_t rx_chunk_size) {
   REQUIRE(frames.size() == can_list_size);
   for (int i = 0; i < frames.size(); ++i) {
     REQUIRE(frames[i].address == i);
+    REQUIRE(frames[i].src == test_buses[i]);
     REQUIRE(test_data.find(frames[i].dat.size()) != test_data.end());
     const std::string &dat = test_data[frames[i].dat.size()];
     REQUIRE(memcmp(dat.data(), frames[i].dat.data(), dat.size()) == 0);
@@ -105,8 +110,9 @@ void PandaTest::test_can_recv(uint32_t rx_chunk_size) {
 }
 
 TEST_CASE("send/recv CAN 2.0 packets") {
+  auto bus_offset = GENERATE(0, 4);
   auto can_list_size = GENERATE(1, 3, 5, 10, 30, 60, 100, 200);
-  PandaTest test(can_list_size, cereal::PandaState::PandaType::DOS);
+  PandaTest test(bus_offset, can_list_size, cereal::PandaState::PandaType::DOS);
 
   SECTION("can_send") {
     test.test_can_send();
@@ -120,8 +126,9 @@ TEST_CASE("send/recv CAN 2.0 packets") {
 }
 
 TEST_CASE("send/recv CAN FD packets") {
+  auto bus_offset = GENERATE(0, 4);
   auto can_list_size = GENERATE(1, 3, 5, 10, 30, 60, 100, 200);
-  PandaTest test(can_list_size, cereal::PandaState::PandaType::RED_PANDA);
+  PandaTest test(bus_offset, can_list_size, cereal::PandaState::PandaType::RED_PANDA);
 
   SECTION("can_send") {
     test.test_can_send();

--- a/openpilot/selfdrive/pandad/tests/test_pandad_wrapper.py
+++ b/openpilot/selfdrive/pandad/tests/test_pandad_wrapper.py
@@ -1,0 +1,59 @@
+from dataclasses import dataclass
+
+import pytest
+
+from openpilot.selfdrive.pandad import panda_helpers
+
+
+@dataclass
+class FakePanda:
+  serial: str
+  hw_type: bytes
+  internal: bool
+  closed: bool = False
+
+  def get_usb_serial(self) -> str:
+    return self.serial
+
+  def get_type(self) -> bytes:
+    return self.hw_type
+
+  def is_internal(self) -> bool:
+    return self.internal
+
+  def close(self) -> None:
+    self.closed = True
+
+
+def test_connect_all_pandas_sorts_c3_internal_first():
+  pandas = {
+    "red": FakePanda("red", b"\x07", False),
+    "dos": FakePanda("dos", b"\x06", True),
+  }
+  connected = panda_helpers.connect_all_pandas(["red", "dos"], lambda serial: pandas[serial])
+
+  assert [p.serial for p in connected] == ["dos", "red"]
+  assert panda_helpers.pandas_include_internal(connected)
+
+
+@pytest.mark.parametrize("hw_type", [b"\x09", b"\x0a"])
+def test_connect_all_pandas_preserves_single_internal(hw_type):
+  panda = FakePanda("internal", hw_type, True)
+  connected = panda_helpers.connect_all_pandas(["internal"], lambda _serial: panda)
+
+  assert connected == [panda]
+  assert panda_helpers.pandas_include_internal(connected)
+
+
+def test_connect_all_pandas_closes_partial_connection():
+  panda = FakePanda("dos", b"\x06", True)
+
+  def fake_flash(serial):
+    if serial == "red":
+      raise RuntimeError("connect failed")
+    return panda
+
+  with pytest.raises(RuntimeError, match="connect failed"):
+    panda_helpers.connect_all_pandas(["dos", "red"], fake_flash)
+
+  assert panda.closed


### PR DESCRIPTION
## What changed

- restore multi-Panda discovery, flashing, deterministic ordering, and launch arguments for C3 DOS + Red Panda setups
- assign independent CAN bus ranges to each Panda
- configure safety, heartbeat, health, and reconnect handling across all connected Pandas
- close Python Panda handles on retry/error paths to prevent repeated `LIBUSB_ERROR_BUSY`
- preserve the current carrot-wip on-road safety, CAN-FD, messaging, IR/driver-view, and state-reporting behavior
- add focused wrapper tests for C3, C3X, and C4 plus CAN bus-offset coverage

## Why

The current wrapper selected only the first Panda returned from an unordered device list. On a C3 clone it could select the external Red Panda, fail the internal-Panda check, and retry without closing the handle. This produced repeated "Internal panda is missing" and `LIBUSB_ERROR_BUSY` errors. C3X and C4 normally have one internal Panda and did not hit this path.

## Impact

C3 can use its internal DOS and external Red Panda together. Single-Panda C3X/C4 configurations keep index 0 and bus offset 0, preserving their existing behavior.

## Validation

- `python -m ruff check openpilot/selfdrive/pandad/pandad.py openpilot/selfdrive/pandad/panda_helpers.py openpilot/selfdrive/pandad/tests/test_pandad_wrapper.py`
- `python -m pytest -q -o addopts='' --confcutdir=openpilot/selfdrive/pandad/tests openpilot/selfdrive/pandad/tests/test_pandad_wrapper.py` (4 passed)
- `python -m py_compile ...`
- `git diff --check`

Native C++ compilation and on-device C3/C3X/C4 testing remain to be run in an openpilot Linux/device build environment.
