### PR TITLE
Optimize on-road UI rendering and scheduling

### DIFF
--- a/openpilot/cereal/log.capnp
+++ b/openpilot/cereal/log.capnp
@@ -2389,6 +2389,10 @@ struct UIDebug {
   hudPlotTimeMillis        @19 :Float32;
   hudAuxTimeMillis         @20 :Float32;
   hudTimingValid           @21 :Bool;
+  # bit 0=left BSM, bit 1=right BSM, bit 2=left assist, bit 3=right assist
+  modelBlindSpotStateMask  @22 :UInt8;
+  # false distinguishes unavailable inputs/legacy logs from a valid inactive mask
+  modelBlindSpotStateValid @23 :Bool;
 }
 
 struct ManagerState {

--- a/openpilot/cereal/log.capnp
+++ b/openpilot/cereal/log.capnp
@@ -2376,23 +2376,22 @@ struct UIDebug {
   extrasTimeMillis      @6 :Float32;
   plotMode              @7 :UInt8;   # ShowPlotMode (~2초 스로틀 캐시, 0=off)
   recording             @8 :Bool;    # 화면 녹화 중 여부
-  modelPathTimeMillis      @9 :Float32;
-  modelLaneTimeMillis      @10 :Float32;
-  modelBlindSpotTimeMillis @11 :Float32;
-  modelRadarTimeMillis     @12 :Float32;
-  modelTimingValid         @13 :Bool;
-  hudHeaderTimeMillis      @14 :Float32;
-  hudSpeedTimeMillis       @15 :Float32;
-  hudStatusTimeMillis      @16 :Float32;
-  hudNavigationTimeMillis  @17 :Float32;
-  hudButtonTimeMillis      @18 :Float32;
-  hudPlotTimeMillis        @19 :Float32;
-  hudAuxTimeMillis         @20 :Float32;
-  hudTimingValid           @21 :Bool;
-  # bit 0=left BSM, bit 1=right BSM, bit 2=left assist, bit 3=right assist
-  modelBlindSpotStateMask  @22 :UInt8;
-  # false distinguishes unavailable inputs/legacy logs from a valid inactive mask
-  modelBlindSpotStateValid @23 :Bool;
+  # 상세 프로파일링 필드는 과거 로그와의 호환성을 위해 번호와 타입만 보존한다.
+  modelPathTimeMillisDEPRECATED       @9 :Float32;
+  modelLaneTimeMillisDEPRECATED       @10 :Float32;
+  modelBlindSpotTimeMillisDEPRECATED  @11 :Float32;
+  modelRadarTimeMillisDEPRECATED      @12 :Float32;
+  modelTimingValidDEPRECATED          @13 :Bool;
+  hudHeaderTimeMillisDEPRECATED       @14 :Float32;
+  hudSpeedTimeMillisDEPRECATED        @15 :Float32;
+  hudStatusTimeMillisDEPRECATED       @16 :Float32;
+  hudNavigationTimeMillisDEPRECATED   @17 :Float32;
+  hudButtonTimeMillisDEPRECATED       @18 :Float32;
+  hudPlotTimeMillisDEPRECATED         @19 :Float32;
+  hudAuxTimeMillisDEPRECATED          @20 :Float32;
+  hudTimingValidDEPRECATED            @21 :Bool;
+  modelBlindSpotStateMaskDEPRECATED   @22 :UInt8;
+  modelBlindSpotStateValidDEPRECATED  @23 :Bool;
 }
 
 struct ManagerState {

--- a/openpilot/cereal/log.capnp
+++ b/openpilot/cereal/log.capnp
@@ -2365,6 +2365,17 @@ struct Sentinel {
 
 struct UIDebug {
   drawTimeMillis @0 :Float32;
+  # carrot: 구간별 계측 (계측 전용 — draw 41.6ms의 내역을 재기 위함).
+  # 합계가 drawTimeMillis보다 작을 수 있다 — scissor begin/end(배치 flush),
+  # 캘리브레이션 등 미귀속 구간은 total에만 포함된다.
+  cameraTimeMillis      @1 :Float32;
+  modelTimeMillis       @2 :Float32;
+  driverStateTimeMillis @3 :Float32;
+  hudTimeMillis         @4 :Float32;
+  alertTimeMillis       @5 :Float32;
+  extrasTimeMillis      @6 :Float32;
+  plotMode              @7 :UInt8;   # ShowPlotMode (~2초 스로틀 캐시, 0=off)
+  recording             @8 :Bool;    # 화면 녹화 중 여부
 }
 
 struct ManagerState {

--- a/openpilot/cereal/log.capnp
+++ b/openpilot/cereal/log.capnp
@@ -2376,6 +2376,11 @@ struct UIDebug {
   extrasTimeMillis      @6 :Float32;
   plotMode              @7 :UInt8;   # ShowPlotMode (~2초 스로틀 캐시, 0=off)
   recording             @8 :Bool;    # 화면 녹화 중 여부
+  modelPathTimeMillis      @9 :Float32;
+  modelLaneTimeMillis      @10 :Float32;
+  modelBlindSpotTimeMillis @11 :Float32;
+  modelRadarTimeMillis     @12 :Float32;
+  modelTimingValid         @13 :Bool;
 }
 
 struct ManagerState {

--- a/openpilot/cereal/log.capnp
+++ b/openpilot/cereal/log.capnp
@@ -2381,6 +2381,14 @@ struct UIDebug {
   modelBlindSpotTimeMillis @11 :Float32;
   modelRadarTimeMillis     @12 :Float32;
   modelTimingValid         @13 :Bool;
+  hudHeaderTimeMillis      @14 :Float32;
+  hudSpeedTimeMillis       @15 :Float32;
+  hudStatusTimeMillis      @16 :Float32;
+  hudNavigationTimeMillis  @17 :Float32;
+  hudButtonTimeMillis      @18 :Float32;
+  hudPlotTimeMillis        @19 :Float32;
+  hudAuxTimeMillis         @20 :Float32;
+  hudTimingValid           @21 :Bool;
 }
 
 struct ManagerState {

--- a/openpilot/selfdrive/ui/carrot_param_cache.py
+++ b/openpilot/selfdrive/ui/carrot_param_cache.py
@@ -1,0 +1,118 @@
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Generic, TypeVar
+
+
+CARROT_PARAM_REFRESH_INTERVAL = 0.5
+PARAM_READ_RETRY_INTERVAL = 0.05
+PENDING_WRITE_TIMEOUT = 1.0
+
+T = TypeVar("T")
+_NO_PENDING_WRITE = object()
+
+
+class TimedSnapshotCache(Generic[T]):
+  """Keep the last complete snapshot and retry failed reads with bounded backoff."""
+
+  def __init__(self, initial: T, loader: Callable[[], T], interval: float = CARROT_PARAM_REFRESH_INTERVAL):
+    self._value = initial
+    self._loader = loader
+    self._interval = interval
+    self._next_refresh_time = 0.0
+    self._read_failures = 0
+    self._pending_write: object = _NO_PENDING_WRITE
+    self._pending_write_deadline = 0.0
+
+  @property
+  def value(self) -> T:
+    return self._value
+
+  @property
+  def next_refresh_time(self) -> float:
+    return self._next_refresh_time
+
+  def refresh(self, now: float) -> T:
+    if now < self._next_refresh_time:
+      return self._value
+
+    try:
+      value = self._loader()
+    except Exception:
+      # Retry once on the next 20 Hz UI frame, then back off to the normal TTL
+      # so a persistent Params failure cannot restore per-frame I/O indefinitely.
+      retry_delay = min(self._interval, PARAM_READ_RETRY_INTERVAL * (2 ** min(self._read_failures, 4)))
+      self._read_failures += 1
+      self._next_refresh_time = now + retry_delay
+      return self._value
+
+    self._read_failures = 0
+    if self._pending_write is not _NO_PENDING_WRITE:
+      if value != self._pending_write and now < self._pending_write_deadline:
+        # A nonblocking write has not reached the Params file yet. Keep the
+        # local source of truth and check for acknowledgement on the next TTL.
+        self._next_refresh_time = now + self._interval
+        return self._value
+      self._pending_write = _NO_PENDING_WRITE
+
+    self._value = value
+    self._next_refresh_time = now + self._interval
+    return value
+
+  def store_pending(self, value: T, now: float) -> None:
+    """Keep a nonblocking write authoritative until observed or its timeout."""
+    self._pending_write = value
+    self._pending_write_deadline = now + PENDING_WRITE_TIMEOUT
+    self._read_failures = 0
+    self._value = value
+    self._next_refresh_time = now + self._interval
+
+
+@dataclass(frozen=True)
+class BorderParamSnapshot:
+  top_left: str = ""
+  top_left_op_long: str = ""
+  custom_sr: float = 0.0
+  bottom_left: str = ""
+  bottom_right: str = ""
+
+
+@dataclass(frozen=True)
+class RealtimeUiParamSnapshot:
+  record_audio: bool = False
+  is_metric: bool = False
+  always_on_dm: bool = False
+
+
+def read_border_params(params, params_memory) -> BorderParamSnapshot:
+  car_name = params.get("CarName") or ""
+  hyundai_camera_scc = params.get_int("HyundaiCameraSCC") > 0
+  nnff_model_name = params.get("NNFFModelName") or ""
+  custom_sr = params.get_float("CustomSR") / 10.0
+  git_branch = params.get("GitBranch") or ""
+  network_address = params_memory.get("NetworkAddress") or ""
+
+  top_left = car_name + ("(CAMERA SCC)" if hyundai_camera_scc else "")
+  top_left_op_long = top_left if hyundai_camera_scc else car_name + " - OP Long"
+  if nnff_model_name:
+    top_left += ",NNFF"
+    top_left_op_long += ",NNFF"
+
+  return BorderParamSnapshot(
+    top_left=top_left,
+    top_left_op_long=top_left_op_long,
+    custom_sr=custom_sr,
+    bottom_left=git_branch,
+    bottom_right=network_address,
+  )
+
+
+def read_realtime_ui_params(params) -> RealtimeUiParamSnapshot:
+  return RealtimeUiParamSnapshot(
+    record_audio=params.get_bool("RecordAudio"),
+    is_metric=params.get_bool("IsMetric"),
+    always_on_dm=params.get_bool("AlwaysOnDM"),
+  )
+
+
+def read_screen_record(params) -> bool:
+  return params.get_bool("ScreenRecord")

--- a/openpilot/selfdrive/ui/carrot_ui_sched.py
+++ b/openpilot/selfdrive/ui/carrot_ui_sched.py
@@ -1,0 +1,43 @@
+"""carrot 전용: UI 스케줄러 계약 — 상시 SCHED_OTHER를 명시 적용하고 검증한다.
+
+UI 목표는 SCHED_OTHER/core5 (offroad는 core0 부트스트랩 — ui.py 소관) — 비RT
+UI는 core5의 plannerd/radard(FIFO51)를 절대 선점하지 못하므로 주행 프로세스가
+항상 우선한다. 기존 FIFO51 UI는 planner/radar와 같은 우선순위로 core5를
+점유해 상시 렌더 부하(DebugPlot 등)에서 20Hz cadence를 위협했다. core7은
+modeld(FIFO54)+dmonitoringmodeld(FIFO5) 전용이라 UI 재배치 금지이고, 이
+branch에는 FIFO 승격/복구 경로 자체가 없어야 한다 — 재도입 금지.
+
+정상 manager launch는 SCHED_OTHER를 상속하므로 사실상 no-op 검증이지만,
+계약을 명시 적용(drop)하고 readback해 어떤 경로로든 RT로 시작된 UI가 그대로
+실행되는 것을 막는다 (시작 시 1회 — 매 프레임 syscall 금지).
+"""
+import os
+import sys
+
+from openpilot.common.realtime import drop_realtime
+from openpilot.common.swaglog import cloudlog
+from openpilot.system.hardware import PC
+
+_VERIFY_ATTEMPTS = 2  # bounded 재시도 — 무한/매 프레임 syscall 폭주 금지
+
+
+def ensure_ui_sched_other() -> None:
+  """UI 메인 스레드를 SCHED_OTHER로 명시 강등하고 readback으로 검증한다.
+
+  검증 실패는 fail-stop — RT policy UI가 core5의 planner/radar를 굶기며 계속
+  실행되는 것보다 manager 재시작(restart_if_crash)이 낫다 (fail-closed).
+  readback이 SCHED_OTHER가 아니면 성공 로그를 내지 않는다 (false success 금지)."""
+  if sys.platform != "linux" or PC:
+    return  # RT 스케줄링이 없는 환경 — 계약 자체가 불필요
+  policy = None
+  for _ in range(_VERIFY_ATTEMPTS):
+    try:
+      drop_realtime()
+      policy = os.sched_getscheduler(0)
+    except OSError:
+      continue
+    if policy == os.SCHED_OTHER:
+      cloudlog.info("UISCHED: UI SCHED_OTHER verified (core0 bootstrap)")
+      return
+  cloudlog.critical(f"UISCHED: UI could not be verified SCHED_OTHER (policy={policy}); fail-stop")
+  raise RuntimeError("UI must run SCHED_OTHER (planner/radar preemption contract)")

--- a/openpilot/selfdrive/ui/layouts/main.py
+++ b/openpilot/selfdrive/ui/layouts/main.py
@@ -1,3 +1,4 @@
+import time
 import pyray as rl
 from enum import IntEnum
 import openpilot.cereal.messaging as messaging
@@ -6,6 +7,7 @@ from openpilot.selfdrive.ui.layouts.sidebar import Sidebar, SIDEBAR_WIDTH
 from openpilot.selfdrive.ui.layouts.home import HomeLayout
 from openpilot.selfdrive.ui.layouts.settings.settings import SettingsLayout, PanelType
 from openpilot.selfdrive.ui.onroad.augmented_road_view import AugmentedRoadView
+from openpilot.selfdrive.ui.carrot_param_cache import TimedSnapshotCache, read_screen_record
 from openpilot.selfdrive.ui.ui_state import device, ui_state
 from openpilot.system.ui.widgets import Widget
 from openpilot.selfdrive.ui.layouts.onboarding import OnboardingWindow
@@ -42,19 +44,23 @@ class MainLayout(Widget):
     self._onboarding_window = OnboardingWindow()
     if not self._onboarding_window.completed:
       gui_app.push_widget(self._onboarding_window)
-    # carrot_man    
+    # carrot_man
     self._last_carrot_cmd_idx = -1
+    self._screen_record_param = TimedSnapshotCache(
+      gui_app.is_recording(),
+      lambda: read_screen_record(ui_state.params),
+    )
 
-  @staticmethod
-  def _sync_screen_record_state(requested: bool) -> bool:
+  def _sync_screen_record_state(self, requested: bool) -> bool:
     recording = gui_app.is_recording()
     if requested != recording:
       ui_state.params.put_bool_nonblocking("ScreenRecord", recording)
+      self._screen_record_param.store_pending(recording, time.monotonic())
     return recording
 
   def _handle_carrot_record_cmd(self, sm) -> bool:
-    screen_record = ui_state.params.get_bool("ScreenRecord")
-    if screen_record:
+    screen_record = self._screen_record_param.refresh(time.monotonic())
+    if screen_record and ui_state.started:
       gui_app.start_recording()
     else:
       gui_app.stop_recording()
@@ -74,10 +80,9 @@ class MainLayout(Widget):
       return recording
     print(f"CarrotMan command received: {cmd} {arg} (index {cmd_idx})")
     self._last_carrot_cmd_idx = cmd_idx
-    
+
     if not ui_state.started:
-      gui_app.stop_recording()
-      return self._sync_screen_record_state(screen_record)
+      return recording
 
 
     if cmd != "RECORD":
@@ -90,9 +95,9 @@ class MainLayout(Widget):
       gui_app.stop_recording()
     elif arg == "TOGGLE":
       gui_app.toggle_recording()
-      
+
     return self._sync_screen_record_state(screen_record)
-    
+
   def _render(self, _):
     self._handle_onroad_transition()
     self._render_main_content()

--- a/openpilot/selfdrive/ui/mici/onroad/augmented_road_view.py
+++ b/openpilot/selfdrive/ui/mici/onroad/augmented_road_view.py
@@ -176,6 +176,18 @@ class AugmentedRoadView(CameraView):
 
     # debug
     self._pm = messaging.PubMaster(['uiDebug'])
+    # uiDebug.plotMode용 ShowPlotMode 캐시 — 파일 읽기라 매 프레임 금지, ~2초 스로틀
+    self._plot_mode = 0
+    self._plot_mode_next_t = 0.0
+
+  def _refresh_plot_mode(self, now: float) -> None:
+    if now < self._plot_mode_next_t:
+      return
+    self._plot_mode_next_t = now + 2.0
+    try:
+      self._plot_mode = min(max(ui_state.params.get_int("ShowPlotMode"), 0), 255)
+    except Exception:
+      self._plot_mode = 0
 
   def is_swiping_left(self) -> bool:
     """Check if currently swiping left (for scroller to disable)."""
@@ -201,7 +213,13 @@ class AugmentedRoadView(CameraView):
       super()._handle_mouse_release(mouse_pos)
 
   def _render(self, _):
+    # plotMode 갱신(가끔 파일 읽기)은 drawTime 창 밖에서 — total을 오염시키지 않는다
+    self._refresh_plot_mode(time.monotonic())
     start_draw = time.monotonic()
+    # 구간별 계측(계측 전용) — 렌더 호출 순서는 그대로, 각 구간 전후 monotonic만 잰다.
+    # alert/extras처럼 흩어진 구간은 누적(+=). scissor begin/end는 raylib 배치 flush
+    # 지점이라 특정 구간에 귀속시키지 않는다 — total과 구간 합의 차이(미귀속)로 남는다.
+    cam_ms = model_ms = ds_ms = hud_ms = alert_ms = extras_ms = 0.0
     if not self._cluster_hud_connected:
       self._switch_stream_if_needed(ui_state.sm)
       self._update_calibration()
@@ -224,45 +242,62 @@ class AugmentedRoadView(CameraView):
     )
 
     road_view_mode = self._road_view_mode()
+    _t = time.monotonic()
     if self._cluster_hud_connected or road_view_mode in (2, 3):
       rl.draw_rectangle_rec(self._content_rect, rl.BLACK)
     else:
       # Render the base camera view
       super()._render(self._content_rect)
+    cam_ms = (time.monotonic() - _t) * 1000.0
 
     if not self._cluster_hud_connected and road_view_mode in (0, 2):
       # Draw all UI overlays
+      _t = time.monotonic()
       self._model_renderer.render(self._content_rect)
+      model_ms = (time.monotonic() - _t) * 1000.0
 
     if not self._cluster_hud_connected:
       # Fade out bottom of overlays for looks
+      _t = time.monotonic()
       rl.draw_texture_ex(self._fade_texture, rl.Vector2(self._content_rect.x, self._content_rect.y), 0.0, 1.0, rl.WHITE)
+      extras_ms += (time.monotonic() - _t) * 1000.0
 
+    _t = time.monotonic()
     alert_to_render, not_animating_out = self._alert_renderer.will_render()
+    alert_ms += (time.monotonic() - _t) * 1000.0
 
     # Hide DMoji when disengaged unless AlwaysOnDM is enabled
     should_draw_dmoji = (not self._hud_renderer.drawing_top_icons() and ui_state.is_onroad() and
                          (ui_state.status != UIStatus.DISENGAGED or ui_state.always_on_dm))
     self._driver_state_renderer.set_should_draw(should_draw_dmoji)
     self._driver_state_renderer.set_position(self._rect.x + 16, self._rect.y + 10)
+    _t = time.monotonic()
     self._driver_state_renderer.render()
+    ds_ms = (time.monotonic() - _t) * 1000.0
 
     self._hud_renderer.set_can_draw_top_icons(alert_to_render is None)
     self._hud_renderer.set_wheel_critical_icon(alert_to_render is not None and not not_animating_out and
                                                alert_to_render.visual_alert == car.CarControl.HUDControl.VisualAlert.steerRequired)
     # TODO: have alert renderer draw offroad mici label below
+    _t = time.monotonic()
     self._hud_renderer.render(self._content_rect)
+    hud_ms = (time.monotonic() - _t) * 1000.0
     if ui_state.started:
+      _t = time.monotonic()
       self._alert_renderer.render(self._content_rect)
+      alert_ms += (time.monotonic() - _t) * 1000.0
 
     # Draw fake rounded border
+    _t = time.monotonic()
     rl.draw_rectangle_rounded_lines_ex(self._content_rect, 0.2 * 1.02, 10, 50, rl.BLACK)
+    extras_ms += (time.monotonic() - _t) * 1000.0
 
     # End clipping region
     rl.end_scissor_mode()
 
     # Custom UI extension point - add custom overlays here
     # Use self._content_rect for positioning within camera bounds
+    _t = time.monotonic()
     self._traffic_light.render(self.rect)
     if not self._traffic_light.is_visible():
       self._confidence_ball.render(self.rect)
@@ -278,10 +313,20 @@ class AugmentedRoadView(CameraView):
       x = int(self._content_rect.x + 16)
       y = int(self._content_rect.y + self._content_rect.height - 16)
       rl.draw_circle(x, y, 6, rl.Color(255, 0, 0, 220))
+    extras_ms += (time.monotonic() - _t) * 1000.0
 
     # publish uiDebug
-    msg = messaging.new_message('uiDebug')
-    msg.uiDebug.drawTimeMillis = (time.monotonic() - start_draw) * 1000
+    msg = messaging.new_message('uiDebug', valid=True)
+    ud = msg.uiDebug
+    ud.drawTimeMillis = (time.monotonic() - start_draw) * 1000
+    ud.cameraTimeMillis = cam_ms
+    ud.modelTimeMillis = model_ms
+    ud.driverStateTimeMillis = ds_ms
+    ud.hudTimeMillis = hud_ms
+    ud.alertTimeMillis = alert_ms
+    ud.extrasTimeMillis = extras_ms
+    ud.plotMode = self._plot_mode
+    ud.recording = gui_app.is_recording()
     self._pm.send('uiDebug', msg)
 
   def _road_view_mode(self):

--- a/openpilot/selfdrive/ui/onroad/augmented_road_view.py
+++ b/openpilot/selfdrive/ui/onroad/augmented_road_view.py
@@ -139,6 +139,12 @@ class AugmentedRoadView(CameraView):
     ud.hudTimeMillis = hud_ms
     ud.alertTimeMillis = alert_ms
     ud.extrasTimeMillis = extras_ms
+    model_timings = self.model_renderer.render_timings
+    ud.modelPathTimeMillis = model_timings.path_time_millis
+    ud.modelLaneTimeMillis = model_timings.lane_time_millis
+    ud.modelBlindSpotTimeMillis = model_timings.blind_spot_time_millis
+    ud.modelRadarTimeMillis = model_timings.radar_time_millis
+    ud.modelTimingValid = model_timings.valid
     ud.plotMode = self._plot_mode
     ud.recording = gui_app.is_recording()
     self._pm.send('uiDebug', msg)

--- a/openpilot/selfdrive/ui/onroad/augmented_road_view.py
+++ b/openpilot/selfdrive/ui/onroad/augmented_road_view.py
@@ -145,6 +145,8 @@ class AugmentedRoadView(CameraView):
     ud.modelBlindSpotTimeMillis = model_timings.blind_spot_time_millis
     ud.modelRadarTimeMillis = model_timings.radar_time_millis
     ud.modelTimingValid = model_timings.valid
+    ud.modelBlindSpotStateMask = model_timings.blind_spot_state_mask
+    ud.modelBlindSpotStateValid = model_timings.blind_spot_state_valid
     hud_timings = self._hud_renderer.render_timings
     ud.hudHeaderTimeMillis = hud_timings.header_time_millis
     ud.hudSpeedTimeMillis = hud_timings.speed_time_millis

--- a/openpilot/selfdrive/ui/onroad/augmented_road_view.py
+++ b/openpilot/selfdrive/ui/onroad/augmented_road_view.py
@@ -145,6 +145,15 @@ class AugmentedRoadView(CameraView):
     ud.modelBlindSpotTimeMillis = model_timings.blind_spot_time_millis
     ud.modelRadarTimeMillis = model_timings.radar_time_millis
     ud.modelTimingValid = model_timings.valid
+    hud_timings = self._hud_renderer.render_timings
+    ud.hudHeaderTimeMillis = hud_timings.header_time_millis
+    ud.hudSpeedTimeMillis = hud_timings.speed_time_millis
+    ud.hudStatusTimeMillis = hud_timings.status_time_millis
+    ud.hudNavigationTimeMillis = hud_timings.navigation_time_millis
+    ud.hudButtonTimeMillis = hud_timings.button_time_millis
+    ud.hudPlotTimeMillis = hud_timings.plot_time_millis
+    ud.hudAuxTimeMillis = hud_timings.aux_time_millis
+    ud.hudTimingValid = hud_timings.valid
     ud.plotMode = self._plot_mode
     ud.recording = gui_app.is_recording()
     self._pm.send('uiDebug', msg)

--- a/openpilot/selfdrive/ui/onroad/augmented_road_view.py
+++ b/openpilot/selfdrive/ui/onroad/augmented_road_view.py
@@ -144,23 +144,6 @@ class AugmentedRoadView(CameraView):
     ud.hudTimeMillis = hud_ms
     ud.alertTimeMillis = alert_ms
     ud.extrasTimeMillis = extras_ms
-    model_timings = self.model_renderer.render_timings
-    ud.modelPathTimeMillis = model_timings.path_time_millis
-    ud.modelLaneTimeMillis = model_timings.lane_time_millis
-    ud.modelBlindSpotTimeMillis = model_timings.blind_spot_time_millis
-    ud.modelRadarTimeMillis = model_timings.radar_time_millis
-    ud.modelTimingValid = model_timings.valid
-    ud.modelBlindSpotStateMask = model_timings.blind_spot_state_mask
-    ud.modelBlindSpotStateValid = model_timings.blind_spot_state_valid
-    hud_timings = self._hud_renderer.render_timings
-    ud.hudHeaderTimeMillis = hud_timings.header_time_millis
-    ud.hudSpeedTimeMillis = hud_timings.speed_time_millis
-    ud.hudStatusTimeMillis = hud_timings.status_time_millis
-    ud.hudNavigationTimeMillis = hud_timings.navigation_time_millis
-    ud.hudButtonTimeMillis = hud_timings.button_time_millis
-    ud.hudPlotTimeMillis = hud_timings.plot_time_millis
-    ud.hudAuxTimeMillis = hud_timings.aux_time_millis
-    ud.hudTimingValid = hud_timings.valid
     ud.plotMode = self._plot_mode
     ud.recording = gui_app.is_recording()
     self._pm.send('uiDebug', msg)

--- a/openpilot/selfdrive/ui/onroad/augmented_road_view.py
+++ b/openpilot/selfdrive/ui/onroad/augmented_road_view.py
@@ -52,14 +52,30 @@ class AugmentedRoadView(CameraView):
 
     # debug
     self._pm = messaging.PubMaster(['uiDebug'])
+    # uiDebug.plotMode용 ShowPlotMode 캐시 — 파일 읽기라 매 프레임 금지, ~2초 스로틀
+    self._plot_mode = 0
+    self._plot_mode_next_t = 0.0
 
-
+  def _refresh_plot_mode(self, now: float) -> None:
+    if now < self._plot_mode_next_t:
+      return
+    self._plot_mode_next_t = now + 2.0
+    try:
+      self._plot_mode = min(max(ui_state.params.get_int("ShowPlotMode"), 0), 255)
+    except Exception:
+      self._plot_mode = 0
 
   def _render(self, rect):
+    # plotMode 갱신(가끔 파일 읽기)은 drawTime 창 밖에서 — total을 오염시키지 않는다
+    self._refresh_plot_mode(time.monotonic())
     # Only render when system is started to avoid invalid data access
     start_draw = time.monotonic()
     if not ui_state.started:
       return
+    # 구간별 계측(계측 전용) — 렌더 호출 순서는 그대로, 각 구간 전후 monotonic만 잰다.
+    # scissor begin/end는 raylib 배치 flush 지점이라 특정 구간에 귀속시키지 않는다 —
+    # total과 구간 합의 차이(미귀속)로 남는다. extras = carrot 테두리(+텍스트)
+    cam_ms = model_ms = ds_ms = hud_ms = alert_ms = extras_ms = 0.0
 
     self._switch_stream_if_needed(ui_state.sm)
 
@@ -84,13 +100,23 @@ class AugmentedRoadView(CameraView):
     )
 
     # Render the base camera view
+    _t = time.monotonic()
     super()._render(rect)
+    cam_ms = (time.monotonic() - _t) * 1000.0
 
     # Draw all UI overlays
+    _t = time.monotonic()
     self.model_renderer.render(self._content_rect)
-    self._hud_renderer.render(self._content_rect)
+    model_ms = (time.monotonic() - _t) * 1000.0
+    _t = time.monotonic()
+    self._hud_renderer.render(self._content_rect)  # plot 활성 시 plot 비용도 hud 구간에 포함
+    hud_ms = (time.monotonic() - _t) * 1000.0
+    _t = time.monotonic()
     self.alert_renderer.render(self._content_rect)
+    alert_ms = (time.monotonic() - _t) * 1000.0
+    _t = time.monotonic()
     self.driver_state_renderer.render(self._content_rect)
+    ds_ms = (time.monotonic() - _t) * 1000.0
 
     # Custom UI extension point - add custom overlays here
     # Use self._content_rect for positioning within camera bounds
@@ -99,11 +125,22 @@ class AugmentedRoadView(CameraView):
     rl.end_scissor_mode()
 
     # Draw colored border based on driving state
+    _t = time.monotonic()
     self._draw_border_carrot(rect)
+    extras_ms = (time.monotonic() - _t) * 1000.0
 
     # publish uiDebug
-    msg = messaging.new_message('uiDebug')
-    msg.uiDebug.drawTimeMillis = (time.monotonic() - start_draw) * 1000
+    msg = messaging.new_message('uiDebug', valid=True)
+    ud = msg.uiDebug
+    ud.drawTimeMillis = (time.monotonic() - start_draw) * 1000
+    ud.cameraTimeMillis = cam_ms
+    ud.modelTimeMillis = model_ms
+    ud.driverStateTimeMillis = ds_ms
+    ud.hudTimeMillis = hud_ms
+    ud.alertTimeMillis = alert_ms
+    ud.extrasTimeMillis = extras_ms
+    ud.plotMode = self._plot_mode
+    ud.recording = gui_app.is_recording()
     self._pm.send('uiDebug', msg)
 
   def _handle_mouse_press(self, _):

--- a/openpilot/selfdrive/ui/onroad/augmented_road_view.py
+++ b/openpilot/selfdrive/ui/onroad/augmented_road_view.py
@@ -4,6 +4,7 @@ import pyray as rl
 from openpilot.cereal import log, messaging
 from msgq.visionipc import VisionStreamType
 from openpilot.selfdrive.ui import UI_BORDER_SIZE
+from openpilot.selfdrive.ui.carrot_param_cache import BorderParamSnapshot, TimedSnapshotCache, read_border_params
 from openpilot.selfdrive.ui.ui_state import ui_state, UIStatus
 from openpilot.selfdrive.ui.onroad.alert_renderer import AlertRenderer
 from openpilot.selfdrive.ui.onroad.driver_state import DriverStateRenderer
@@ -55,6 +56,10 @@ class AugmentedRoadView(CameraView):
     # uiDebug.plotMode용 ShowPlotMode 캐시 — 파일 읽기라 매 프레임 금지, ~2초 스로틀
     self._plot_mode = 0
     self._plot_mode_next_t = 0.0
+    self._border_params = TimedSnapshotCache(
+      BorderParamSnapshot(),
+      lambda: read_border_params(ui_state.params, ui_state.params_memory),
+    )
 
   def _refresh_plot_mode(self, now: float) -> None:
     if now < self._plot_mode_next_t:
@@ -284,6 +289,7 @@ class AugmentedRoadView(CameraView):
       self._draw_border(rect)
       return
 
+    border_params = self._border_params.refresh(time.monotonic())
     car_state = sm["carState"]
 
     x = float(rect.x)
@@ -432,22 +438,12 @@ class AugmentedRoadView(CameraView):
     bottom_left = ""
     bottom_right = ""
 
-    car_name = ui_state.params.get("CarName") or ""
-
-    if ui_state.params.get_int("HyundaiCameraSCC") > 0:
-      car_name += "(CAMERA SCC)"
-    else:
-      try:
-        if sm.alive["carParams"] and sm["carParams"].openpilotLongitudinalControl:
-          car_name += " - OP Long"
-      except Exception:
-        pass
-
-    nnff_model_name = ui_state.params.get("NNFFModelName") or ""
-    if len(nnff_model_name) > 0:
-      car_name += ",NNFF"
-
-    top_left = car_name
+    top_left = border_params.top_left
+    try:
+      if sm.alive["carParams"] and sm["carParams"].openpilotLongitudinalControl:
+        top_left = border_params.top_left_op_long
+    except Exception:
+      pass
 
     try:
       top_right_parts = []
@@ -467,8 +463,7 @@ class AugmentedRoadView(CameraView):
 
       if sm.alive["liveParameters"]:
         lp = sm["liveParameters"]
-        custom_sr = ui_state.params.get_float("CustomSR") / 10.0
-        top_right_parts.append(f"SR({lp.steerRatio:.1f},{custom_sr:.1f})")
+        top_right_parts.append(f"SR({lp.steerRatio:.1f},{border_params.custom_sr:.1f})")
 
       top_right = ", ".join(top_right_parts)
     except Exception:
@@ -479,9 +474,8 @@ class AugmentedRoadView(CameraView):
       lat_plan = sm["lateralPlan"]
       bottom = str(lat_plan.latDebugText)
 
-    bottom_left = ui_state.params.get("GitBranch") or ""
-
-    bottom_right = ui_state.params_memory.get("NetworkAddress") or ""
+    bottom_left = border_params.bottom_left
+    bottom_right = border_params.bottom_right
 
     # text positions
     top_text_y = y + line_margin

--- a/openpilot/selfdrive/ui/onroad/hud_renderer.py
+++ b/openpilot/selfdrive/ui/onroad/hud_renderer.py
@@ -88,28 +88,6 @@ class SetSpeedOverrideState:
   force_persist: bool
 
 
-@dataclass
-class HudRenderTimings:
-  header_time_millis: float = 0.0
-  speed_time_millis: float = 0.0
-  status_time_millis: float = 0.0
-  navigation_time_millis: float = 0.0
-  button_time_millis: float = 0.0
-  plot_time_millis: float = 0.0
-  aux_time_millis: float = 0.0
-  valid: bool = False
-
-  def reset(self) -> None:
-    self.header_time_millis = 0.0
-    self.speed_time_millis = 0.0
-    self.status_time_millis = 0.0
-    self.navigation_time_millis = 0.0
-    self.button_time_millis = 0.0
-    self.plot_time_millis = 0.0
-    self.aux_time_millis = 0.0
-    self.valid = False
-
-
 class SetSpeedOverride:
 
   def compute(self, sm, set_speed_kph: float) -> SetSpeedOverrideState:
@@ -212,7 +190,6 @@ class HudRenderer(Widget):
     self._disk_usage_text = "100%"
     self._voltage_text = "0.0V"
     self._plot_renderer = None
-    self._render_timings = HudRenderTimings()
     self._round_box_rect = rl.Rectangle(0.0, 0.0, 0.0, 0.0)
 
     self._hud_params_next_refresh_time = 0.0
@@ -224,10 +201,6 @@ class HudRenderer(Widget):
     self._date_time_minute_key: tuple[int, int, int, int, int] | None = None
     self._date_time_text = ""
     self._date_text = ""
-
-  @property
-  def render_timings(self) -> HudRenderTimings:
-    return self._render_timings
 
   def _refresh_hud_params(self, now: float) -> None:
     if now < self._hud_params_next_refresh_time:
@@ -293,11 +266,9 @@ class HudRenderer(Widget):
 
   def _render(self, rect: rl.Rectangle) -> None:
     """Render HUD elements to the screen."""
-    self._render_timings.reset()
     self._refresh_hud_params(time.monotonic())
 
     # Draw the header background
-    header_start = time.monotonic_ns()
     rl.draw_rectangle_gradient_v(
       int(rect.x),
       int(rect.y),
@@ -306,35 +277,23 @@ class HudRenderer(Widget):
       COLORS.HEADER_GRADIENT_START,
       COLORS.HEADER_GRADIENT_END,
     )
-    header_end = time.monotonic_ns()
-    self._render_timings.header_time_millis = (header_end - header_start) * 1e-6
 
     if self.is_cruise_available:
       self._draw_set_speed_carrot(rect)
 
     #self._draw_current_speed(rect)
 
-    button_start = time.monotonic_ns()
     button_x = rect.x + rect.width - UI_CONFIG.border_size - UI_CONFIG.button_size
     button_y = rect.y + UI_CONFIG.border_size
     self._exp_button.render(rl.Rectangle(button_x, button_y, UI_CONFIG.button_size, UI_CONFIG.button_size))
-    button_end = time.monotonic_ns()
-    self._render_timings.button_time_millis = (button_end - button_start) * 1e-6
 
-    plot_start = time.monotonic_ns()
     if self._plot_renderer is None:
       self._plot_renderer = PlotRenderer()
     self._plot_renderer.draw(rect, self._font_display, self._show_plot_mode)
-    plot_end = time.monotonic_ns()
-    self._render_timings.plot_time_millis = (plot_end - plot_start) * 1e-6
 
-    aux_start = time.monotonic_ns()
     self._draw_date_time(rect)
     self._draw_tpms_top_right(rect)
     self._draw_cruise_speed_animation(rect)
-    render_end = time.monotonic_ns()
-    self._render_timings.aux_time_millis = (render_end - aux_start) * 1e-6
-    self._render_timings.valid = True
 
   def user_interacting(self) -> bool:
     return self._exp_button.is_pressed
@@ -1337,8 +1296,6 @@ class HudRenderer(Widget):
       )
 
   def _draw_set_speed_carrot(self, rect: rl.Rectangle) -> None:
-    speed_start = time.monotonic_ns()
-
     self._blink_timer = (self._blink_timer + 1) % 16
     self._disp_timer = (self._disp_timer + 1) % 64
 
@@ -1350,19 +1307,12 @@ class HudRenderer(Widget):
     self._draw_carrot_main_background(bx, by, speed_limit_info)
     self._draw_carrot_traffic_light(bx, by)
     self._draw_carrot_speed_panel(bx, by)
-    speed_end = time.monotonic_ns()
 
     self._draw_carrot_lower_status(bx, by)
     self._draw_carrot_speed_limit_box(bx, by, speed_limit_info)
     self._draw_carrot_device_state(bx, by)
-    status_end = time.monotonic_ns()
 
     self._draw_turn_info_hud(rect)
-    navigation_end = time.monotonic_ns()
-
-    self._render_timings.speed_time_millis = (speed_end - speed_start) * 1e-6
-    self._render_timings.status_time_millis = (status_end - speed_end) * 1e-6
-    self._render_timings.navigation_time_millis = (navigation_end - status_end) * 1e-6
 
 
 

--- a/openpilot/selfdrive/ui/onroad/hud_renderer.py
+++ b/openpilot/selfdrive/ui/onroad/hud_renderer.py
@@ -1,5 +1,4 @@
 import time
-from collections import deque
 import pyray as rl
 from dataclasses import dataclass
 from openpilot.common.constants import CV
@@ -59,6 +58,21 @@ class Colors:
   HEADER_GRADIENT_START = rl.Color(0, 0, 0, 114)
   HEADER_GRADIENT_END = rl.BLANK
   CARROT_GREEN = rl.Color(0, 203, 0, 255)
+  BLACK_90 = rl.Color(0, 0, 0, 90)
+  RED_180 = rl.Color(255, 0, 0, 180)
+  GREEN_190 = rl.Color(0, 255, 0, 190)
+  GREEN_200 = rl.Color(0, 255, 0, 200)
+  GREEN_210 = rl.Color(0, 255, 0, 210)
+  BLUE_210 = rl.Color(0, 120, 255, 210)
+  RED_200 = rl.Color(255, 0, 0, 200)
+  RED_210 = rl.Color(255, 0, 0, 210)
+  YELLOW_210 = rl.Color(255, 255, 0, 210)
+  WHITE_210 = rl.Color(255, 255, 255, 210)
+  WHITE_220 = rl.Color(255, 255, 255, 220)
+  TPMS_LOW = rl.Color(255, 90, 90, 220)
+  ORANGE_200 = rl.Color(255, 165, 0, 200)
+  ORANGE_230 = rl.Color(255, 165, 0, 230)
+  RED_SOLID = rl.Color(255, 0, 0, 255)
 
 
 UI_CONFIG = UIConfig()
@@ -193,8 +207,13 @@ class HudRenderer(Widget):
     self._voltage = 0.0
     self._device_info_loaded = False
     self._device_info_recv_frames = (-1, -1)
+    self._cpu_temp_text = "0°C"
+    self._memory_usage_text = "0%"
+    self._disk_usage_text = "100%"
+    self._voltage_text = "0.0V"
     self._plot_renderer = None
     self._render_timings = HudRenderTimings()
+    self._round_box_rect = rl.Rectangle(0.0, 0.0, 0.0, 0.0)
 
     self._hud_params_next_refresh_time = 0.0
     self._show_device_state = 0
@@ -380,7 +399,11 @@ class HudRenderer(Widget):
                       roundness=0.25,
                       segments=8,
                       line_thickness=2):
-    rect = rl.Rectangle(float(x), float(y), float(w), float(h))
+    rect = self._round_box_rect
+    rect.x = float(x)
+    rect.y = float(y)
+    rect.width = float(w)
+    rect.height = float(h)
     rl.draw_rectangle_rounded(rect, roundness, segments, fill_color)
     if line_color is not None and line_thickness > 0:
       rl.draw_rectangle_rounded_lines_ex(rect, roundness, segments, float(line_thickness), line_color)
@@ -397,7 +420,7 @@ class HudRenderer(Widget):
       0.0,
       tint,
     )
-  
+
   def _get_gear_text(self) -> str:
     sm = ui_state.sm
 
@@ -457,18 +480,18 @@ class HudRenderer(Widget):
     try:
       mode_val = int(ui_state.sm["longitudinalPlan"].myDrivingMode)
     except Exception:
-      return "", rl.Color(255, 255, 255, 200)
+      return "", COLORS.WHITE_TRANSLUCENT
 
     if mode_val == 1:   # eco
-      return tr("eco"), rl.Color(0, 255, 0, 200)
+      return tr("eco"), COLORS.GREEN_200
     if mode_val == 2:   # safe
-      return tr("safe"), rl.Color(255, 165, 0, 200)
+      return tr("safe"), COLORS.ORANGE_200
     if mode_val == 3:   # normal
-      return tr("norm"), rl.Color(255, 255, 255, 200)
+      return tr("norm"), COLORS.WHITE_TRANSLUCENT
     if mode_val == 4:   # high
-      return tr("high"), rl.Color(255, 0, 0, 200)
+      return tr("high"), COLORS.RED_200
 
-    return "", rl.Color(255, 255, 255, 200)
+    return "", COLORS.WHITE_TRANSLUCENT
 
   def _update_device_info(self):
     sm = ui_state.sm
@@ -508,6 +531,10 @@ class HudRenderer(Widget):
     except Exception:
       loaded = False
 
+    self._cpu_temp_text = f"{self._cpu_temp:.0f}°C"
+    self._memory_usage_text = f"{self._memory_usage}%"
+    self._disk_usage_text = f"{100 - self._free_space:.0f}%"
+    self._voltage_text = f"{self._voltage:.1f}V"
     self._device_info_loaded = loaded
 
   def _get_active_carrot(self) -> int:
@@ -652,7 +679,7 @@ class HudRenderer(Widget):
       if ov.speed_color_mode == 1:
         ov_color = rl.GREEN
       elif ov.speed_color_mode == 2:
-        ov_color = rl.Color(255, 165, 0, 230)
+        ov_color = COLORS.ORANGE_230
       else:
         ov_color = rl.GREEN
 
@@ -731,7 +758,7 @@ class HudRenderer(Widget):
     mode_text, mode_color = self._get_driving_mode_text_and_color()
     if self._debug_speed_panel:
       mode_text = "safe"
-      mode_color = rl.Color(255, 165, 0, 230)
+      mode_color = COLORS.ORANGE_230
 
     # driving mode
     if mode_text:
@@ -784,7 +811,7 @@ class HudRenderer(Widget):
         dy - ddy * (i + 1) + 2,
         70,
         ddy - 2,
-        rl.Color(0, 255, 0, 210),
+        COLORS.GREEN_210,
         line_color=rl.WHITE,
         roundness=0.12,
         segments=4,
@@ -798,7 +825,7 @@ class HudRenderer(Widget):
 
     self._draw_round_box(
       gx - 35, gy - 70, 70, 80,
-      rl.Color(0, 255, 0, 210),
+      COLORS.GREEN_210,
       line_color=rl.WHITE,
       roundness=0.20,
       segments=8,
@@ -837,7 +864,7 @@ class HudRenderer(Widget):
     elif active_carrot >= 1:
       self._draw_round_box(
         dx - 55, dy - 38, 110, 48,
-        rl.Color(0, 120, 255, 210),
+        COLORS.BLUE_210,
         line_color=rl.WHITE,
         roundness=0.25,
         segments=8,
@@ -867,22 +894,22 @@ class HudRenderer(Widget):
     dy = by + 175
 
     disp_speed = 0
-    limit_color = rl.Color(0, 255, 0, 210)
+    limit_color = COLORS.GREEN_210
     label = "LIMIT"
 
     if x_spd_limit > 0 and x_sign_type != 22:
       disp_speed = int(x_spd_limit if ui_state.is_metric else (x_spd_limit * KM_TO_MILE + 0.5))
       label = "CAM"
       if self._blink_timer <= 8:
-        limit_color = rl.Color(255, 0, 0, 210)
+        limit_color = COLORS.RED_210
       else:
-        limit_color = rl.Color(255, 255, 0, 210)
+        limit_color = COLORS.YELLOW_210
     else:
       disp_speed = int(road_limit_speed if ui_state.is_metric else (road_limit_speed * KM_TO_MILE + 0.5))
       if self.speed > disp_speed + 2:
-        limit_color = rl.Color(255, 0, 0, 210)
+        limit_color = COLORS.RED_210
       else:
-        limit_color = rl.Color(255, 255, 255, 210)
+        limit_color = COLORS.WHITE_210
 
     draw_text_ui_style(
       label, dx, dy - 45, 30, rl.WHITE,
@@ -915,9 +942,9 @@ class HudRenderer(Widget):
 
     stroke_color = rl.WHITE
     if cam_detected and self._blink_timer > 8:
-      bg_color = rl.Color(255, 0, 0, 180)
+      bg_color = COLORS.RED_180
     else:
-      bg_color = rl.Color(0, 0, 0, 90)
+      bg_color = COLORS.BLACK_90
 
     if self._show_device_state > 0:
       self._draw_round_box(
@@ -944,20 +971,20 @@ class HudRenderer(Widget):
 
     dx = bx - 35
     dy = by - 200
-    ok_color = rl.Color(0, 255, 0, 190)
+    ok_color = COLORS.GREEN_190
 
     # CPU
-    cpu_fill = rl.Color(255, 0, 0, 255) if (self._cpu_temp > 80 and self._blink_timer <= 8) else ok_color
+    cpu_fill = COLORS.RED_SOLID if (self._cpu_temp > 80 and self._blink_timer <= 8) else ok_color
     self._draw_round_box(dx - 65, dy - 38, 130, 90, cpu_fill, line_color=rl.WHITE, roundness=0.16, segments=8, line_thickness=2)
     draw_text_ui_style("CPU", dx, dy - 5, 25, rl.WHITE, font=self._font_display, border_width=1.0, shadow_offset=4.0, align="center_bottom")
-    draw_text_ui_style(f"{self._cpu_temp:.0f}°C", dx, dy + 40, 40, rl.WHITE, font=self._font_display, border_width=1.0, shadow_offset=4.0, align="center_bottom")
+    draw_text_ui_style(self._cpu_temp_text, dx, dy + 40, 40, rl.WHITE, font=self._font_display, border_width=1.0, shadow_offset=4.0, align="center_bottom")
 
     # MEM
     dx2 = dx + 150
-    mem_fill = rl.Color(255, 0, 0, 255) if (self._memory_usage > 85 and self._blink_timer <= 8) else ok_color
+    mem_fill = COLORS.RED_SOLID if (self._memory_usage > 85 and self._blink_timer <= 8) else ok_color
     self._draw_round_box(dx2 - 65, dy - 38, 130, 90, mem_fill, line_color=rl.WHITE, roundness=0.16, segments=8, line_thickness=2)
     draw_text_ui_style("MEM", dx2, dy - 5, 25, rl.WHITE, font=self._font_display, border_width=1.0, shadow_offset=4.0, align="center_bottom")
-    draw_text_ui_style(f"{self._memory_usage}%", dx2, dy + 40, 40, rl.WHITE, font=self._font_display, border_width=1.0, shadow_offset=4.0, align="center_bottom")
+    draw_text_ui_style(self._memory_usage_text, dx2, dy + 40, 40, rl.WHITE, font=self._font_display, border_width=1.0, shadow_offset=4.0, align="center_bottom")
 
     # DISK / VOLT
     dx3 = dx2 + 150
@@ -965,10 +992,10 @@ class HudRenderer(Widget):
 
     if self._disp_timer < 32:
       draw_text_ui_style("DISK", dx3, dy - 5, 25, rl.WHITE, font=self._font_display, border_width=1.0, shadow_offset=4.0, align="center_bottom")
-      draw_text_ui_style(f"{100 - self._free_space:.0f}%", dx3, dy + 40, 40, rl.WHITE, font=self._font_display, border_width=1.0, shadow_offset=4.0, align="center_bottom")
+      draw_text_ui_style(self._disk_usage_text, dx3, dy + 40, 40, rl.WHITE, font=self._font_display, border_width=1.0, shadow_offset=4.0, align="center_bottom")
     else:
       draw_text_ui_style("VOLT", dx3, dy - 5, 25, rl.WHITE, font=self._font_display, border_width=1.0, shadow_offset=4.0, align="center_bottom")
-      draw_text_ui_style(f"{self._voltage:.1f}V", dx3, dy + 40, 40, rl.WHITE, font=self._font_display, border_width=1.0, shadow_offset=4.0, align="center_bottom")
+      draw_text_ui_style(self._voltage_text, dx3, dy + 40, 40, rl.WHITE, font=self._font_display, border_width=1.0, shadow_offset=4.0, align="center_bottom")
 
   def _draw_date_time(self, rect: rl.Rectangle) -> None:
     show_datetime = self._show_date_time
@@ -1010,10 +1037,10 @@ class HudRenderer(Widget):
 
   def _get_tpms_color(self, tpms: float) -> rl.Color:
     if tpms < 5 or tpms > 60:
-      return rl.Color(255, 255, 255, 220)
+      return COLORS.WHITE_220
     if tpms < 31:
-      return rl.Color(255, 90, 90, 220)
-    return rl.Color(255, 255, 255, 220)
+      return COLORS.TPMS_LOW
+    return COLORS.WHITE_220
 
   def _get_tpms_text(self, tpms: float) -> str:
     if tpms < 5 or tpms > 60:
@@ -1145,7 +1172,8 @@ class HudRenderer(Widget):
     if remain_sec <= 0:
       return ""
 
-    eta_tm = time.localtime(time.time() + remain_sec)
+    # Arrival time is wall-clock based; monotonic time cannot be converted to local time.
+    eta_tm = time.localtime(time.time() + remain_sec)  # noqa: TID251
     remain_min = remain_sec / 60.0
     return f"도착: {remain_min:.1f}분({eta_tm.tm_hour:02d}:{eta_tm.tm_min:02d})"
 

--- a/openpilot/selfdrive/ui/onroad/hud_renderer.py
+++ b/openpilot/selfdrive/ui/onroad/hud_renderer.py
@@ -19,6 +19,8 @@ CRUISE_SPEED_ANIMATION_START = 120
 CRUISE_SPEED_ANIMATION_MAX = 100
 CRUISE_SPEED_ANIMATION_STEP = 12
 CRUISE_SPEED_ANIMATION_START_SIZE = 300
+HUD_PARAM_REFRESH_INTERVAL = 1.0
+WEEKDAYS_KO = ("일", "월", "화", "수", "목", "금", "토")
 
 
 @dataclass(frozen=True)
@@ -70,6 +72,28 @@ class SetSpeedOverrideState:
   label: str
   speed_color_mode: int # 0: white, 1: green, 2: orange
   force_persist: bool
+
+
+@dataclass
+class HudRenderTimings:
+  header_time_millis: float = 0.0
+  speed_time_millis: float = 0.0
+  status_time_millis: float = 0.0
+  navigation_time_millis: float = 0.0
+  button_time_millis: float = 0.0
+  plot_time_millis: float = 0.0
+  aux_time_millis: float = 0.0
+  valid: bool = False
+
+  def reset(self) -> None:
+    self.header_time_millis = 0.0
+    self.speed_time_millis = 0.0
+    self.status_time_millis = 0.0
+    self.navigation_time_millis = 0.0
+    self.button_time_millis = 0.0
+    self.plot_time_millis = 0.0
+    self.aux_time_millis = 0.0
+    self.valid = False
 
 
 class SetSpeedOverride:
@@ -167,11 +191,60 @@ class HudRenderer(Widget):
     self._memory_usage = 0
     self._free_space = 0.0
     self._voltage = 0.0
+    self._device_info_loaded = False
+    self._device_info_recv_frames = (-1, -1)
     self._plot_renderer = None
+    self._render_timings = HudRenderTimings()
+
+    self._hud_params_next_refresh_time = 0.0
+    self._show_device_state = 0
+    self._show_date_time = 0
+    self._show_plot_mode = 0
+    self._longitudinal_personality = 7
+
+    self._date_time_minute_key: tuple[int, int, int, int, int] | None = None
+    self._date_time_text = ""
+    self._date_text = ""
+
+  @property
+  def render_timings(self) -> HudRenderTimings:
+    return self._render_timings
+
+  def _refresh_hud_params(self, now: float) -> None:
+    if now < self._hud_params_next_refresh_time:
+      return
+
+    try:
+      show_device_state = ui_state.params.get_int("ShowDeviceState")
+      show_date_time = ui_state.params.get_int("ShowDateTime")
+      show_plot_mode = ui_state.params.get_int("ShowPlotMode")
+    except Exception:
+      # Keep the last complete snapshot and retry on the next frame.
+      return
+
+    personality_read_failed = False
+    try:
+      longitudinal_personality = ui_state.params.get_int("LongitudinalPersonality")
+    except Exception:
+      # Preserve the legacy fallback (gap 8) and retry on the next frame.
+      longitudinal_personality = 7
+      personality_read_failed = True
+
+    self._show_device_state = show_device_state
+    self._show_date_time = show_date_time
+    self._show_plot_mode = show_plot_mode
+    self._longitudinal_personality = longitudinal_personality
+    self._hud_params_next_refresh_time = now if personality_read_failed else now + HUD_PARAM_REFRESH_INTERVAL
 
   def _update_state(self) -> None:
     """Update HUD state based on car state and controls state."""
     sm = ui_state.sm
+    device_info_recv_frames = (sm.recv_frame["deviceState"], sm.recv_frame["peripheralState"])
+    if not self._device_info_loaded or device_info_recv_frames != self._device_info_recv_frames:
+      self._update_device_info()
+      if self._device_info_loaded:
+        self._device_info_recv_frames = device_info_recv_frames
+
     if sm.recv_frame["carState"] < ui_state.started_frame:
       self.is_cruise_set = False
       self.set_speed = SET_SPEED_NA
@@ -201,7 +274,11 @@ class HudRenderer(Widget):
 
   def _render(self, rect: rl.Rectangle) -> None:
     """Render HUD elements to the screen."""
+    self._render_timings.reset()
+    self._refresh_hud_params(time.monotonic())
+
     # Draw the header background
+    header_start = time.monotonic_ns()
     rl.draw_rectangle_gradient_v(
       int(rect.x),
       int(rect.y),
@@ -210,22 +287,35 @@ class HudRenderer(Widget):
       COLORS.HEADER_GRADIENT_START,
       COLORS.HEADER_GRADIENT_END,
     )
+    header_end = time.monotonic_ns()
+    self._render_timings.header_time_millis = (header_end - header_start) * 1e-6
 
     if self.is_cruise_available:
       self._draw_set_speed_carrot(rect)
 
     #self._draw_current_speed(rect)
 
+    button_start = time.monotonic_ns()
     button_x = rect.x + rect.width - UI_CONFIG.border_size - UI_CONFIG.button_size
     button_y = rect.y + UI_CONFIG.border_size
     self._exp_button.render(rl.Rectangle(button_x, button_y, UI_CONFIG.button_size, UI_CONFIG.button_size))
+    button_end = time.monotonic_ns()
+    self._render_timings.button_time_millis = (button_end - button_start) * 1e-6
 
+    plot_start = time.monotonic_ns()
     if self._plot_renderer is None:
       self._plot_renderer = PlotRenderer()
-    self._plot_renderer.draw(rect, self._font_display)
+    self._plot_renderer.draw(rect, self._font_display, self._show_plot_mode)
+    plot_end = time.monotonic_ns()
+    self._render_timings.plot_time_millis = (plot_end - plot_start) * 1e-6
+
+    aux_start = time.monotonic_ns()
     self._draw_date_time(rect)
     self._draw_tpms_top_right(rect)
     self._draw_cruise_speed_animation(rect)
+    render_end = time.monotonic_ns()
+    self._render_timings.aux_time_millis = (render_end - aux_start) * 1e-6
+    self._render_timings.valid = True
 
   def user_interacting(self) -> bool:
     return self._exp_button.is_pressed
@@ -361,13 +451,7 @@ class HudRenderer(Widget):
     return "M"
 
   def _get_cruise_gap(self) -> int:
-    try:
-      personality = ui_state.params.get_int("LongitudinalPersonality")
-      gap = int(personality) + 1
-    except Exception:
-      gap = 8
-
-    return gap
+    return int(self._longitudinal_personality) + 1
 
   def _get_driving_mode_text_and_color(self) -> tuple[str, rl.Color]:
     try:
@@ -388,6 +472,7 @@ class HudRenderer(Widget):
 
   def _update_device_info(self):
     sm = ui_state.sm
+    loaded = True
 
     self._cpu_temp = 0.0
     self._cpu_usage = 0.0
@@ -406,22 +491,24 @@ class HudRenderer(Widget):
         if len(cpu_temps) > 0:
           self._cpu_temp = sum(cpu_temps) / len(cpu_temps)
       except Exception:
-        pass
+        loaded = False
 
       try:
         cpu_usages = [float(v) for v in device_state.cpuUsagePercent if float(v) > 0]
         if len(cpu_usages) > 0:
           self._cpu_usage = sum(cpu_usages) / len(cpu_usages)
       except Exception:
-        pass
+        loaded = False
     except Exception:
-      pass
+      loaded = False
 
     try:
       peripheral_state = sm["peripheralState"]
       self._voltage = float(peripheral_state.voltage) / 1000.0
     except Exception:
-      pass
+      loaded = False
+
+    self._device_info_loaded = loaded
 
   def _get_active_carrot(self) -> int:
     try:
@@ -451,25 +538,27 @@ class HudRenderer(Widget):
       return 0
 
 
-  def _get_speed_limit_info(self):
+  def _get_speed_limit_info(self) -> tuple[int, int, int]:
     """
     return:
       x_spd_limit, x_sign_type, road_limit_speed
     """
     try:
       cm = ui_state.sm["carrotMan"]
+    except Exception:
+      return 0, 0, 0
+
+    try:
       x_spd_limit = int(cm.xSpdLimit)
     except Exception:
       x_spd_limit = 0
 
     try:
-      cm = ui_state.sm["carrotMan"]
       x_sign_type = int(cm.xSignType)
     except Exception:
       x_sign_type = 0
 
     try:
-      cm = ui_state.sm["carrotMan"]
       road_limit_speed = int(cm.nRoadLimitSpeed)
     except Exception:
       road_limit_speed = 0
@@ -771,8 +860,8 @@ class HudRenderer(Widget):
         align="center_bottom",
       )
 
-  def _draw_carrot_speed_limit_box(self, bx: int, by: int):
-    x_spd_limit, x_sign_type, road_limit_speed = self._get_speed_limit_info()
+  def _draw_carrot_speed_limit_box(self, bx: int, by: int, speed_limit_info: tuple[int, int, int]):
+    x_spd_limit, x_sign_type, road_limit_speed = speed_limit_info
 
     dx = bx + 75
     dy = by + 175
@@ -820,10 +909,8 @@ class HudRenderer(Widget):
       align="center_bottom",
     )
 
-  def _draw_carrot_main_background(self, bx: int, by: int):
-    show_device_state = ui_state.params.get_int("ShowDeviceState")
-
-    x_spd_limit, x_sign_type, _ = self._get_speed_limit_info()
+  def _draw_carrot_main_background(self, bx: int, by: int, speed_limit_info: tuple[int, int, int]):
+    x_spd_limit, x_sign_type, _ = speed_limit_info
     cam_detected = x_spd_limit > 0 and x_sign_type not in (22, 4)
 
     stroke_color = rl.WHITE
@@ -832,7 +919,7 @@ class HudRenderer(Widget):
     else:
       bg_color = rl.Color(0, 0, 0, 90)
 
-    if show_device_state > 0:
+    if self._show_device_state > 0:
       self._draw_round_box(
         bx - 120, by - 270, 475, 495,
         bg_color,
@@ -852,11 +939,8 @@ class HudRenderer(Widget):
       )
 
   def _draw_carrot_device_state(self, bx: int, by: int):
-    show_device_state = ui_state.params.get_int("ShowDeviceState")
-    if show_device_state <= 0:
+    if self._show_device_state <= 0:
       return
-
-    self._update_device_info()
 
     dx = bx - 35
     dy = by - 200
@@ -887,19 +971,18 @@ class HudRenderer(Widget):
       draw_text_ui_style(f"{self._voltage:.1f}V", dx3, dy + 40, 40, rl.WHITE, font=self._font_display, border_width=1.0, shadow_offset=4.0, align="center_bottom")
 
   def _draw_date_time(self, rect: rl.Rectangle) -> None:
-    show_datetime = ui_state.params.get_int("ShowDateTime")
+    show_datetime = self._show_date_time
     if show_datetime <= 0:
       return
 
-    now = time.localtime()
-    weekdays_ko = ["일", "월", "화", "수", "목", "금", "토"]
+    self._refresh_date_time_text(time.localtime())
 
     x = int(rect.x + 170)
     y = int(rect.y + 120)
 
     if show_datetime in (1, 2):
       draw_text_ui_style(
-        time.strftime("%H:%M", now), x, y, 100, rl.WHITE,
+        self._date_time_text, x, y, 100, rl.WHITE,
         font=self._font_display,
         border_width=3.0,
         shadow_offset=8.0,
@@ -907,15 +990,23 @@ class HudRenderer(Widget):
       )
 
     if show_datetime in (1, 3):
-      weekday = weekdays_ko[(now.tm_wday + 1) % 7]
-      date_text = f"{time.strftime('%m-%d', now)}({weekday})"
       draw_text_ui_style(
-        date_text, x, y + 70, 60, rl.WHITE,
+        self._date_text, x, y + 70, 60, rl.WHITE,
         font=self._font_display,
         border_width=3.0,
         shadow_offset=8.0,
         align="center_bottom",
       )
+
+  def _refresh_date_time_text(self, now: time.struct_time) -> None:
+    minute_key = (now.tm_year, now.tm_yday, now.tm_hour, now.tm_min, now.tm_isdst)
+    if minute_key == self._date_time_minute_key:
+      return
+
+    weekday = WEEKDAYS_KO[(now.tm_wday + 1) % 7]
+    self._date_time_text = time.strftime("%H:%M", now)
+    self._date_text = f"{time.strftime('%m-%d', now)}({weekday})"
+    self._date_time_minute_key = minute_key
 
   def _get_tpms_color(self, tpms: float) -> rl.Color:
     if tpms < 5 or tpms > 60:
@@ -1218,6 +1309,8 @@ class HudRenderer(Widget):
       )
 
   def _draw_set_speed_carrot(self, rect: rl.Rectangle) -> None:
+    speed_start = time.monotonic_ns()
+
     self._blink_timer = (self._blink_timer + 1) % 16
     self._disp_timer = (self._disp_timer + 1) % 64
 
@@ -1225,14 +1318,24 @@ class HudRenderer(Widget):
     bx = int(rect.x + 140)
     by = int(rect.y + rect.height - 230)
 
-    self._draw_carrot_main_background(bx, by)
+    speed_limit_info = self._get_speed_limit_info()
+    self._draw_carrot_main_background(bx, by, speed_limit_info)
     self._draw_carrot_traffic_light(bx, by)
     self._draw_carrot_speed_panel(bx, by)
+    speed_end = time.monotonic_ns()
+
     self._draw_carrot_lower_status(bx, by)
-    self._draw_carrot_speed_limit_box(bx, by)
+    self._draw_carrot_speed_limit_box(bx, by, speed_limit_info)
     self._draw_carrot_device_state(bx, by)
+    status_end = time.monotonic_ns()
+
     self._draw_turn_info_hud(rect)
-  
+    navigation_end = time.monotonic_ns()
+
+    self._render_timings.speed_time_millis = (speed_end - speed_start) * 1e-6
+    self._render_timings.status_time_millis = (status_end - speed_end) * 1e-6
+    self._render_timings.navigation_time_millis = (navigation_end - status_end) * 1e-6
+
 
 
 class PlotRenderer:
@@ -1435,8 +1538,7 @@ class PlotRenderer:
         font=font, border_width=2.0, shadow_offset=4.0, align='center_bottom',
       )
 
-  def draw(self, rect: rl.Rectangle, font) -> None:
-    show_plot_mode = ui_state.params.get_int('ShowPlotMode')
+  def draw(self, rect: rl.Rectangle, font, show_plot_mode: int) -> None:
     if show_plot_mode == 0:
       return
     try:

--- a/openpilot/selfdrive/ui/onroad/model_renderer.py
+++ b/openpilot/selfdrive/ui/onroad/model_renderer.py
@@ -1192,7 +1192,9 @@ class ModelRenderer(Widget):
     input_services = ("modelV2", "carState", "radarState")
     if not all(sm.valid[service] for service in input_services):
       return 0, False
-    state_valid = all(sm.alive[service] for service in input_services)
+    # Match the actual draw gate. A temporarily non-alive service can still
+    # render its last valid sample, so that executed branch remains attributable.
+    state_valid = True
 
     car_state = sm['carState']
     radar_state = sm['radarState']

--- a/openpilot/selfdrive/ui/onroad/model_renderer.py
+++ b/openpilot/selfdrive/ui/onroad/model_renderer.py
@@ -20,6 +20,11 @@ CARROT_PARAM_REFRESH_INTERVAL = 1.0
 
 LaneChangeState = log.LaneChangeState
 
+BLIND_SPOT_LEFT_MASK = 1 << 0
+BLIND_SPOT_RIGHT_MASK = 1 << 1
+BLIND_SPOT_LEFT_ASSIST_MASK = 1 << 2
+BLIND_SPOT_RIGHT_ASSIST_MASK = 1 << 3
+
 THROTTLE_COLORS = [
   rl.Color(13, 248, 122, 102),   # HSLF(148/360, 0.94, 0.51, 0.4)
   rl.Color(114, 255, 92, 89),    # HSLF(112/360, 1.0, 0.68, 0.35)
@@ -68,6 +73,8 @@ class ModelRenderTimings:
   blind_spot_time_millis: float = 0.0
   radar_time_millis: float = 0.0
   valid: bool = False
+  blind_spot_state_mask: int = 0
+  blind_spot_state_valid: bool = False
 
   def reset(self) -> None:
     self.path_time_millis = 0.0
@@ -75,6 +82,8 @@ class ModelRenderTimings:
     self.blind_spot_time_millis = 0.0
     self.radar_time_millis = 0.0
     self.valid = False
+    self.blind_spot_state_mask = 0
+    self.blind_spot_state_valid = False
 
 
 class ModelRenderer(Widget):
@@ -172,7 +181,7 @@ class ModelRenderer(Widget):
     lane_start = time.monotonic_ns()
     self._draw_lane_lines_carrot(sm)
     blind_spot_start = time.monotonic_ns()
-    self._draw_blind_spot_carrot(sm)
+    blind_spot_state_mask, blind_spot_state_valid = self._draw_blind_spot_carrot(sm)
     radar_start = time.monotonic_ns()
     self._draw_radar_info_carrot(sm)
     render_end = time.monotonic_ns()
@@ -182,6 +191,8 @@ class ModelRenderer(Widget):
     self._render_timings.blind_spot_time_millis = (radar_start - blind_spot_start) * 1e-6
     self._render_timings.radar_time_millis = (render_end - radar_start) * 1e-6
     self._render_timings.valid = True
+    self._render_timings.blind_spot_state_mask = blind_spot_state_mask
+    self._render_timings.blind_spot_state_valid = blind_spot_state_valid
 
   def _update_raw_points(self, model):
     """Update raw 3D points from model data"""
@@ -708,7 +719,12 @@ class ModelRenderer(Widget):
       )
 
   def _draw_polygon_from_xy_carrot(self, xs, ys, fill_color: rl.Color, brake_valid: bool, color_idx: int):
-    pts = np.array(list(zip(xs, ys)), dtype=np.float32)
+    pts = np.column_stack((xs, ys)).astype(np.float32, copy=False)
+    self._draw_polygon_points_carrot(pts, fill_color, brake_valid, color_idx)
+
+
+  def _draw_polygon_points_carrot(self, pts: np.ndarray, fill_color: rl.Color, brake_valid: bool, color_idx: int):
+    pts = np.asarray(pts, dtype=np.float32)
 
     if pts.shape[0] >= 2:
       keep = [0]
@@ -1025,6 +1041,68 @@ class ModelRenderer(Widget):
 
 
 
+  def _build_blind_spot_barrier_carrot(self, model_position: np.ndarray, y_shift: float) -> np.ndarray:
+    max_idx_barrier = self._get_path_length_idx(model_position[:, 0], 40.0)
+    points = model_position[:max_idx_barrier + 1]
+    points = points[points[:, 0] >= 0]
+    if points.shape[0] == 0:
+      return np.empty((0, 2), dtype=np.float32)
+
+    # Project the upper/lower barrier edges together. This preserves the old
+    # point and clipping rules without two Python projection calls per point.
+    offsets = np.array(
+      [[0.0, y_shift, 1.15], [0.0, y_shift, 0.6]],
+      dtype=np.float32,
+    )
+    points_3d = points[None, :, :] + offsets[:, None, :]
+    # Keep the former three-term float32 dot-product order while applying the
+    # projection to both edges and all model points at once.
+    transform = self._car_space_transform
+    projected = (
+      transform[:, 0, None, None] * points_3d[None, :, :, 0] +
+      transform[:, 1, None, None] * points_3d[None, :, :, 1] +
+      transform[:, 2, None, None] * points_3d[None, :, :, 2]
+    )
+    upper_projected = projected[:, 0, :]
+    lower_projected = projected[:, 1, :]
+
+    valid_depth = (np.abs(upper_projected[2]) >= 1e-6) & (np.abs(lower_projected[2]) >= 1e-6)
+    if not np.any(valid_depth):
+      return np.empty((0, 2), dtype=np.float32)
+
+    upper_screen = upper_projected[:2, valid_depth] / upper_projected[2, valid_depth][None, :]
+    lower_screen = lower_projected[:2, valid_depth] / lower_projected[2, valid_depth][None, :]
+
+    clip = self._clip_region
+    x_min, x_max = clip.x, clip.x + clip.width
+    y_min, y_max = clip.y, clip.y + clip.height
+    upper_in_clip = (
+      (upper_screen[0] >= x_min) & (upper_screen[0] <= x_max) &
+      (upper_screen[1] >= y_min) & (upper_screen[1] <= y_max)
+    )
+    lower_in_clip = (
+      (lower_screen[0] >= x_min) & (lower_screen[0] <= x_max) &
+      (lower_screen[1] >= y_min) & (lower_screen[1] <= y_max)
+    )
+    both_in_clip = upper_in_clip & lower_in_clip
+    if not np.any(both_in_clip):
+      return np.empty((0, 2), dtype=np.float32)
+
+    upper_screen = upper_screen[:, both_in_clip]
+    lower_screen = lower_screen[:, both_in_clip]
+
+    # Match the old hill/inversion filter: keep a point only when its upper
+    # screen Y does not increase relative to the last accepted point.
+    if upper_screen.shape[1] > 1:
+      keep = upper_screen[1] == np.minimum.accumulate(upper_screen[1])
+      upper_screen = upper_screen[:, keep]
+      lower_screen = lower_screen[:, keep]
+
+    if upper_screen.shape[1] == 0:
+      return np.empty((0, 2), dtype=np.float32)
+    return np.vstack((upper_screen.T, lower_screen[:, ::-1].T)).astype(np.float32)
+
+
   def _update_blind_spot_barriers_carrot(self, sm, update_left: bool = True, update_right: bool = True):
     if not sm.valid['modelV2']:
       self._carrot_lane_barrier_vertices[0] = np.empty((0, 2), dtype=np.float32)
@@ -1037,51 +1115,10 @@ class ModelRenderer(Widget):
       self._carrot_lane_barrier_vertices[1] = np.empty((0, 2), dtype=np.float32)
       return
 
-    max_idx_barrier = self._get_path_length_idx(model_position[:, 0], 40.0)
-
-    def build_barrier(y_shift: float) -> np.ndarray:
-      left_points = []
-      right_points = []
-
-      for i in range(0, max_idx_barrier + 1):
-        if model_position[i, 0] < 0:
-          continue
-
-        left = self._map_to_screen(
-          model_position[i, 0],
-          model_position[i, 1] + y_shift,
-          model_position[i, 2] + (1.2 - 0.05),
-        )
-        right = self._map_to_screen(
-          model_position[i, 0],
-          model_position[i, 1] + y_shift,
-          model_position[i, 2] + (1.2 - 0.6),
-        )
-
-        if left is not None and right is not None:
-          if len(left_points) > 0 and left[1] > left_points[-1][1]:
-            continue
-          left_points.append(left)
-          right_points.insert(0, right)
-
-      if len(left_points) == 0:
-        return np.empty((0, 2), dtype=np.float32)
-      return np.array(left_points + right_points, dtype=np.float32)
-
     if update_left:
-      self._carrot_lane_barrier_vertices[0] = build_barrier(-1.7)
+      self._carrot_lane_barrier_vertices[0] = self._build_blind_spot_barrier_carrot(model_position, -1.7)
     if update_right:
-      self._carrot_lane_barrier_vertices[1] = build_barrier(1.7)
-
-
-  def _order_polygon_points_carrot(self, pts: np.ndarray) -> np.ndarray:
-    if pts.shape[0] < 3:
-      return pts
-
-    center = np.mean(pts, axis=0)
-    angles = np.arctan2(pts[:, 1] - center[1], pts[:, 0] - center[0])
-    order = np.argsort(angles)
-    return pts[order]
+      self._carrot_lane_barrier_vertices[1] = self._build_blind_spot_barrier_carrot(model_position, 1.7)
 
   def _draw_blind_spot_segments_carrot(self, points: np.ndarray, color: rl.Color):
     if points.size == 0:
@@ -1092,19 +1129,26 @@ class ModelRenderer(Widget):
     if half < 3:
       return
 
-    for i in range(0, half - 2, 2):
-      p0 = points[i + 0]
-      p1 = points[i + 1]
-      p2 = points[count - i - 3]
-      p3 = points[count - i - 2]
+    starts = np.arange(0, half - 2, 2)
+    if starts.size == 0:
+      return
 
-      quad = np.array([p0, p1, p2, p3], dtype=np.float32)
-      quad = self._order_polygon_points_carrot(quad)
+    quads = np.stack(
+      (
+        points[starts],
+        points[starts + 1],
+        points[count - starts - 3],
+        points[count - starts - 2],
+      ),
+      axis=1,
+    )
+    centers = np.mean(quads, axis=1, keepdims=True)
+    angles = np.arctan2(quads[:, :, 1] - centers[:, :, 1], quads[:, :, 0] - centers[:, :, 0])
+    order = np.argsort(angles, axis=1)
+    ordered_quads = np.take_along_axis(quads, order[:, :, None], axis=1)
 
-      xs = [float(p[0]) for p in quad]
-      ys = [float(p[1]) for p in quad]
-
-      self._draw_polygon_from_xy_carrot(xs, ys, color, False, 10)
+    for quad in ordered_quads:
+      self._draw_polygon_points_carrot(quad, color, False, 10)
 
 
   @staticmethod
@@ -1129,9 +1173,26 @@ class ModelRenderer(Widget):
     return left_blindspot, right_blindspot, left_assist, right_assist
 
 
-  def _draw_blind_spot_carrot(self, sm):
-    if not sm.valid['modelV2'] or not sm.valid['carState'] or not sm.valid['radarState']:
-      return
+  @staticmethod
+  def _blind_spot_state_mask_carrot(
+    left_blindspot: bool,
+    right_blindspot: bool,
+    left_assist: bool,
+    right_assist: bool,
+  ) -> int:
+    return (
+      (BLIND_SPOT_LEFT_MASK if left_blindspot else 0) |
+      (BLIND_SPOT_RIGHT_MASK if right_blindspot else 0) |
+      (BLIND_SPOT_LEFT_ASSIST_MASK if left_assist else 0) |
+      (BLIND_SPOT_RIGHT_ASSIST_MASK if right_assist else 0)
+    )
+
+
+  def _draw_blind_spot_carrot(self, sm) -> tuple[int, bool]:
+    input_services = ("modelV2", "carState", "radarState")
+    if not all(sm.valid[service] for service in input_services):
+      return 0, False
+    state_valid = all(sm.alive[service] for service in input_services)
 
     car_state = sm['carState']
     radar_state = sm['radarState']
@@ -1140,8 +1201,11 @@ class ModelRenderer(Widget):
     left_blindspot, right_blindspot, left_assist, right_assist = self._blind_spot_draw_state_carrot(
       car_state, radar_state, meta,
     )
+    state_mask = self._blind_spot_state_mask_carrot(
+      left_blindspot, right_blindspot, left_assist, right_assist,
+    )
     if not (left_blindspot or right_blindspot or left_assist or right_assist):
-      return
+      return state_mask, state_valid
 
     warn_color = rl.Color(255, 215, 0, 150)
     assist_color = rl.Color(0, 204, 0, 150)
@@ -1160,6 +1224,8 @@ class ModelRenderer(Widget):
       self._draw_blind_spot_segments_carrot(self._carrot_lane_barrier_vertices[1], warn_color)
     elif right_assist:
       self._draw_blind_spot_segments_carrot(self._carrot_lane_barrier_vertices[1], assist_color)
+
+    return state_mask, state_valid
 
 
   def _draw_radar_info_carrot(self, sm):

--- a/openpilot/selfdrive/ui/onroad/model_renderer.py
+++ b/openpilot/selfdrive/ui/onroad/model_renderer.py
@@ -10,7 +10,7 @@ from openpilot.selfdrive.locationd.calibrationd import HEIGHT_INIT
 from openpilot.selfdrive.ui.ui_state import ui_state
 from openpilot.system.ui.lib.application import gui_app, FontWeight
 from openpilot.system.ui.lib.text_draw import draw_text_ui_style
-from openpilot.system.ui.lib.shader_polygon import draw_polygon, Gradient
+from openpilot.system.ui.lib.shader_polygon import draw_polygon, draw_polygon_solid, Gradient
 from openpilot.system.ui.widgets import Widget
 
 CLIP_MARGIN = 500
@@ -687,7 +687,7 @@ class ModelRenderer(Widget):
 
   def _draw_quad_fill_carrot(self, p0, p1, p2, p3, color: rl.Color):
     pts = np.array([p0, p1, p2, p3], dtype=np.float32)
-    draw_polygon(self._rect, pts, color)
+    draw_polygon_solid(pts, color)
 
   def _draw_two_quads_from_6pts_carrot(self, x, y, fill_color: rl.Color, brake_valid: bool, color_idx: int):
     pts = np.array(list(zip(x, y)), dtype=np.float32)
@@ -697,8 +697,8 @@ class ModelRenderer(Widget):
     left_pts = np.array([pts[0], pts[1], pts[2], pts[5]], dtype=np.float32)
     right_pts = np.array([pts[5], pts[2], pts[3], pts[4]], dtype=np.float32)
 
-    draw_polygon(self._rect, left_pts, fill_color)
-    draw_polygon(self._rect, right_pts, fill_color)
+    draw_polygon_solid(left_pts, fill_color)
+    draw_polygon_solid(right_pts, fill_color)
 
     if color_idx >= 10 or brake_valid:
       self._draw_polygon_outline_carrot(
@@ -724,7 +724,7 @@ class ModelRenderer(Widget):
     if pts.shape[0] < 3:
       return
 
-    draw_polygon(self._rect, pts, fill_color)
+    draw_polygon_solid(pts, fill_color)
 
     if color_idx >= 10 or brake_valid:
       self._draw_polygon_outline_carrot(
@@ -944,10 +944,13 @@ class ModelRenderer(Widget):
 
     car_state = sm['carState']
     lane_line_probs = self._lane_line_probs
+    lane_line_visible = lane_line_probs > 0.3
     road_edge_stds = self._road_edge_stds
     lane_zero = self._lane_lines[0].raw_points
 
     if lane_zero.shape[0] == 0:
+      return
+    if self._carrot_show_lane_info == 1 and not np.any(lane_line_visible):
       return
 
     max_distance = float(np.clip(lane_zero[-1, 0], MIN_DRAW_DISTANCE, MAX_DRAW_DISTANCE))
@@ -957,9 +960,17 @@ class ModelRenderer(Widget):
     draw_double_left = left_lane_line % 10 == 4
 
     lane_vertices = []
-    lane_vertices_double = np.empty((0, 2), dtype=np.float32)
+    empty_vertices = np.empty((0, 2), dtype=np.float32)
+    lane_vertices_double = empty_vertices
 
     for i, lane_line in enumerate(self._lane_lines):
+      # The old path projected and submitted low-confidence lanes with alpha
+      # zero. They cannot affect the framebuffer, so avoid both the projection
+      # work and the draw call while preserving the > 0.3 visibility threshold.
+      if not lane_line_visible[i]:
+        lane_vertices.append(empty_vertices)
+        continue
+
       line_width = 0.025
       if i == 1 and left_lane_line >= 20:
         line_width = 0.05
@@ -980,7 +991,7 @@ class ModelRenderer(Widget):
     for i in range(4):
       if lane_vertices[i].size == 0:
         continue
-      alpha = 220 if lane_line_probs[i] > 0.3 else 0
+      alpha = 220
       stroke = 0.0
       if i == 1:
         color = rl.Color(218, 202, 37, alpha) if left_lane_line >= 20 else rl.Color(255, 255, 255, alpha)
@@ -990,12 +1001,12 @@ class ModelRenderer(Widget):
       else:
         color = rl.Color(255, 255, 255, alpha)
 
-      draw_polygon(self._rect, lane_vertices[i], color)
+      draw_polygon_solid(lane_vertices[i], color)
       if stroke > 0.0:
         self._draw_polygon_outline_carrot(lane_vertices[i], color, stroke)
 
       if i == 1 and draw_double_left and lane_vertices_double.size != 0:
-        draw_polygon(self._rect, lane_vertices_double, color)
+        draw_polygon_solid(lane_vertices_double, color)
         if stroke > 0.0:
           self._draw_polygon_outline_carrot(lane_vertices_double, color, stroke)
 
@@ -1010,7 +1021,7 @@ class ModelRenderer(Widget):
           continue
         temp_f = float(np.clip(road_edge_stds[i] / 2.0, 0.0, 1.0))
         color = rl.Color(int((1.0 - temp_f) * 255.0), 0, int(temp_f * 255.0), 255)
-        draw_polygon(self._rect, road_vertices[i], color)
+        draw_polygon_solid(road_vertices[i], color)
 
 
 
@@ -1651,7 +1662,7 @@ class ModelRenderer(Widget):
     show_path_mode = self._carrot_show_path_mode
 
     if show_path_mode == 0:
-      draw_polygon(self._rect, self._path.projected_points, self._carrot_colors[show_path_color % 10])
+      draw_polygon_solid(self._path.projected_points, self._carrot_colors[show_path_color % 10])
       if show_path_color >= 10 or brake_valid:
         self._draw_polygon_outline_carrot(
           self._path.projected_points,

--- a/openpilot/selfdrive/ui/onroad/model_renderer.py
+++ b/openpilot/selfdrive/ui/onroad/model_renderer.py
@@ -16,6 +16,7 @@ from openpilot.system.ui.widgets import Widget
 CLIP_MARGIN = 500
 MIN_DRAW_DISTANCE = 10.0
 MAX_DRAW_DISTANCE = 100.0
+CARROT_PARAM_REFRESH_INTERVAL = 1.0
 
 LaneChangeState = log.LaneChangeState
 
@@ -58,7 +59,24 @@ class RadarLeadInfo:
   radar: bool = False
   model_prob: float = 0.0
   has_future_point: bool = False
-  
+
+
+@dataclass
+class ModelRenderTimings:
+  path_time_millis: float = 0.0
+  lane_time_millis: float = 0.0
+  blind_spot_time_millis: float = 0.0
+  radar_time_millis: float = 0.0
+  valid: bool = False
+
+  def reset(self) -> None:
+    self.path_time_millis = 0.0
+    self.lane_time_millis = 0.0
+    self.blind_spot_time_millis = 0.0
+    self.radar_time_millis = 0.0
+    self.valid = False
+
+
 class ModelRenderer(Widget):
   def __init__(self):
     super().__init__()
@@ -76,6 +94,7 @@ class ModelRenderer(Widget):
     self._lane_lines = [ModelPoints() for _ in range(4)]
     self._road_edges = [ModelPoints() for _ in range(2)]
     self._acceleration_x = np.empty((0,), dtype=np.float32)
+    self._render_timings = ModelRenderTimings()
 
     # Transform matrix (3x3 for car space to screen space)
     self._car_space_transform = np.zeros((3, 3), dtype=np.float32)
@@ -101,7 +120,12 @@ class ModelRenderer(Widget):
     self._car_space_transform = transform.astype(np.float32)
     self._transform_dirty = True
 
+  @property
+  def render_timings(self) -> ModelRenderTimings:
+    return self._render_timings
+
   def _render(self, rect: rl.Rectangle):
+    self._render_timings.reset()
     sm = ui_state.sm
 
     # Check if data is up-to-date
@@ -140,10 +164,24 @@ class ModelRenderer(Widget):
     # self._draw_lane_lines()
     # self._draw_path(sm)
     # self._draw_lead_indicator()
+    self._draw_carrot_overlays(sm)
+
+  def _draw_carrot_overlays(self, sm) -> None:
+    path_start = time.monotonic_ns()
     self._draw_path_carrot(sm)
+    lane_start = time.monotonic_ns()
     self._draw_lane_lines_carrot(sm)
+    blind_spot_start = time.monotonic_ns()
     self._draw_blind_spot_carrot(sm)
+    radar_start = time.monotonic_ns()
     self._draw_radar_info_carrot(sm)
+    render_end = time.monotonic_ns()
+
+    self._render_timings.path_time_millis = (lane_start - path_start) * 1e-6
+    self._render_timings.lane_time_millis = (blind_spot_start - lane_start) * 1e-6
+    self._render_timings.blind_spot_time_millis = (radar_start - blind_spot_start) * 1e-6
+    self._render_timings.radar_time_millis = (render_end - radar_start) * 1e-6
+    self._render_timings.valid = True
 
   def _update_raw_points(self, model):
     """Update raw 3D points from model data"""
@@ -452,6 +490,7 @@ class ModelRenderer(Widget):
 
 
   def _init_carrot(self):
+    self._carrot_params_next_refresh_time = 0.0
     self._carrot_show_lane_info = 1
     self._carrot_show_radar_info = 0
     self._carrot_radar_lat_factor = 0.5
@@ -520,7 +559,10 @@ class ModelRenderer(Widget):
     ]
 
 
-  def _refresh_carrot_params(self):
+  def _refresh_carrot_params(self, now: float):
+    if now < self._carrot_params_next_refresh_time:
+      return
+
     self._carrot_show_lane_info = ui_state.params.get_int("ShowLaneInfo")
     self._carrot_show_radar_info = ui_state.params.get_int("ShowRadarInfo")
     self._carrot_radar_lat_factor = 0.5
@@ -530,6 +572,7 @@ class ModelRenderer(Widget):
     self._carrot_show_path_mode_lane = ui_state.params.get_int("ShowPathModeLane")
     self._carrot_show_path_color_lane = ui_state.params.get_int("ShowPathColorLane")
     self._carrot_show_path_color_cruise_off = ui_state.params.get_int("ShowPathColorCruiseOff")
+    self._carrot_params_next_refresh_time = now + CARROT_PARAM_REFRESH_INTERVAL
 
 
   def _carrot_interp(self, x: float, xp, fp) -> float:
@@ -899,46 +942,40 @@ class ModelRenderer(Widget):
     if not sm.valid['modelV2'] or not sm.valid['carState']:
       return
 
-    model = sm['modelV2']
     car_state = sm['carState']
+    lane_line_probs = self._lane_line_probs
+    road_edge_stds = self._road_edge_stds
+    lane_zero = self._lane_lines[0].raw_points
 
-    lane_lines_raw = [np.array([ll.x, ll.y, ll.z], dtype=np.float32).T for ll in model.laneLines]
-    road_edges_raw = [np.array([re.x, re.y, re.z], dtype=np.float32).T for re in model.roadEdges]
-    lane_line_probs = np.array(model.laneLineProbs, dtype=np.float32)
-    road_edge_stds = np.array(model.roadEdgeStds, dtype=np.float32)
-
-    if lane_lines_raw[0].shape[0] == 0:
+    if lane_zero.shape[0] == 0:
       return
 
-    max_idx = self._get_path_length_idx(lane_lines_raw[0][:, 0], np.clip(lane_lines_raw[0][-1, 0], MIN_DRAW_DISTANCE, MAX_DRAW_DISTANCE))
+    max_distance = float(np.clip(lane_zero[-1, 0], MIN_DRAW_DISTANCE, MAX_DRAW_DISTANCE))
+    max_idx = self._get_path_length_idx(lane_zero[:, 0], max_distance)
     left_lane_line = car_state.leftLaneLine
     right_lane_line = car_state.rightLaneLine
+    draw_double_left = left_lane_line % 10 == 4
 
     lane_vertices = []
     lane_vertices_double = np.empty((0, 2), dtype=np.float32)
 
-    for i in range(4):
+    for i, lane_line in enumerate(self._lane_lines):
       line_width = 0.025
       if i == 1 and left_lane_line >= 20:
         line_width = 0.05
-      pts = self._map_line_to_polygon(lane_lines_raw[i], line_width, 0.0, max_idx, np.clip(lane_lines_raw[0][-1, 0], MIN_DRAW_DISTANCE, MAX_DRAW_DISTANCE))
+      pts = self._map_line_to_polygon(lane_line.raw_points, line_width, 0.0, max_idx, max_distance)
       lane_vertices.append(pts)
 
-      if i == 1:
+      if i == 1 and draw_double_left:
         lane_vertices_double = self._map_line_to_polygon(
-          lane_lines_raw[i],
+          lane_line.raw_points,
           line_width,
           0.0,
           max_idx,
-          np.clip(lane_lines_raw[0][-1, 0], MIN_DRAW_DISTANCE, MAX_DRAW_DISTANCE),
+          max_distance,
           True,
           -0.3,
         )
-
-    road_vertices = []
-    max_idx_road_edge = self._get_path_length_idx(lane_lines_raw[0][:, 0], 100.0)
-    for i in range(2):
-      road_vertices.append(self._map_line_to_polygon(road_edges_raw[i], 0.025, 0.0, max_idx_road_edge, 100.0))
 
     for i in range(4):
       if lane_vertices[i].size == 0:
@@ -957,12 +994,17 @@ class ModelRenderer(Widget):
       if stroke > 0.0:
         self._draw_polygon_outline_carrot(lane_vertices[i], color, stroke)
 
-      if i == 1 and (left_lane_line % 10 == 4) and lane_vertices_double.size != 0:
+      if i == 1 and draw_double_left and lane_vertices_double.size != 0:
         draw_polygon(self._rect, lane_vertices_double, color)
         if stroke > 0.0:
           self._draw_polygon_outline_carrot(lane_vertices_double, color, stroke)
 
     if self._carrot_show_lane_info > 1:
+      max_idx_road_edge = self._get_path_length_idx(lane_zero[:, 0], 100.0)
+      road_vertices = [
+        self._map_line_to_polygon(road_edge.raw_points, 0.025, 0.0, max_idx_road_edge, 100.0)
+        for road_edge in self._road_edges
+      ]
       for i in range(2):
         if road_vertices[i].size == 0:
           continue
@@ -972,19 +1014,18 @@ class ModelRenderer(Widget):
 
 
 
-  def _update_blind_spot_barriers_carrot(self, sm):
+  def _update_blind_spot_barriers_carrot(self, sm, update_left: bool = True, update_right: bool = True):
     if not sm.valid['modelV2']:
       self._carrot_lane_barrier_vertices[0] = np.empty((0, 2), dtype=np.float32)
       self._carrot_lane_barrier_vertices[1] = np.empty((0, 2), dtype=np.float32)
       return
 
-    model = sm['modelV2']
-    if len(model.position.x) == 0:
+    model_position = self._path.raw_points
+    if model_position.shape[0] == 0:
       self._carrot_lane_barrier_vertices[0] = np.empty((0, 2), dtype=np.float32)
       self._carrot_lane_barrier_vertices[1] = np.empty((0, 2), dtype=np.float32)
       return
 
-    model_position = np.array([model.position.x, model.position.y, model.position.z], dtype=np.float32).T
     max_idx_barrier = self._get_path_length_idx(model_position[:, 0], 40.0)
 
     def build_barrier(y_shift: float) -> np.ndarray:
@@ -1016,8 +1057,10 @@ class ModelRenderer(Widget):
         return np.empty((0, 2), dtype=np.float32)
       return np.array(left_points + right_points, dtype=np.float32)
 
-    self._carrot_lane_barrier_vertices[0] = build_barrier(-1.7)
-    self._carrot_lane_barrier_vertices[1] = build_barrier(1.7)
+    if update_left:
+      self._carrot_lane_barrier_vertices[0] = build_barrier(-1.7)
+    if update_right:
+      self._carrot_lane_barrier_vertices[1] = build_barrier(1.7)
 
 
   def _order_polygon_points_carrot(self, pts: np.ndarray) -> np.ndarray:
@@ -1053,38 +1096,58 @@ class ModelRenderer(Widget):
       self._draw_polygon_from_xy_carrot(xs, ys, color, False, 10)
 
 
+  @staticmethod
+  def _blind_spot_draw_state_carrot(car_state, radar_state, meta) -> tuple[bool, bool, bool, bool]:
+    left_blindspot = bool(car_state.leftBlindspot)
+    right_blindspot = bool(car_state.rightBlindspot)
+
+    lane_change_state = meta.laneChangeState
+    lane_change_direction = str(meta.laneChangeDirection).lower()
+    right_lane_change = lane_change_state == LaneChangeState.preLaneChange and "right" in lane_change_direction
+    left_lane_change = lane_change_state == LaneChangeState.preLaneChange and "left" in lane_change_direction
+
+    assist_distance = float(car_state.vEgo) * 3.0
+    left_assist = (
+      not left_blindspot and radar_state.leadLeft.status and
+      float(radar_state.leadLeft.dRel) < assist_distance and left_lane_change
+    )
+    right_assist = (
+      not right_blindspot and radar_state.leadRight.status and
+      float(radar_state.leadRight.dRel) < assist_distance and right_lane_change
+    )
+    return left_blindspot, right_blindspot, left_assist, right_assist
+
+
   def _draw_blind_spot_carrot(self, sm):
     if not sm.valid['modelV2'] or not sm.valid['carState'] or not sm.valid['radarState']:
       return
-
-    self._update_blind_spot_barriers_carrot(sm)
-
-    warn_color = rl.Color(255, 215, 0, 150)
-    assist_color = rl.Color(0, 204, 0, 150)
 
     car_state = sm['carState']
     radar_state = sm['radarState']
     meta = sm['modelV2'].meta
 
-    left_blindspot = bool(car_state.leftBlindspot)
-    right_blindspot = bool(car_state.rightBlindspot)
+    left_blindspot, right_blindspot, left_assist, right_assist = self._blind_spot_draw_state_carrot(
+      car_state, radar_state, meta,
+    )
+    if not (left_blindspot or right_blindspot or left_assist or right_assist):
+      return
 
-    lead_left = radar_state.leadLeft
-    lead_right = radar_state.leadRight
-
-    lane_change_state = meta.laneChangeState
-    lane_change_direction = str(meta.laneChangeDirection).lower()
-    right_lane_change = (lane_change_state == LaneChangeState.preLaneChange) and ("right" in lane_change_direction)
-    left_lane_change = (lane_change_state == LaneChangeState.preLaneChange) and ("left" in lane_change_direction)
+    warn_color = rl.Color(255, 215, 0, 150)
+    assist_color = rl.Color(0, 204, 0, 150)
+    self._update_blind_spot_barriers_carrot(
+      sm,
+      update_left=left_blindspot or left_assist,
+      update_right=right_blindspot or right_assist,
+    )
 
     if left_blindspot:
       self._draw_blind_spot_segments_carrot(self._carrot_lane_barrier_vertices[0], warn_color)
-    elif lead_left.status and float(lead_left.dRel) < float(car_state.vEgo) * 3.0 and left_lane_change:
+    elif left_assist:
       self._draw_blind_spot_segments_carrot(self._carrot_lane_barrier_vertices[0], assist_color)
 
     if right_blindspot:
       self._draw_blind_spot_segments_carrot(self._carrot_lane_barrier_vertices[1], warn_color)
-    elif lead_right.status and float(lead_right.dRel) < float(car_state.vEgo) * 3.0 and right_lane_change:
+    elif right_assist:
       self._draw_blind_spot_segments_carrot(self._carrot_lane_barrier_vertices[1], assist_color)
 
 
@@ -1554,7 +1617,7 @@ class ModelRenderer(Widget):
 
 
   def _draw_path_carrot(self, sm):
-    self._refresh_carrot_params()
+    self._refresh_carrot_params(rl.get_time())
     if not self._make_path_data_carrot(sm):
       return
 

--- a/openpilot/selfdrive/ui/onroad/model_renderer.py
+++ b/openpilot/selfdrive/ui/onroad/model_renderer.py
@@ -20,11 +20,6 @@ CARROT_PARAM_REFRESH_INTERVAL = 1.0
 
 LaneChangeState = log.LaneChangeState
 
-BLIND_SPOT_LEFT_MASK = 1 << 0
-BLIND_SPOT_RIGHT_MASK = 1 << 1
-BLIND_SPOT_LEFT_ASSIST_MASK = 1 << 2
-BLIND_SPOT_RIGHT_ASSIST_MASK = 1 << 3
-
 THROTTLE_COLORS = [
   rl.Color(13, 248, 122, 102),   # HSLF(148/360, 0.94, 0.51, 0.4)
   rl.Color(114, 255, 92, 89),    # HSLF(112/360, 1.0, 0.68, 0.35)
@@ -66,26 +61,6 @@ class RadarLeadInfo:
   has_future_point: bool = False
 
 
-@dataclass
-class ModelRenderTimings:
-  path_time_millis: float = 0.0
-  lane_time_millis: float = 0.0
-  blind_spot_time_millis: float = 0.0
-  radar_time_millis: float = 0.0
-  valid: bool = False
-  blind_spot_state_mask: int = 0
-  blind_spot_state_valid: bool = False
-
-  def reset(self) -> None:
-    self.path_time_millis = 0.0
-    self.lane_time_millis = 0.0
-    self.blind_spot_time_millis = 0.0
-    self.radar_time_millis = 0.0
-    self.valid = False
-    self.blind_spot_state_mask = 0
-    self.blind_spot_state_valid = False
-
-
 class ModelRenderer(Widget):
   def __init__(self):
     super().__init__()
@@ -103,7 +78,6 @@ class ModelRenderer(Widget):
     self._lane_lines = [ModelPoints() for _ in range(4)]
     self._road_edges = [ModelPoints() for _ in range(2)]
     self._acceleration_x = np.empty((0,), dtype=np.float32)
-    self._render_timings = ModelRenderTimings()
 
     # Transform matrix (3x3 for car space to screen space)
     self._car_space_transform = np.zeros((3, 3), dtype=np.float32)
@@ -129,12 +103,7 @@ class ModelRenderer(Widget):
     self._car_space_transform = transform.astype(np.float32)
     self._transform_dirty = True
 
-  @property
-  def render_timings(self) -> ModelRenderTimings:
-    return self._render_timings
-
   def _render(self, rect: rl.Rectangle):
-    self._render_timings.reset()
     sm = ui_state.sm
 
     # Check if data is up-to-date
@@ -176,23 +145,10 @@ class ModelRenderer(Widget):
     self._draw_carrot_overlays(sm)
 
   def _draw_carrot_overlays(self, sm) -> None:
-    path_start = time.monotonic_ns()
     self._draw_path_carrot(sm)
-    lane_start = time.monotonic_ns()
     self._draw_lane_lines_carrot(sm)
-    blind_spot_start = time.monotonic_ns()
-    blind_spot_state_mask, blind_spot_state_valid = self._draw_blind_spot_carrot(sm)
-    radar_start = time.monotonic_ns()
+    self._draw_blind_spot_carrot(sm)
     self._draw_radar_info_carrot(sm)
-    render_end = time.monotonic_ns()
-
-    self._render_timings.path_time_millis = (lane_start - path_start) * 1e-6
-    self._render_timings.lane_time_millis = (blind_spot_start - lane_start) * 1e-6
-    self._render_timings.blind_spot_time_millis = (radar_start - blind_spot_start) * 1e-6
-    self._render_timings.radar_time_millis = (render_end - radar_start) * 1e-6
-    self._render_timings.valid = True
-    self._render_timings.blind_spot_state_mask = blind_spot_state_mask
-    self._render_timings.blind_spot_state_valid = blind_spot_state_valid
 
   def _update_raw_points(self, model):
     """Update raw 3D points from model data"""
@@ -1173,28 +1129,10 @@ class ModelRenderer(Widget):
     return left_blindspot, right_blindspot, left_assist, right_assist
 
 
-  @staticmethod
-  def _blind_spot_state_mask_carrot(
-    left_blindspot: bool,
-    right_blindspot: bool,
-    left_assist: bool,
-    right_assist: bool,
-  ) -> int:
-    return (
-      (BLIND_SPOT_LEFT_MASK if left_blindspot else 0) |
-      (BLIND_SPOT_RIGHT_MASK if right_blindspot else 0) |
-      (BLIND_SPOT_LEFT_ASSIST_MASK if left_assist else 0) |
-      (BLIND_SPOT_RIGHT_ASSIST_MASK if right_assist else 0)
-    )
-
-
-  def _draw_blind_spot_carrot(self, sm) -> tuple[int, bool]:
+  def _draw_blind_spot_carrot(self, sm) -> None:
     input_services = ("modelV2", "carState", "radarState")
     if not all(sm.valid[service] for service in input_services):
-      return 0, False
-    # Match the actual draw gate. A temporarily non-alive service can still
-    # render its last valid sample, so that executed branch remains attributable.
-    state_valid = True
+      return
 
     car_state = sm['carState']
     radar_state = sm['radarState']
@@ -1203,11 +1141,8 @@ class ModelRenderer(Widget):
     left_blindspot, right_blindspot, left_assist, right_assist = self._blind_spot_draw_state_carrot(
       car_state, radar_state, meta,
     )
-    state_mask = self._blind_spot_state_mask_carrot(
-      left_blindspot, right_blindspot, left_assist, right_assist,
-    )
     if not (left_blindspot or right_blindspot or left_assist or right_assist):
-      return state_mask, state_valid
+      return
 
     warn_color = rl.Color(255, 215, 0, 150)
     assist_color = rl.Color(0, 204, 0, 150)
@@ -1226,8 +1161,6 @@ class ModelRenderer(Widget):
       self._draw_blind_spot_segments_carrot(self._carrot_lane_barrier_vertices[1], warn_color)
     elif right_assist:
       self._draw_blind_spot_segments_carrot(self._carrot_lane_barrier_vertices[1], assist_color)
-
-    return state_mask, state_valid
 
 
   def _draw_radar_info_carrot(self, sm):

--- a/openpilot/selfdrive/ui/onroad/model_renderer.py
+++ b/openpilot/selfdrive/ui/onroad/model_renderer.py
@@ -124,31 +124,22 @@ class ModelRenderer(Widget):
       self._longitudinal_control = sm['carParams'].openpilotLongitudinalControl
 
     model = sm['modelV2']
-    radar_state = sm['radarState'] if sm.valid['radarState'] else None
-    lead_one = radar_state.leadOne if radar_state else None
-    render_lead_indicator = self._longitudinal_control and radar_state is not None
+    if sm.updated['modelV2']:
+      self._update_raw_points(model)
 
-    # Update model data when needed
-    model_updated = sm.updated['modelV2']
-    if model_updated or sm.updated['radarState'] or self._transform_dirty:
-      if model_updated:
-        self._update_raw_points(model)
+    if self._path.raw_points.shape[0] == 0:
+      return
 
-      path_x_array = self._path.raw_points[:, 0]
-      if path_x_array.size == 0:
-        return
+    # The Carrot renderers below rebuild all projected geometry they consume.
+    # The legacy _update_model/_update_leads results only feed the disabled draw
+    # calls, and _draw_path_carrot immediately replaces path.projected_points.
+    self._transform_dirty = False
 
-      self._update_model(lead_one, path_x_array)
-      if render_lead_indicator:
-        self._update_leads(radar_state, path_x_array)
-      self._transform_dirty = False
-
-    # Draw elements
-    #self._draw_lane_lines()
-    #self._draw_path(sm)
-
-    #if render_lead_indicator and radar_state:
-    #  self._draw_lead_indicator()
+    # Legacy renderers are intentionally disabled. Restore their update pipeline
+    # together with these draw calls if they are ever enabled again.
+    # self._draw_lane_lines()
+    # self._draw_path(sm)
+    # self._draw_lead_indicator()
     self._draw_path_carrot(sm)
     self._draw_lane_lines_carrot(sm)
     self._draw_blind_spot_carrot(sm)

--- a/openpilot/selfdrive/ui/tests/test_carrot_hud_renderer.py
+++ b/openpilot/selfdrive/ui/tests/test_carrot_hud_renderer.py
@@ -1,0 +1,482 @@
+import ast
+import importlib.util
+import sys
+import time as stdlib_time
+import types
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+HUD_RENDERER_PATH = Path(__file__).parents[1] / "onroad" / "hud_renderer.py"
+
+
+@pytest.fixture
+def hud_module(monkeypatch):
+  @dataclass(frozen=True)
+  class Color:
+    r: int
+    g: int
+    b: int
+    a: int
+
+  @dataclass
+  class Rectangle:
+    x: float
+    y: float
+    width: float
+    height: float
+
+  @dataclass
+  class Vector2:
+    x: float
+    y: float
+
+  raylib = types.ModuleType("pyray")
+  raylib.Color = Color
+  raylib.Rectangle = Rectangle
+  raylib.Vector2 = Vector2
+  raylib.WHITE = Color(255, 255, 255, 255)
+  raylib.BLACK = Color(0, 0, 0, 255)
+  raylib.BLANK = Color(0, 0, 0, 0)
+  raylib.GREEN = Color(0, 255, 0, 255)
+  raylib.YELLOW = Color(255, 255, 0, 255)
+  for name in (
+    "draw_line_ex",
+    "draw_rectangle_gradient_v",
+    "draw_rectangle_rounded",
+    "draw_rectangle_rounded_lines_ex",
+    "draw_text_ex",
+    "draw_texture_pro",
+  ):
+    setattr(raylib, name, lambda *args, **kwargs: None)
+
+  class FakeExpButton:
+    def __init__(self, *args):
+      self.is_pressed = False
+
+    def render(self, rect):
+      pass
+
+  class Widget:
+    def __init__(self):
+      pass
+
+  fake_ui_state = SimpleNamespace(
+    params=None,
+    sm=None,
+    started_frame=0,
+    status=0,
+    is_metric=True,
+  )
+  gui_app = SimpleNamespace(
+    font=lambda weight: ("font", weight),
+    texture=lambda path: ("texture", path),
+  )
+
+  stubs = {
+    "pyray": raylib,
+    "openpilot.common.constants": SimpleNamespace(
+      CV=SimpleNamespace(MS_TO_KPH=3.6, MS_TO_MPH=2.2369362920544),
+    ),
+    "openpilot.selfdrive.ui.onroad.exp_button": SimpleNamespace(ExpButton=FakeExpButton),
+    "openpilot.selfdrive.ui.ui_state": SimpleNamespace(
+      ui_state=fake_ui_state,
+      UIStatus=SimpleNamespace(ENGAGED=1, DISENGAGED=2, OVERRIDE=3),
+    ),
+    "openpilot.system.ui.lib.application": SimpleNamespace(
+      gui_app=gui_app,
+      FontWeight=SimpleNamespace(SEMI_BOLD=1, BOLD=2, MEDIUM=3, DISPLAY=4),
+    ),
+    "openpilot.system.ui.lib.multilang": SimpleNamespace(tr=lambda text: text),
+    "openpilot.system.ui.lib.text_measure": SimpleNamespace(
+      measure_text_cached=lambda font, text, size: Vector2(len(text) * size, size),
+    ),
+    "openpilot.system.ui.lib.text_draw": SimpleNamespace(draw_text_ui_style=lambda *args, **kwargs: None),
+    "openpilot.system.ui.widgets": SimpleNamespace(Widget=Widget),
+  }
+  for name, stub in stubs.items():
+    monkeypatch.setitem(sys.modules, name, stub)
+
+  module_name = f"_test_carrot_hud_renderer_{id(fake_ui_state)}"
+  spec = importlib.util.spec_from_file_location(module_name, HUD_RENDERER_PATH)
+  assert spec is not None and spec.loader is not None
+  module = importlib.util.module_from_spec(spec)
+  monkeypatch.setitem(sys.modules, module_name, module)
+  spec.loader.exec_module(module)
+  return module, fake_ui_state
+
+
+class FakeParams:
+  def __init__(self, values, failures=None):
+    self.values = values
+    self.failures = dict(failures or {})
+    self.calls = []
+
+  def get_int(self, key):
+    self.calls.append(key)
+    if self.failures.get(key, 0) > 0:
+      self.failures[key] -= 1
+      raise RuntimeError(f"failed to read {key}")
+    return self.values[key]
+
+
+def make_param_renderer(module, *, next_refresh=0.0):
+  renderer = object.__new__(module.HudRenderer)
+  renderer._hud_params_next_refresh_time = next_refresh
+  renderer._show_device_state = 91
+  renderer._show_date_time = 92
+  renderer._show_plot_mode = 93
+  renderer._longitudinal_personality = 94
+  return renderer
+
+
+def test_direct_hud_param_reads_are_isolated_to_refresh():
+  tree = ast.parse(HUD_RENDERER_PATH.read_text(encoding="utf-8"))
+  reads = []
+
+  for function in (node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)):
+    for call in (node for node in ast.walk(function) if isinstance(node, ast.Call)):
+      func = call.func
+      if (
+        isinstance(func, ast.Attribute)
+        and func.attr == "get_int"
+        and isinstance(func.value, ast.Attribute)
+        and func.value.attr == "params"
+        and isinstance(func.value.value, ast.Name)
+        and func.value.value.id == "ui_state"
+      ):
+        assert len(call.args) == 1 and isinstance(call.args[0], ast.Constant)
+        reads.append((function.name, call.args[0].value))
+
+  assert reads == [
+    ("_refresh_hud_params", "ShowDeviceState"),
+    ("_refresh_hud_params", "ShowDateTime"),
+    ("_refresh_hud_params", "ShowPlotMode"),
+    ("_refresh_hud_params", "LongitudinalPersonality"),
+  ]
+
+
+def test_hud_render_timings_reset(hud_module):
+  module, _ = hud_module
+  timings = module.HudRenderTimings(1, 2, 3, 4, 5, 6, 7, True)
+
+  timings.reset()
+
+  assert timings == module.HudRenderTimings()
+
+
+def test_initial_cruise_gap_preserves_legacy_fallback(hud_module):
+  module, _ = hud_module
+
+  renderer = module.HudRenderer()
+
+  assert renderer._longitudinal_personality == 7
+  assert renderer._get_cruise_gap() == 8
+
+
+def test_hud_params_are_refreshed_once_per_interval(hud_module):
+  module, fake_ui_state = hud_module
+  params = FakeParams({
+    "ShowDeviceState": 1,
+    "ShowDateTime": 2,
+    "ShowPlotMode": 3,
+    "LongitudinalPersonality": 4,
+  })
+  fake_ui_state.params = params
+  renderer = make_param_renderer(module)
+
+  renderer._refresh_hud_params(0.0)
+  assert (
+    renderer._show_device_state,
+    renderer._show_date_time,
+    renderer._show_plot_mode,
+    renderer._longitudinal_personality,
+  ) == (1, 2, 3, 4)
+  assert renderer._hud_params_next_refresh_time == 1.0
+  assert params.calls == [
+    "ShowDeviceState",
+    "ShowDateTime",
+    "ShowPlotMode",
+    "LongitudinalPersonality",
+  ]
+
+  renderer._refresh_hud_params(0.999)
+  assert len(params.calls) == 4
+
+  renderer._refresh_hud_params(1.0)
+  assert len(params.calls) == 8
+  assert renderer._hud_params_next_refresh_time == 2.0
+
+
+def test_show_param_failure_keeps_complete_snapshot_and_retries(hud_module):
+  module, fake_ui_state = hud_module
+  params = FakeParams({
+    "ShowDeviceState": 1,
+    "ShowDateTime": 2,
+    "ShowPlotMode": 3,
+    "LongitudinalPersonality": 4,
+  }, failures={"ShowDateTime": 1})
+  fake_ui_state.params = params
+  renderer = make_param_renderer(module)
+
+  renderer._refresh_hud_params(0.0)
+
+  assert (
+    renderer._show_device_state,
+    renderer._show_date_time,
+    renderer._show_plot_mode,
+    renderer._longitudinal_personality,
+  ) == (91, 92, 93, 94)
+  assert renderer._hud_params_next_refresh_time == 0.0
+  assert params.calls == ["ShowDeviceState", "ShowDateTime"]
+
+  renderer._refresh_hud_params(0.1)
+  assert (
+    renderer._show_device_state,
+    renderer._show_date_time,
+    renderer._show_plot_mode,
+    renderer._longitudinal_personality,
+  ) == (1, 2, 3, 4)
+  assert renderer._hud_params_next_refresh_time == pytest.approx(1.1)
+
+
+def test_personality_failure_uses_gap_eight_and_retries_next_frame(hud_module):
+  module, fake_ui_state = hud_module
+  params = FakeParams({
+    "ShowDeviceState": 1,
+    "ShowDateTime": 2,
+    "ShowPlotMode": 3,
+    "LongitudinalPersonality": 4,
+  }, failures={"LongitudinalPersonality": 1})
+  fake_ui_state.params = params
+  renderer = make_param_renderer(module)
+
+  renderer._refresh_hud_params(0.0)
+
+  assert (renderer._show_device_state, renderer._show_date_time, renderer._show_plot_mode) == (1, 2, 3)
+  assert renderer._get_cruise_gap() == 8
+  assert renderer._hud_params_next_refresh_time == 0.0
+
+  renderer._refresh_hud_params(0.1)
+  assert renderer._get_cruise_gap() == 5
+  assert renderer._hud_params_next_refresh_time == pytest.approx(1.1)
+  assert params.calls.count("LongitudinalPersonality") == 2
+
+
+def test_speed_limit_snapshot_reads_submaster_once(hud_module):
+  module, fake_ui_state = hud_module
+  carrot_man = SimpleNamespace(xSpdLimit="80", xSignType=2.0, nRoadLimitSpeed=90)
+
+  class CountingSubMaster:
+    def __init__(self):
+      self.calls = 0
+
+    def __getitem__(self, key):
+      assert key == "carrotMan"
+      self.calls += 1
+      if self.calls > 1:
+        raise AssertionError("carrotMan was read more than once")
+      return carrot_man
+
+  fake_ui_state.sm = CountingSubMaster()
+  renderer = object.__new__(module.HudRenderer)
+
+  assert renderer._get_speed_limit_info() == (80, 2, 90)
+  assert fake_ui_state.sm.calls == 1
+
+
+def test_speed_panel_reuses_one_snapshot_and_records_subsection_timings(hud_module, monkeypatch):
+  module, _ = hud_module
+  renderer = object.__new__(module.HudRenderer)
+  renderer._render_timings = module.HudRenderTimings()
+  renderer._blink_timer = 15
+  renderer._disp_timer = 63
+  speed_limit_info = (80, 2, 90)
+  snapshots = []
+  calls = []
+
+  monkeypatch.setattr(renderer, "_get_speed_limit_info", lambda: calls.append("snapshot") or speed_limit_info)
+  monkeypatch.setattr(renderer, "_draw_carrot_main_background", lambda bx, by, info: (calls.append("background"), snapshots.append(info)))
+  monkeypatch.setattr(renderer, "_draw_carrot_traffic_light", lambda bx, by: calls.append("traffic"))
+  monkeypatch.setattr(renderer, "_draw_carrot_speed_panel", lambda bx, by: calls.append("speed"))
+  monkeypatch.setattr(renderer, "_draw_carrot_lower_status", lambda bx, by: calls.append("status"))
+  monkeypatch.setattr(renderer, "_draw_carrot_speed_limit_box", lambda bx, by, info: (calls.append("limit"), snapshots.append(info)))
+  monkeypatch.setattr(renderer, "_draw_carrot_device_state", lambda bx, by: calls.append("device"))
+  monkeypatch.setattr(renderer, "_draw_turn_info_hud", lambda rect: calls.append("navigation"))
+  timestamps = iter((0, 10_000_000, 13_000_000, 20_000_000))
+  monkeypatch.setattr(module.time, "monotonic_ns", lambda: next(timestamps))
+
+  renderer._draw_set_speed_carrot(module.rl.Rectangle(10, 20, 1000, 600))
+
+  assert calls == ["snapshot", "background", "traffic", "speed", "status", "limit", "device", "navigation"]
+  assert snapshots[0] is speed_limit_info
+  assert snapshots[1] is speed_limit_info
+  assert renderer._blink_timer == 0
+  assert renderer._disp_timer == 0
+  assert renderer._render_timings.speed_time_millis == pytest.approx(10.0)
+  assert renderer._render_timings.status_time_millis == pytest.approx(3.0)
+  assert renderer._render_timings.navigation_time_millis == pytest.approx(7.0)
+
+
+def test_device_info_updates_only_on_first_frame_or_new_service_frame(hud_module, monkeypatch):
+  module, fake_ui_state = hud_module
+  renderer = object.__new__(module.HudRenderer)
+  renderer._device_info_loaded = False
+  renderer._device_info_recv_frames = (-1, -1)
+  renderer.is_cruise_set = True
+  renderer.set_speed = 10
+  renderer.speed = 20
+  fake_ui_state.started_frame = 2
+  fake_ui_state.sm = SimpleNamespace(
+    recv_frame={"carState": 1, "deviceState": 10, "peripheralState": 20},
+  )
+  refreshes = []
+
+  def update_device_info():
+    refreshes.append(True)
+    renderer._device_info_loaded = True
+
+  monkeypatch.setattr(renderer, "_update_device_info", update_device_info)
+
+  renderer._update_state()
+  assert len(refreshes) == 1
+
+  renderer._update_state()
+  assert len(refreshes) == 1
+
+  fake_ui_state.sm.recv_frame["deviceState"] = 11
+  renderer._update_state()
+  assert len(refreshes) == 2
+
+  fake_ui_state.sm.recv_frame["peripheralState"] = 21
+  renderer._update_state()
+  assert len(refreshes) == 3
+
+
+def test_incomplete_device_info_is_retried(hud_module):
+  module, fake_ui_state = hud_module
+  renderer = object.__new__(module.HudRenderer)
+  device_state = SimpleNamespace(
+    freeSpacePercent=55.0,
+    memoryUsagePercent=20,
+    cpuUsagePercent=[10.0, 20.0],
+  )
+  peripheral_state = SimpleNamespace(voltage=12_500)
+  fake_ui_state.sm = {
+    "deviceState": device_state,
+    "peripheralState": peripheral_state,
+  }
+
+  renderer._update_device_info()
+  assert renderer._device_info_loaded is False
+
+  device_state.cpuTempC = [40.0, 42.0]
+  renderer._update_device_info()
+  assert renderer._device_info_loaded is True
+  assert renderer._cpu_temp == pytest.approx(41.0)
+  assert renderer._cpu_usage == pytest.approx(15.0)
+  assert renderer._voltage == pytest.approx(12.5)
+
+
+def test_date_text_formats_only_when_minute_key_changes(hud_module, monkeypatch):
+  module, _ = hud_module
+  renderer = object.__new__(module.HudRenderer)
+  renderer._show_date_time = 1
+  renderer._date_time_minute_key = None
+  renderer._date_time_text = ""
+  renderer._date_text = ""
+  renderer._font_display = object()
+  moments = iter((
+    stdlib_time.struct_time((2026, 7, 16, 12, 1, 1, 3, 197, 0)),
+    stdlib_time.struct_time((2026, 7, 16, 12, 1, 59, 3, 197, 0)),
+    stdlib_time.struct_time((2026, 7, 16, 12, 2, 0, 3, 197, 0)),
+    stdlib_time.struct_time((2026, 7, 16, 13, 2, 0, 3, 197, 0)),
+  ))
+  localtime_calls = []
+  strftime_calls = []
+  draw_calls = []
+
+  def fake_localtime():
+    localtime_calls.append(True)
+    return next(moments)
+
+  def fake_strftime(fmt, now):
+    strftime_calls.append((fmt, now.tm_hour, now.tm_min))
+    return f"{fmt}:{now.tm_hour:02d}:{now.tm_min:02d}"
+
+  monkeypatch.setattr(module.time, "localtime", fake_localtime)
+  monkeypatch.setattr(module.time, "strftime", fake_strftime)
+  monkeypatch.setattr(module, "draw_text_ui_style", lambda *args, **kwargs: draw_calls.append((args, kwargs)))
+  rect = module.rl.Rectangle(0, 0, 1000, 600)
+
+  for _ in range(4):
+    renderer._draw_date_time(rect)
+
+  assert len(localtime_calls) == 4
+  assert len(strftime_calls) == 6
+  assert strftime_calls == [
+    ("%H:%M", 12, 1), ("%m-%d", 12, 1),
+    ("%H:%M", 12, 2), ("%m-%d", 12, 2),
+    ("%H:%M", 13, 2), ("%m-%d", 13, 2),
+  ]
+  assert len(draw_calls) == 8
+  assert renderer._date_time_minute_key == (2026, 197, 13, 2, 0)
+  assert renderer._date_text.endswith(f"({module.WEEKDAYS_KO[4]})")
+
+  renderer._show_date_time = 0
+  monkeypatch.setattr(module.time, "localtime", lambda: pytest.fail("hidden date HUD read the clock"))
+  renderer._draw_date_time(rect)
+  assert len(draw_calls) == 8
+
+
+def test_render_resets_and_publishes_exact_frame_timings(hud_module, monkeypatch):
+  module, _ = hud_module
+  renderer = object.__new__(module.HudRenderer)
+  renderer._render_timings = module.HudRenderTimings(99, 99, 99, 99, 99, 99, 99, True)
+  renderer.is_cruise_available = False
+  renderer._show_plot_mode = 6
+  renderer._font_display = object()
+  calls = []
+
+  renderer._exp_button = SimpleNamespace(render=lambda rect: calls.append("button"))
+  renderer._plot_renderer = SimpleNamespace(
+    draw=lambda rect, font, mode: calls.append(("plot", mode)),
+  )
+  monkeypatch.setattr(renderer, "_refresh_hud_params", lambda now: calls.append(("params", now)))
+  monkeypatch.setattr(renderer, "_draw_date_time", lambda rect: calls.append("date"))
+  monkeypatch.setattr(renderer, "_draw_tpms_top_right", lambda rect: calls.append("tpms"))
+  monkeypatch.setattr(renderer, "_draw_cruise_speed_animation", lambda rect: calls.append("animation"))
+  monkeypatch.setattr(module.rl, "draw_rectangle_gradient_v", lambda *args: calls.append("header"))
+  monkeypatch.setattr(module.time, "monotonic", lambda: 12.5)
+  timestamps = iter((
+    0, 2_000_000,
+    10_000_000, 13_000_000,
+    20_000_000, 25_000_000,
+    30_000_000, 37_000_000,
+  ))
+  monkeypatch.setattr(module.time, "monotonic_ns", lambda: next(timestamps))
+
+  renderer._render(module.rl.Rectangle(0, 0, 1000, 600))
+
+  assert calls == [
+    ("params", 12.5),
+    "header",
+    "button",
+    ("plot", 6),
+    "date",
+    "tpms",
+    "animation",
+  ]
+  assert renderer._render_timings == module.HudRenderTimings(
+    header_time_millis=2.0,
+    speed_time_millis=0.0,
+    status_time_millis=0.0,
+    navigation_time_millis=0.0,
+    button_time_millis=3.0,
+    plot_time_millis=5.0,
+    aux_time_millis=7.0,
+    valid=True,
+  )

--- a/openpilot/selfdrive/ui/tests/test_carrot_hud_renderer.py
+++ b/openpilot/selfdrive/ui/tests/test_carrot_hud_renderer.py
@@ -159,13 +159,19 @@ def test_direct_hud_param_reads_are_isolated_to_refresh():
   ]
 
 
-def test_hud_render_timings_reset(hud_module):
-  module, _ = hud_module
-  timings = module.HudRenderTimings(1, 2, 3, 4, 5, 6, 7, True)
+def test_hud_renderer_has_no_subsection_profiling():
+  tree = ast.parse(HUD_RENDERER_PATH.read_text(encoding="utf-8"))
 
-  timings.reset()
-
-  assert timings == module.HudRenderTimings()
+  assert not any(
+    isinstance(node, ast.ClassDef) and node.name == "HudRenderTimings"
+    for node in ast.walk(tree)
+  )
+  assert not any(
+    isinstance(node, ast.Call)
+    and isinstance(node.func, ast.Attribute)
+    and node.func.attr == "monotonic_ns"
+    for node in ast.walk(tree)
+  )
 
 
 def test_initial_cruise_gap_preserves_legacy_fallback(hud_module):
@@ -288,10 +294,9 @@ def test_speed_limit_snapshot_reads_submaster_once(hud_module):
   assert fake_ui_state.sm.calls == 1
 
 
-def test_speed_panel_reuses_one_snapshot_and_records_subsection_timings(hud_module, monkeypatch):
+def test_speed_panel_reuses_one_snapshot(hud_module, monkeypatch):
   module, _ = hud_module
   renderer = object.__new__(module.HudRenderer)
-  renderer._render_timings = module.HudRenderTimings()
   renderer._blink_timer = 15
   renderer._disp_timer = 63
   speed_limit_info = (80, 2, 90)
@@ -306,8 +311,6 @@ def test_speed_panel_reuses_one_snapshot_and_records_subsection_timings(hud_modu
   monkeypatch.setattr(renderer, "_draw_carrot_speed_limit_box", lambda bx, by, info: (calls.append("limit"), snapshots.append(info)))
   monkeypatch.setattr(renderer, "_draw_carrot_device_state", lambda bx, by: calls.append("device"))
   monkeypatch.setattr(renderer, "_draw_turn_info_hud", lambda rect: calls.append("navigation"))
-  timestamps = iter((0, 10_000_000, 13_000_000, 20_000_000))
-  monkeypatch.setattr(module.time, "monotonic_ns", lambda: next(timestamps))
 
   renderer._draw_set_speed_carrot(module.rl.Rectangle(10, 20, 1000, 600))
 
@@ -316,9 +319,6 @@ def test_speed_panel_reuses_one_snapshot_and_records_subsection_timings(hud_modu
   assert snapshots[1] is speed_limit_info
   assert renderer._blink_timer == 0
   assert renderer._disp_timer == 0
-  assert renderer._render_timings.speed_time_millis == pytest.approx(10.0)
-  assert renderer._render_timings.status_time_millis == pytest.approx(3.0)
-  assert renderer._render_timings.navigation_time_millis == pytest.approx(7.0)
 
 
 def test_device_info_updates_only_on_first_frame_or_new_service_frame(hud_module, monkeypatch):
@@ -542,10 +542,9 @@ def test_date_text_formats_only_when_minute_key_changes(hud_module, monkeypatch)
   assert len(draw_calls) == 8
 
 
-def test_render_resets_and_publishes_exact_frame_timings(hud_module, monkeypatch):
+def test_render_draws_each_hud_section_in_order(hud_module, monkeypatch):
   module, _ = hud_module
   renderer = object.__new__(module.HudRenderer)
-  renderer._render_timings = module.HudRenderTimings(99, 99, 99, 99, 99, 99, 99, True)
   renderer.is_cruise_available = False
   renderer._show_plot_mode = 6
   renderer._font_display = object()
@@ -561,13 +560,6 @@ def test_render_resets_and_publishes_exact_frame_timings(hud_module, monkeypatch
   monkeypatch.setattr(renderer, "_draw_cruise_speed_animation", lambda rect: calls.append("animation"))
   monkeypatch.setattr(module.rl, "draw_rectangle_gradient_v", lambda *args: calls.append("header"))
   monkeypatch.setattr(module.time, "monotonic", lambda: 12.5)
-  timestamps = iter((
-    0, 2_000_000,
-    10_000_000, 13_000_000,
-    20_000_000, 25_000_000,
-    30_000_000, 37_000_000,
-  ))
-  monkeypatch.setattr(module.time, "monotonic_ns", lambda: next(timestamps))
 
   renderer._render(module.rl.Rectangle(0, 0, 1000, 600))
 
@@ -580,13 +572,3 @@ def test_render_resets_and_publishes_exact_frame_timings(hud_module, monkeypatch
     "tpms",
     "animation",
   ]
-  assert renderer._render_timings == module.HudRenderTimings(
-    header_time_millis=2.0,
-    speed_time_millis=0.0,
-    status_time_millis=0.0,
-    navigation_time_millis=0.0,
-    button_time_millis=3.0,
-    plot_time_millis=5.0,
-    aux_time_millis=7.0,
-    valid=True,
-  )

--- a/openpilot/selfdrive/ui/tests/test_carrot_hud_renderer.py
+++ b/openpilot/selfdrive/ui/tests/test_carrot_hud_renderer.py
@@ -356,6 +356,62 @@ def test_device_info_updates_only_on_first_frame_or_new_service_frame(hud_module
   assert len(refreshes) == 3
 
 
+def test_device_display_cache_follows_service_receive_frames(hud_module):
+  module, fake_ui_state = hud_module
+  renderer = object.__new__(module.HudRenderer)
+  renderer._device_info_loaded = False
+  renderer._device_info_recv_frames = (-1, -1)
+  renderer.is_cruise_set = True
+  renderer.set_speed = 10
+  renderer.speed = 20
+  device_state = SimpleNamespace(
+    freeSpacePercent=55.0,
+    memoryUsagePercent=20,
+    cpuTempC=[40.0, 42.0],
+    cpuUsagePercent=[10.0, 20.0],
+  )
+  peripheral_state = SimpleNamespace(voltage=12_500)
+
+  class FakeSubMaster(dict):
+    pass
+
+  sm = FakeSubMaster(deviceState=device_state, peripheralState=peripheral_state)
+  sm.recv_frame = {"carState": 1, "deviceState": 10, "peripheralState": 20}
+  fake_ui_state.started_frame = 2
+  fake_ui_state.sm = sm
+
+  renderer._update_state()
+  assert renderer._device_info_recv_frames == (10, 20)
+  assert (
+    renderer._cpu_temp_text,
+    renderer._memory_usage_text,
+    renderer._disk_usage_text,
+    renderer._voltage_text,
+  ) == ("41°C", "20%", "45%", "12.5V")
+
+  device_state.cpuTempC = [50.0]
+  device_state.memoryUsagePercent = 30
+  device_state.freeSpacePercent = 40.0
+  peripheral_state.voltage = 13_250
+  renderer._update_state()
+  assert (
+    renderer._cpu_temp_text,
+    renderer._memory_usage_text,
+    renderer._disk_usage_text,
+    renderer._voltage_text,
+  ) == ("41°C", "20%", "45%", "12.5V")
+
+  sm.recv_frame["deviceState"] = 11
+  renderer._update_state()
+  assert renderer._device_info_recv_frames == (11, 20)
+  assert (
+    renderer._cpu_temp_text,
+    renderer._memory_usage_text,
+    renderer._disk_usage_text,
+    renderer._voltage_text,
+  ) == ("50°C", "30%", "60%", "13.2V")
+
+
 def test_incomplete_device_info_is_retried(hud_module):
   module, fake_ui_state = hud_module
   renderer = object.__new__(module.HudRenderer)
@@ -379,6 +435,60 @@ def test_incomplete_device_info_is_retried(hud_module):
   assert renderer._cpu_temp == pytest.approx(41.0)
   assert renderer._cpu_usage == pytest.approx(15.0)
   assert renderer._voltage == pytest.approx(12.5)
+  assert renderer._cpu_temp_text == "41°C"
+  assert renderer._memory_usage_text == "20%"
+  assert renderer._disk_usage_text == "45%"
+  assert renderer._voltage_text == "12.5V"
+
+
+def test_round_box_reuses_scratch_rectangle_without_changing_draw_geometry(hud_module, monkeypatch):
+  module, _ = hud_module
+  renderer = object.__new__(module.HudRenderer)
+  renderer._round_box_rect = module.rl.Rectangle(0, 0, 0, 0)
+  fill_color = module.rl.Color(1, 2, 3, 4)
+  line_color = module.rl.Color(5, 6, 7, 8)
+  calls = []
+
+  def snapshot(kind, rect, *args):
+    calls.append((kind, id(rect), (rect.x, rect.y, rect.width, rect.height), args))
+
+  monkeypatch.setattr(module.rl, "draw_rectangle_rounded", lambda rect, *args: snapshot("fill", rect, *args))
+  monkeypatch.setattr(module.rl, "draw_rectangle_rounded_lines_ex", lambda rect, *args: snapshot("line", rect, *args))
+
+  renderer._draw_round_box(1, 2, 3, 4, fill_color, line_color, 0.25, 8, 2)
+  renderer._draw_round_box(5, 6, 7, 8, fill_color, line_color, 0.5, 4, 3)
+
+  assert [call[0] for call in calls] == ["fill", "line", "fill", "line"]
+  assert len({call[1] for call in calls}) == 1
+  assert [call[2] for call in calls] == [
+    (1.0, 2.0, 3.0, 4.0),
+    (1.0, 2.0, 3.0, 4.0),
+    (5.0, 6.0, 7.0, 8.0),
+    (5.0, 6.0, 7.0, 8.0),
+  ]
+  assert calls[0][3] == (0.25, 8, fill_color)
+  assert calls[1][3] == (0.25, 8, 2.0, line_color)
+  assert calls[2][3] == (0.5, 4, fill_color)
+  assert calls[3][3] == (0.5, 4, 3.0, line_color)
+
+
+@pytest.mark.parametrize(("value", "expected_text", "expected_color_name"), (
+  (4.9, "  -", "WHITE_220"),
+  (5.0, "5", "TPMS_LOW"),
+  (5.1, "5", "TPMS_LOW"),
+  (30.9, "31", "TPMS_LOW"),
+  (31.0, "31", "WHITE_220"),
+  (31.1, "31", "WHITE_220"),
+  (59.9, "60", "WHITE_220"),
+  (60.0, "60", "WHITE_220"),
+  (60.1, "  -", "WHITE_220"),
+))
+def test_tpms_legacy_display_boundaries(hud_module, value, expected_text, expected_color_name):
+  module, _ = hud_module
+  renderer = object.__new__(module.HudRenderer)
+
+  assert renderer._get_tpms_text(value) == expected_text
+  assert renderer._get_tpms_color(value) == getattr(module.COLORS, expected_color_name)
 
 
 def test_date_text_formats_only_when_minute_key_changes(hud_module, monkeypatch):

--- a/openpilot/selfdrive/ui/tests/test_carrot_model_renderer.py
+++ b/openpilot/selfdrive/ui/tests/test_carrot_model_renderer.py
@@ -10,7 +10,6 @@ class FakeSubMaster(dict):
   def __init__(self, **messages):
     super().__init__(messages)
     self.valid = dict.fromkeys(messages, True)
-    self.alive = dict.fromkeys(messages, True)
 
 
 def blind_spot_messages(
@@ -103,10 +102,6 @@ def test_blind_spot_invalid_state_is_distinct_from_inactive():
   sm = FakeSubMaster(modelV2=SimpleNamespace(meta=meta), carState=car_state, radarState=radar_state)
   sm.valid["radarState"] = False
 
-  assert renderer._draw_blind_spot_carrot(sm) == (0, False)
-
-  sm.valid["radarState"] = True
-  sm.alive["radarState"] = False
   assert renderer._draw_blind_spot_carrot(sm) == (0, False)
 
 

--- a/openpilot/selfdrive/ui/tests/test_carrot_model_renderer.py
+++ b/openpilot/selfdrive/ui/tests/test_carrot_model_renderer.py
@@ -1,0 +1,300 @@
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from openpilot.selfdrive.ui.onroad import model_renderer
+
+
+class FakeSubMaster(dict):
+  def __init__(self, **messages):
+    super().__init__(messages)
+    self.valid = dict.fromkeys(messages, True)
+
+
+def blind_spot_messages(
+  *,
+  left_blindspot: bool = False,
+  right_blindspot: bool = False,
+  left_status: bool = False,
+  right_status: bool = False,
+  left_d_rel: float = 100.0,
+  right_d_rel: float = 100.0,
+  v_ego: float = 10.0,
+  lane_change_state=None,
+  lane_change_direction: str = "none",
+):
+  if lane_change_state is None:
+    lane_change_state = model_renderer.LaneChangeState.off
+  car_state = SimpleNamespace(
+    leftBlindspot=left_blindspot,
+    rightBlindspot=right_blindspot,
+    vEgo=v_ego,
+  )
+  radar_state = SimpleNamespace(
+    leadLeft=SimpleNamespace(status=left_status, dRel=left_d_rel),
+    leadRight=SimpleNamespace(status=right_status, dRel=right_d_rel),
+  )
+  meta = SimpleNamespace(
+    laneChangeState=lane_change_state,
+    laneChangeDirection=lane_change_direction,
+  )
+  return car_state, radar_state, meta
+
+
+@pytest.mark.parametrize(
+  "messages, expected",
+  [
+    (blind_spot_messages(), (False, False, False, False)),
+    (blind_spot_messages(left_blindspot=True), (True, False, False, False)),
+    (blind_spot_messages(right_blindspot=True), (False, True, False, False)),
+    (
+      blind_spot_messages(
+        left_status=True,
+        left_d_rel=29.9,
+        lane_change_state=model_renderer.LaneChangeState.preLaneChange,
+        lane_change_direction="left",
+      ),
+      (False, False, True, False),
+    ),
+    (
+      blind_spot_messages(
+        right_status=True,
+        right_d_rel=30.0,
+        lane_change_state=model_renderer.LaneChangeState.preLaneChange,
+        lane_change_direction="right",
+      ),
+      (False, False, False, False),
+    ),
+    (
+      blind_spot_messages(
+        left_blindspot=True,
+        left_status=True,
+        left_d_rel=5.0,
+        lane_change_state=model_renderer.LaneChangeState.preLaneChange,
+        lane_change_direction="left",
+      ),
+      (True, False, False, False),
+    ),
+  ],
+)
+def test_blind_spot_draw_state(messages, expected):
+  assert model_renderer.ModelRenderer._blind_spot_draw_state_carrot(*messages) == expected
+
+
+def test_blind_spot_inactive_skips_barrier_update():
+  renderer = object.__new__(model_renderer.ModelRenderer)
+  car_state, radar_state, meta = blind_spot_messages()
+  sm = FakeSubMaster(modelV2=SimpleNamespace(meta=meta), carState=car_state, radarState=radar_state)
+  updates = []
+  renderer._update_blind_spot_barriers_carrot = lambda *args, **kwargs: updates.append((args, kwargs))
+
+  renderer._draw_blind_spot_carrot(sm)
+
+  assert updates == []
+
+
+def test_blind_spot_updates_only_active_side():
+  renderer = object.__new__(model_renderer.ModelRenderer)
+  renderer._carrot_lane_barrier_vertices = [np.ones((4, 2), dtype=np.float32), np.ones((4, 2), dtype=np.float32)]
+  car_state, radar_state, meta = blind_spot_messages(left_blindspot=True)
+  sm = FakeSubMaster(modelV2=SimpleNamespace(meta=meta), carState=car_state, radarState=radar_state)
+  updates = []
+  draws = []
+  renderer._update_blind_spot_barriers_carrot = lambda _, **kwargs: updates.append(kwargs)
+  renderer._draw_blind_spot_segments_carrot = lambda points, color: draws.append((points, color))
+
+  renderer._draw_blind_spot_carrot(sm)
+
+  assert updates == [{"update_left": True, "update_right": False}]
+  assert len(draws) == 1
+  assert draws[0][0] is renderer._carrot_lane_barrier_vertices[0]
+
+
+class FakeParams:
+  def __init__(self):
+    self.values = {
+      "ShowLaneInfo": 1,
+      "CarrotTireTrajectory": False,
+      "ShowRadarInfo": 0,
+      "ShowPathMode": 9,
+      "ShowPathColor": 20,
+      "ShowPathModeLane": 14,
+      "ShowPathColorLane": 20,
+      "ShowPathColorCruiseOff": 19,
+    }
+    self.calls = []
+
+  def get_int(self, key):
+    self.calls.append(key)
+    return int(self.values[key])
+
+  def get_bool(self, key):
+    self.calls.append(key)
+    return bool(self.values[key])
+
+
+def test_carrot_params_refresh_is_throttled(monkeypatch):
+  params = FakeParams()
+  monkeypatch.setattr(model_renderer.ui_state, "params", params)
+  renderer = object.__new__(model_renderer.ModelRenderer)
+  renderer._carrot_params_next_refresh_time = 0.0
+
+  renderer._refresh_carrot_params(0.0)
+  assert len(params.calls) == 8
+  assert renderer._carrot_show_path_mode_normal == 9
+
+  params.values["ShowPathMode"] = 13
+  renderer._refresh_carrot_params(0.999)
+  assert len(params.calls) == 8
+  assert renderer._carrot_show_path_mode_normal == 9
+
+  renderer._refresh_carrot_params(1.0)
+  assert len(params.calls) == 16
+  assert renderer._carrot_show_path_mode_normal == 13
+
+
+def test_carrot_params_failed_refresh_retries(monkeypatch):
+  params = FakeParams()
+  original_get_int = params.get_int
+  failed = False
+
+  def fail_once(key):
+    nonlocal failed
+    if key == "ShowPathColor" and not failed:
+      failed = True
+      raise OSError("temporary params read failure")
+    return original_get_int(key)
+
+  params.get_int = fail_once
+  monkeypatch.setattr(model_renderer.ui_state, "params", params)
+  renderer = object.__new__(model_renderer.ModelRenderer)
+  renderer._carrot_params_next_refresh_time = 0.0
+
+  with pytest.raises(OSError):
+    renderer._refresh_carrot_params(0.0)
+  assert renderer._carrot_params_next_refresh_time == 0.0
+
+  renderer._refresh_carrot_params(0.1)
+  assert renderer._carrot_params_next_refresh_time == pytest.approx(1.1)
+
+
+def test_lane_draw_reuses_cached_raw_points():
+  renderer = object.__new__(model_renderer.ModelRenderer)
+  renderer._carrot_show_lane_info = 1
+  renderer._lane_line_probs = np.ones(4, dtype=np.float32)
+  renderer._road_edge_stds = np.zeros(2, dtype=np.float32)
+  renderer._lane_lines = [
+    model_renderer.ModelPoints(raw_points=np.array([[0.0, i, 0.0], [20.0, i, 0.0]], dtype=np.float32))
+    for i in range(4)
+  ]
+  renderer._road_edges = [
+    model_renderer.ModelPoints(raw_points=np.array([[0.0, i, 0.0], [20.0, i, 0.0]], dtype=np.float32))
+    for i in range(2)
+  ]
+  renderer._get_path_length_idx = lambda *_: 1
+  projected_inputs = []
+
+  def project(line, *_args, **_kwargs):
+    projected_inputs.append(line)
+    return np.empty((0, 2), dtype=np.float32)
+
+  renderer._map_line_to_polygon = project
+  car_state = SimpleNamespace(leftLaneLine=0, rightLaneLine=0)
+
+  class LaneSubMaster(FakeSubMaster):
+    def __getitem__(self, key):
+      if key == "modelV2":
+        raise AssertionError("lane draw must reuse cached model arrays")
+      return super().__getitem__(key)
+
+  sm = LaneSubMaster(modelV2=object(), carState=car_state)
+  renderer._draw_lane_lines_carrot(sm)
+
+  expected = [
+    renderer._lane_lines[0].raw_points,
+    renderer._lane_lines[1].raw_points,
+    renderer._lane_lines[2].raw_points,
+    renderer._lane_lines[3].raw_points,
+  ]
+  assert len(projected_inputs) == len(expected)
+  assert all(actual is cached for actual, cached in zip(projected_inputs, expected, strict=True))
+
+
+def test_lane_draw_builds_cached_optional_geometry():
+  renderer = object.__new__(model_renderer.ModelRenderer)
+  renderer._carrot_show_lane_info = 2
+  renderer._lane_line_probs = np.ones(4, dtype=np.float32)
+  renderer._road_edge_stds = np.zeros(2, dtype=np.float32)
+  renderer._lane_lines = [
+    model_renderer.ModelPoints(raw_points=np.array([[0.0, i, 0.0], [20.0, i, 0.0]], dtype=np.float32))
+    for i in range(4)
+  ]
+  renderer._road_edges = [
+    model_renderer.ModelPoints(raw_points=np.array([[0.0, i, 0.0], [20.0, i, 0.0]], dtype=np.float32))
+    for i in range(2)
+  ]
+  renderer._get_path_length_idx = lambda *_: 1
+  projected_inputs = []
+
+  def project(line, *_args, **_kwargs):
+    projected_inputs.append(line)
+    return np.empty((0, 2), dtype=np.float32)
+
+  renderer._map_line_to_polygon = project
+  car_state = SimpleNamespace(leftLaneLine=24, rightLaneLine=0)
+
+  class LaneSubMaster(FakeSubMaster):
+    def __getitem__(self, key):
+      if key == "modelV2":
+        raise AssertionError("lane draw must reuse cached model arrays")
+      return super().__getitem__(key)
+
+  sm = LaneSubMaster(modelV2=object(), carState=car_state)
+  renderer._draw_lane_lines_carrot(sm)
+
+  expected = [
+    renderer._lane_lines[0].raw_points,
+    renderer._lane_lines[1].raw_points,
+    renderer._lane_lines[1].raw_points,
+    renderer._lane_lines[2].raw_points,
+    renderer._lane_lines[3].raw_points,
+    renderer._road_edges[0].raw_points,
+    renderer._road_edges[1].raw_points,
+  ]
+  assert len(projected_inputs) == len(expected)
+  assert all(actual is cached for actual, cached in zip(projected_inputs, expected, strict=True))
+
+
+def test_model_overlay_timings(monkeypatch):
+  renderer = object.__new__(model_renderer.ModelRenderer)
+  renderer._render_timings = model_renderer.ModelRenderTimings()
+  calls = []
+  renderer._draw_path_carrot = lambda _: calls.append("path")
+  renderer._draw_lane_center_indicator_carrot = lambda _: calls.append("laneCenter")
+  renderer._draw_lane_lines_carrot = lambda _: calls.append("laneLines")
+  renderer._draw_blind_spot_carrot = lambda _: calls.append("blindSpot")
+  renderer._draw_radar_info_carrot = lambda _: calls.append("radar")
+  timestamps = iter((1_000_000_000, 1_010_000_000, 1_030_000_000, 1_034_000_000, 1_035_000_000))
+  monkeypatch.setattr(model_renderer.time, "monotonic_ns", lambda: next(timestamps))
+
+  renderer._draw_carrot_overlays(object())
+
+  assert calls == ["path", "laneCenter", "laneLines", "blindSpot", "radar"]
+  assert renderer.render_timings.path_time_millis == pytest.approx(10.0)
+  assert renderer.render_timings.lane_time_millis == pytest.approx(20.0)
+  assert renderer.render_timings.blind_spot_time_millis == pytest.approx(4.0)
+  assert renderer.render_timings.radar_time_millis == pytest.approx(1.0)
+  assert renderer.render_timings.valid
+
+
+def test_render_early_return_resets_timings(monkeypatch):
+  renderer = object.__new__(model_renderer.ModelRenderer)
+  renderer._render_timings = model_renderer.ModelRenderTimings(1.0, 2.0, 3.0, 4.0, True)
+  sm = SimpleNamespace(recv_frame={"liveCalibration": 0, "modelV2": 0})
+  monkeypatch.setattr(model_renderer.ui_state, "sm", sm, raising=False)
+  monkeypatch.setattr(model_renderer.ui_state, "started_frame", 1, raising=False)
+
+  renderer._render(object())
+
+  assert renderer.render_timings == model_renderer.ModelRenderTimings()

--- a/openpilot/selfdrive/ui/tests/test_carrot_model_renderer.py
+++ b/openpilot/selfdrive/ui/tests/test_carrot_model_renderer.py
@@ -89,26 +89,22 @@ def test_blind_spot_inactive_skips_barrier_update():
   updates = []
   renderer._update_blind_spot_barriers_carrot = lambda *args, **kwargs: updates.append((args, kwargs))
 
-  state_mask, state_valid = renderer._draw_blind_spot_carrot(sm)
+  renderer._draw_blind_spot_carrot(sm)
 
   assert updates == []
-  assert state_mask == 0
-  assert state_valid
 
 
-def test_blind_spot_invalid_state_is_distinct_from_inactive():
+def test_blind_spot_invalid_input_skips_barrier_update():
   renderer = object.__new__(model_renderer.ModelRenderer)
-  car_state, radar_state, meta = blind_spot_messages()
+  car_state, radar_state, meta = blind_spot_messages(left_blindspot=True)
   sm = FakeSubMaster(modelV2=SimpleNamespace(meta=meta), carState=car_state, radarState=radar_state)
   sm.valid["radarState"] = False
+  updates = []
+  renderer._update_blind_spot_barriers_carrot = lambda *args, **kwargs: updates.append((args, kwargs))
 
-  assert renderer._draw_blind_spot_carrot(sm) == (0, False)
+  renderer._draw_blind_spot_carrot(sm)
 
-
-@pytest.mark.parametrize("mask", range(16))
-def test_blind_spot_state_mask_uses_stable_bits(mask):
-  state = tuple(bool(mask & (1 << bit)) for bit in range(4))
-  assert model_renderer.ModelRenderer._blind_spot_state_mask_carrot(*state) == mask
+  assert updates == []
 
 
 def test_blind_spot_updates_only_active_side():
@@ -121,20 +117,17 @@ def test_blind_spot_updates_only_active_side():
   renderer._update_blind_spot_barriers_carrot = lambda _, **kwargs: updates.append(kwargs)
   renderer._draw_blind_spot_segments_carrot = lambda points, color: draws.append((points, color))
 
-  state_mask, state_valid = renderer._draw_blind_spot_carrot(sm)
+  renderer._draw_blind_spot_carrot(sm)
 
   assert updates == [{"update_left": True, "update_right": False}]
   assert len(draws) == 1
   assert draws[0][0] is renderer._carrot_lane_barrier_vertices[0]
-  assert state_mask == model_renderer.BLIND_SPOT_LEFT_MASK
-  assert state_valid
 
 
 class FakeParams:
   def __init__(self):
     self.values = {
       "ShowLaneInfo": 1,
-      "CarrotTireTrajectory": False,
       "ShowRadarInfo": 0,
       "ShowPathMode": 9,
       "ShowPathColor": 20,
@@ -148,10 +141,6 @@ class FakeParams:
     self.calls.append(key)
     return int(self.values[key])
 
-  def get_bool(self, key):
-    self.calls.append(key)
-    return bool(self.values[key])
-
 
 def test_carrot_params_refresh_is_throttled(monkeypatch):
   params = FakeParams()
@@ -160,16 +149,16 @@ def test_carrot_params_refresh_is_throttled(monkeypatch):
   renderer._carrot_params_next_refresh_time = 0.0
 
   renderer._refresh_carrot_params(0.0)
-  assert len(params.calls) == 8
+  assert len(params.calls) == 7
   assert renderer._carrot_show_path_mode_normal == 9
 
   params.values["ShowPathMode"] = 13
   renderer._refresh_carrot_params(0.999)
-  assert len(params.calls) == 8
+  assert len(params.calls) == 7
   assert renderer._carrot_show_path_mode_normal == 9
 
   renderer._refresh_carrot_params(1.0)
-  assert len(params.calls) == 16
+  assert len(params.calls) == 14
   assert renderer._carrot_show_path_mode_normal == 13
 
 
@@ -285,41 +274,27 @@ def test_lane_draw_builds_cached_optional_geometry():
   assert all(actual is cached for actual, cached in zip(projected_inputs, expected, strict=True))
 
 
-def test_model_overlay_timings(monkeypatch):
+def test_model_overlay_draw_order():
   renderer = object.__new__(model_renderer.ModelRenderer)
-  renderer._render_timings = model_renderer.ModelRenderTimings()
   calls = []
   renderer._draw_path_carrot = lambda _: calls.append("path")
-  renderer._draw_lane_center_indicator_carrot = lambda _: calls.append("laneCenter")
   renderer._draw_lane_lines_carrot = lambda _: calls.append("laneLines")
-  def draw_blind_spot(_):
-    calls.append("blindSpot")
-    return model_renderer.BLIND_SPOT_LEFT_MASK, True
-
-  renderer._draw_blind_spot_carrot = draw_blind_spot
+  renderer._draw_blind_spot_carrot = lambda _: calls.append("blindSpot")
   renderer._draw_radar_info_carrot = lambda _: calls.append("radar")
-  timestamps = iter((1_000_000_000, 1_010_000_000, 1_030_000_000, 1_034_000_000, 1_035_000_000))
-  monkeypatch.setattr(model_renderer.time, "monotonic_ns", lambda: next(timestamps))
 
   renderer._draw_carrot_overlays(object())
 
-  assert calls == ["path", "laneCenter", "laneLines", "blindSpot", "radar"]
-  assert renderer.render_timings.path_time_millis == pytest.approx(10.0)
-  assert renderer.render_timings.lane_time_millis == pytest.approx(20.0)
-  assert renderer.render_timings.blind_spot_time_millis == pytest.approx(4.0)
-  assert renderer.render_timings.radar_time_millis == pytest.approx(1.0)
-  assert renderer.render_timings.valid
-  assert renderer.render_timings.blind_spot_state_mask == model_renderer.BLIND_SPOT_LEFT_MASK
-  assert renderer.render_timings.blind_spot_state_valid
+  assert calls == ["path", "laneLines", "blindSpot", "radar"]
 
 
-def test_render_early_return_resets_timings(monkeypatch):
+def test_render_stale_data_skips_overlays(monkeypatch):
   renderer = object.__new__(model_renderer.ModelRenderer)
-  renderer._render_timings = model_renderer.ModelRenderTimings(1.0, 2.0, 3.0, 4.0, True, 15, True)
+  calls = []
+  renderer._draw_carrot_overlays = lambda _: calls.append("overlays")
   sm = SimpleNamespace(recv_frame={"liveCalibration": 0, "modelV2": 0})
   monkeypatch.setattr(model_renderer.ui_state, "sm", sm, raising=False)
   monkeypatch.setattr(model_renderer.ui_state, "started_frame", 1, raising=False)
 
   renderer._render(object())
 
-  assert renderer.render_timings == model_renderer.ModelRenderTimings()
+  assert calls == []

--- a/openpilot/selfdrive/ui/tests/test_carrot_model_renderer.py
+++ b/openpilot/selfdrive/ui/tests/test_carrot_model_renderer.py
@@ -10,6 +10,7 @@ class FakeSubMaster(dict):
   def __init__(self, **messages):
     super().__init__(messages)
     self.valid = dict.fromkeys(messages, True)
+    self.alive = dict.fromkeys(messages, True)
 
 
 def blind_spot_messages(
@@ -89,9 +90,30 @@ def test_blind_spot_inactive_skips_barrier_update():
   updates = []
   renderer._update_blind_spot_barriers_carrot = lambda *args, **kwargs: updates.append((args, kwargs))
 
-  renderer._draw_blind_spot_carrot(sm)
+  state_mask, state_valid = renderer._draw_blind_spot_carrot(sm)
 
   assert updates == []
+  assert state_mask == 0
+  assert state_valid
+
+
+def test_blind_spot_invalid_state_is_distinct_from_inactive():
+  renderer = object.__new__(model_renderer.ModelRenderer)
+  car_state, radar_state, meta = blind_spot_messages()
+  sm = FakeSubMaster(modelV2=SimpleNamespace(meta=meta), carState=car_state, radarState=radar_state)
+  sm.valid["radarState"] = False
+
+  assert renderer._draw_blind_spot_carrot(sm) == (0, False)
+
+  sm.valid["radarState"] = True
+  sm.alive["radarState"] = False
+  assert renderer._draw_blind_spot_carrot(sm) == (0, False)
+
+
+@pytest.mark.parametrize("mask", range(16))
+def test_blind_spot_state_mask_uses_stable_bits(mask):
+  state = tuple(bool(mask & (1 << bit)) for bit in range(4))
+  assert model_renderer.ModelRenderer._blind_spot_state_mask_carrot(*state) == mask
 
 
 def test_blind_spot_updates_only_active_side():
@@ -104,11 +126,13 @@ def test_blind_spot_updates_only_active_side():
   renderer._update_blind_spot_barriers_carrot = lambda _, **kwargs: updates.append(kwargs)
   renderer._draw_blind_spot_segments_carrot = lambda points, color: draws.append((points, color))
 
-  renderer._draw_blind_spot_carrot(sm)
+  state_mask, state_valid = renderer._draw_blind_spot_carrot(sm)
 
   assert updates == [{"update_left": True, "update_right": False}]
   assert len(draws) == 1
   assert draws[0][0] is renderer._carrot_lane_barrier_vertices[0]
+  assert state_mask == model_renderer.BLIND_SPOT_LEFT_MASK
+  assert state_valid
 
 
 class FakeParams:
@@ -273,7 +297,11 @@ def test_model_overlay_timings(monkeypatch):
   renderer._draw_path_carrot = lambda _: calls.append("path")
   renderer._draw_lane_center_indicator_carrot = lambda _: calls.append("laneCenter")
   renderer._draw_lane_lines_carrot = lambda _: calls.append("laneLines")
-  renderer._draw_blind_spot_carrot = lambda _: calls.append("blindSpot")
+  def draw_blind_spot(_):
+    calls.append("blindSpot")
+    return model_renderer.BLIND_SPOT_LEFT_MASK, True
+
+  renderer._draw_blind_spot_carrot = draw_blind_spot
   renderer._draw_radar_info_carrot = lambda _: calls.append("radar")
   timestamps = iter((1_000_000_000, 1_010_000_000, 1_030_000_000, 1_034_000_000, 1_035_000_000))
   monkeypatch.setattr(model_renderer.time, "monotonic_ns", lambda: next(timestamps))
@@ -286,11 +314,13 @@ def test_model_overlay_timings(monkeypatch):
   assert renderer.render_timings.blind_spot_time_millis == pytest.approx(4.0)
   assert renderer.render_timings.radar_time_millis == pytest.approx(1.0)
   assert renderer.render_timings.valid
+  assert renderer.render_timings.blind_spot_state_mask == model_renderer.BLIND_SPOT_LEFT_MASK
+  assert renderer.render_timings.blind_spot_state_valid
 
 
 def test_render_early_return_resets_timings(monkeypatch):
   renderer = object.__new__(model_renderer.ModelRenderer)
-  renderer._render_timings = model_renderer.ModelRenderTimings(1.0, 2.0, 3.0, 4.0, True)
+  renderer._render_timings = model_renderer.ModelRenderTimings(1.0, 2.0, 3.0, 4.0, True, 15, True)
   sm = SimpleNamespace(recv_frame={"liveCalibration": 0, "modelV2": 0})
   monkeypatch.setattr(model_renderer.ui_state, "sm", sm, raising=False)
   monkeypatch.setattr(model_renderer.ui_state, "started_frame", 1, raising=False)

--- a/openpilot/selfdrive/ui/tests/test_carrot_model_renderer_lane_visibility.py
+++ b/openpilot/selfdrive/ui/tests/test_carrot_model_renderer_lane_visibility.py
@@ -341,14 +341,9 @@ def test_blind_spot_state_valid_distinguishes_inactive_from_missing_input(model_
     def __init__(self):
       super().__init__(modelV2=model, carState=car_state, radarState=radar_state)
       self.valid = dict.fromkeys(self, True)
-      self.alive = dict.fromkeys(self, True)
 
   sm = BlindSpotSubMaster()
   assert renderer._draw_blind_spot_carrot(sm) == (0, True)
 
   sm.valid["radarState"] = False
-  assert renderer._draw_blind_spot_carrot(sm) == (0, False)
-
-  sm.valid["radarState"] = True
-  sm.alive["radarState"] = False
   assert renderer._draw_blind_spot_carrot(sm) == (0, False)

--- a/openpilot/selfdrive/ui/tests/test_carrot_model_renderer_lane_visibility.py
+++ b/openpilot/selfdrive/ui/tests/test_carrot_model_renderer_lane_visibility.py
@@ -218,3 +218,137 @@ def test_mode9_complex_path_preserves_segment_fill_outline_order(model_renderer_
   events.clear()
   renderer._draw_complex_path_carrot(color_idx=5, brake_valid=False)
   assert [event[0] for event in events] == ["fill", "fill", "fill", "fill"]
+
+
+@pytest.mark.parametrize("y_shift", (-1.7, 1.7))
+def test_blind_spot_barrier_vectorization_matches_scalar_reference(model_renderer_module, y_shift):
+  module = model_renderer_module
+  renderer = object.__new__(module.ModelRenderer)
+  renderer._car_space_transform = np.array(
+    [[0.0, 120.0, 960.0], [-18.0, 8.0, 720.0], [0.02, 0.0, 1.0]],
+    dtype=np.float32,
+  )
+  renderer._clip_region = module.rl.Rectangle(-500.0, -500.0, 3000.0, 2000.0)
+  model_position = np.array(
+    [
+      [-1.0, 0.0, 0.0],
+      [0.0, 0.0, 0.0],
+      [5.0, 0.2, 0.05],
+      [10.0, -0.1, 0.10],
+      [20.0, 0.4, 0.15],
+      [30.0, -0.2, 0.20],
+      [40.0, 0.1, 0.25],
+      [50.0, 0.0, 0.30],
+    ],
+    dtype=np.float32,
+  )
+
+  max_idx = renderer._get_path_length_idx(model_position[:, 0], 40.0)
+  upper_points = []
+  lower_points = []
+  for i in range(max_idx + 1):
+    if model_position[i, 0] < 0:
+      continue
+    upper = renderer._map_to_screen(
+      model_position[i, 0], model_position[i, 1] + y_shift, model_position[i, 2] + 1.15,
+    )
+    lower = renderer._map_to_screen(
+      model_position[i, 0], model_position[i, 1] + y_shift, model_position[i, 2] + 0.6,
+    )
+    if upper is not None and lower is not None:
+      if upper_points and upper[1] > upper_points[-1][1]:
+        continue
+      upper_points.append(upper)
+      lower_points.insert(0, lower)
+  expected = np.array(upper_points + lower_points, dtype=np.float32)
+
+  actual = renderer._build_blind_spot_barrier_carrot(model_position, y_shift)
+
+  np.testing.assert_array_equal(actual, expected)
+
+
+def test_blind_spot_segment_vectorization_preserves_fill_outline_order(model_renderer_module, monkeypatch):
+  module = model_renderer_module
+  renderer = object.__new__(module.ModelRenderer)
+  upper = np.array(
+    [[100.0, 700.0], [110.0, 650.0], [120.0, 600.0], [130.0, 550.0], [140.0, 500.0], [150.0, 450.0]],
+    dtype=np.float32,
+  )
+  lower = np.array(
+    [[90.0, 710.0], [100.0, 660.0], [110.0, 610.0], [120.0, 560.0], [130.0, 510.0], [140.0, 460.0]],
+    dtype=np.float32,
+  )
+  points = np.vstack((upper, lower[::-1]))
+  color = module.rl.Color(255, 215, 0, 150)
+  events = []
+  monkeypatch.setattr(
+    module,
+    "draw_polygon_solid",
+    lambda quad, fill_color: events.append(("fill", quad.copy(), fill_color)),
+  )
+  renderer._draw_polygon_outline_carrot = (
+    lambda quad, outline_color, thickness: events.append(("outline", quad.copy(), outline_color, thickness))
+  )
+
+  expected_quads = []
+  count = points.shape[0]
+  half = count // 2
+  for i in range(0, half - 2, 2):
+    quad = np.array(
+      [points[i], points[i + 1], points[count - i - 3], points[count - i - 2]],
+      dtype=np.float32,
+    )
+    center = np.mean(quad, axis=0)
+    angles = np.arctan2(quad[:, 1] - center[1], quad[:, 0] - center[0])
+    expected_quads.append(quad[np.argsort(angles)])
+
+  renderer._draw_blind_spot_segments_carrot(points, color)
+
+  assert [event[0] for event in events] == ["fill", "outline", "fill", "outline"]
+  for index, expected in enumerate(expected_quads):
+    fill = events[index * 2]
+    outline = events[index * 2 + 1]
+    np.testing.assert_array_equal(fill[1], expected)
+    np.testing.assert_array_equal(outline[1], expected)
+    assert fill[2] == color
+    assert outline[2] == module.rl.WHITE
+    assert outline[3] == 2.0
+
+
+@pytest.mark.parametrize("mask", range(16))
+def test_blind_spot_state_mask_uses_stable_bits(model_renderer_module, mask):
+  module = model_renderer_module
+  state = tuple(bool(mask & (1 << bit)) for bit in range(4))
+  assert module.ModelRenderer._blind_spot_state_mask_carrot(*state) == mask
+
+
+def test_blind_spot_state_valid_distinguishes_inactive_from_missing_input(model_renderer_module):
+  module = model_renderer_module
+  renderer = object.__new__(module.ModelRenderer)
+  car_state = SimpleNamespace(leftBlindspot=False, rightBlindspot=False, vEgo=10.0)
+  radar_state = SimpleNamespace(
+    leadLeft=SimpleNamespace(status=False, dRel=100.0),
+    leadRight=SimpleNamespace(status=False, dRel=100.0),
+  )
+  model = SimpleNamespace(
+    meta=SimpleNamespace(
+      laneChangeState=module.LaneChangeState.off,
+      laneChangeDirection="none",
+    ),
+  )
+
+  class BlindSpotSubMaster(dict):
+    def __init__(self):
+      super().__init__(modelV2=model, carState=car_state, radarState=radar_state)
+      self.valid = dict.fromkeys(self, True)
+      self.alive = dict.fromkeys(self, True)
+
+  sm = BlindSpotSubMaster()
+  assert renderer._draw_blind_spot_carrot(sm) == (0, True)
+
+  sm.valid["radarState"] = False
+  assert renderer._draw_blind_spot_carrot(sm) == (0, False)
+
+  sm.valid["radarState"] = True
+  sm.alive["radarState"] = False
+  assert renderer._draw_blind_spot_carrot(sm) == (0, False)

--- a/openpilot/selfdrive/ui/tests/test_carrot_model_renderer_lane_visibility.py
+++ b/openpilot/selfdrive/ui/tests/test_carrot_model_renderer_lane_visibility.py
@@ -1,0 +1,220 @@
+import importlib.util
+import sys
+import types
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+
+MODEL_RENDERER_PATH = Path(__file__).parents[1] / "onroad" / "model_renderer.py"
+
+
+@pytest.fixture
+def model_renderer_module(monkeypatch):
+  @dataclass(frozen=True)
+  class Color:
+    r: int
+    g: int
+    b: int
+    a: int
+
+  @dataclass(frozen=True)
+  class Rectangle:
+    x: float
+    y: float
+    width: float
+    height: float
+
+  @dataclass(frozen=True)
+  class Vector2:
+    x: float
+    y: float
+
+  class Font:
+    pass
+
+  raylib = types.ModuleType("pyray")
+  raylib.Color = Color
+  raylib.Rectangle = Rectangle
+  raylib.Vector2 = Vector2
+  raylib.Font = Font
+  raylib.WHITE = Color(255, 255, 255, 255)
+  raylib.RL_QUADS = 7
+  raylib.get_time = lambda: 0.0
+  for name in (
+    "draw_circle",
+    "draw_line_ex",
+    "draw_rectangle_rounded",
+    "draw_rectangle_rounded_lines_ex",
+    "draw_triangle_fan",
+    "rl_begin",
+    "rl_color4ub",
+    "rl_disable_texture",
+    "rl_end",
+    "rl_vertex2f",
+  ):
+    setattr(raylib, name, lambda *args, **kwargs: None)
+
+  class FirstOrderFilter:
+    def __init__(self, *args, **kwargs):
+      pass
+
+  class Params:
+    def get(self, _key):
+      return None
+
+  class Widget:
+    def __init__(self):
+      pass
+
+  @dataclass
+  class Gradient:
+    start: tuple[float, float]
+    end: tuple[float, float]
+    colors: list
+    stops: list[float]
+
+  lane_change_state = SimpleNamespace(off=0, preLaneChange=1)
+  cereal = types.ModuleType("openpilot.cereal")
+  cereal.messaging = SimpleNamespace(log_from_bytes=lambda *_args: None)
+  cereal.car = SimpleNamespace(CarParams=object)
+  cereal.log = SimpleNamespace(LaneChangeState=lane_change_state)
+
+  stubs = {
+    "pyray": raylib,
+    "openpilot.cereal": cereal,
+    "openpilot.common.filter_simple": SimpleNamespace(FirstOrderFilter=FirstOrderFilter),
+    "openpilot.common.params": SimpleNamespace(Params=Params),
+    "openpilot.selfdrive.locationd.calibrationd": SimpleNamespace(HEIGHT_INIT=(1.22,)),
+    "openpilot.selfdrive.ui.ui_state": SimpleNamespace(ui_state=SimpleNamespace()),
+    "openpilot.system.ui.lib.application": SimpleNamespace(
+      gui_app=SimpleNamespace(target_fps=20, font=lambda _weight: Font()),
+      FontWeight=SimpleNamespace(DISPLAY=0),
+    ),
+    "openpilot.system.ui.lib.text_draw": SimpleNamespace(draw_text_ui_style=lambda *args, **kwargs: None),
+    "openpilot.system.ui.lib.shader_polygon": SimpleNamespace(
+      draw_polygon=lambda *args, **kwargs: None,
+      draw_polygon_solid=lambda *args, **kwargs: None,
+      Gradient=Gradient,
+    ),
+    "openpilot.system.ui.widgets": SimpleNamespace(Widget=Widget),
+  }
+  for name, stub in stubs.items():
+    monkeypatch.setitem(sys.modules, name, stub)
+
+  module_name = f"_test_carrot_model_renderer_lane_{id(raylib)}"
+  spec = importlib.util.spec_from_file_location(module_name, MODEL_RENDERER_PATH)
+  assert spec is not None and spec.loader is not None
+  module = importlib.util.module_from_spec(spec)
+  monkeypatch.setitem(sys.modules, module_name, module)
+  spec.loader.exec_module(module)
+  return module
+
+
+def test_lane_draw_skips_zero_alpha_projection(model_renderer_module, monkeypatch):
+  module = model_renderer_module
+  renderer = object.__new__(module.ModelRenderer)
+  renderer._carrot_show_lane_info = 1
+  renderer._lane_line_probs = np.array([0.3, 0.31, np.nan, 0.9], dtype=np.float32)
+  renderer._road_edge_stds = np.zeros(2, dtype=np.float32)
+  renderer._lane_lines = [
+    module.ModelPoints(raw_points=np.array([[0.0, i, 0.0], [20.0, i, 0.0]], dtype=np.float32))
+    for i in range(4)
+  ]
+  renderer._road_edges = [module.ModelPoints(), module.ModelPoints()]
+  renderer._rect = module.rl.Rectangle(0.0, 0.0, 2160.0, 1080.0)
+  renderer._get_path_length_idx = lambda *_args: 1
+
+  projected = []
+
+  def project(line, *args):
+    projected.append((line, args))
+    return np.array([[0.0, 1.0], [0.0, 0.0], [1.0, 0.0], [1.0, 1.0]], dtype=np.float32)
+
+  renderer._map_line_to_polygon = project
+  outlines = []
+  renderer._draw_polygon_outline_carrot = lambda *args: outlines.append(args)
+  draws = []
+  monkeypatch.setattr(module, "draw_polygon_solid", lambda *args: draws.append(args))
+
+  class LaneSubMaster:
+    valid = {"modelV2": True, "carState": True}
+
+    def __getitem__(self, key):
+      assert key == "carState"
+      return SimpleNamespace(leftLaneLine=24, rightLaneLine=0)
+
+  renderer._draw_lane_lines_carrot(LaneSubMaster())
+
+  actual_lines = [entry[0] for entry in projected]
+  expected_lines = [
+    renderer._lane_lines[1].raw_points,
+    renderer._lane_lines[1].raw_points,
+    renderer._lane_lines[3].raw_points,
+  ]
+  assert all(actual is expected for actual, expected in zip(actual_lines, expected_lines, strict=True))
+  assert projected[1][1][-2:] == (True, -0.3)
+  assert len(draws) == 3
+  assert len(outlines) == 2
+  assert all(draw[1].a == 220 for draw in draws)
+
+  projected.clear()
+  draws.clear()
+  outlines.clear()
+  renderer._lane_line_probs = np.array([0.31, 0.3, 0.0, 0.0], dtype=np.float32)
+
+  renderer._draw_lane_lines_carrot(LaneSubMaster())
+
+  assert len(projected) == 1
+  assert projected[0][0] is renderer._lane_lines[0].raw_points
+  assert len(draws) == 1
+  assert outlines == []
+
+  projected.clear()
+  draws.clear()
+  renderer._lane_line_probs = np.array([0.3, 0.0, np.nan, -1.0], dtype=np.float32)
+
+  renderer._draw_lane_lines_carrot(LaneSubMaster())
+
+  assert projected == []
+  assert draws == []
+
+
+def test_mode9_complex_path_preserves_segment_fill_outline_order(model_renderer_module, monkeypatch):
+  module = model_renderer_module
+  renderer = object.__new__(module.ModelRenderer)
+  renderer._path = module.ModelPoints(
+    projected_points=np.array([[float(i), float(i) + 0.25] for i in range(12)], dtype=np.float32),
+  )
+  renderer._carrot_colors = [module.rl.Color(i, i + 1, i + 2, 120) for i in range(10)]
+  events = []
+
+  monkeypatch.setattr(
+    module,
+    "draw_polygon_solid",
+    lambda points, color: events.append(("fill", points.copy(), color)),
+  )
+  renderer._draw_polygon_outline_carrot = (
+    lambda points, color, thickness: events.append(("outline", points.copy(), color, thickness))
+  )
+
+  renderer._draw_complex_path_carrot(color_idx=20, brake_valid=False)
+
+  assert [event[0] for event in events] == ["fill", "fill", "outline", "fill", "fill", "outline"]
+  for offset in (0, 3):
+    left_fill = events[offset][1]
+    right_fill = events[offset + 1][1]
+    outline = events[offset + 2][1]
+    np.testing.assert_array_equal(left_fill, outline[[0, 1, 2, 5]])
+    np.testing.assert_array_equal(right_fill, outline[[5, 2, 3, 4]])
+    assert events[offset][2] is renderer._carrot_colors[0]
+    assert events[offset + 1][2] is renderer._carrot_colors[0]
+    assert events[offset + 2][2] == module.rl.Color(255, 255, 255, 255)
+    assert events[offset + 2][3] == 2.0
+
+  events.clear()
+  renderer._draw_complex_path_carrot(color_idx=5, brake_valid=False)
+  assert [event[0] for event in events] == ["fill", "fill", "fill", "fill"]

--- a/openpilot/selfdrive/ui/tests/test_carrot_model_renderer_lane_visibility.py
+++ b/openpilot/selfdrive/ui/tests/test_carrot_model_renderer_lane_visibility.py
@@ -315,17 +315,11 @@ def test_blind_spot_segment_vectorization_preserves_fill_outline_order(model_ren
     assert outline[3] == 2.0
 
 
-@pytest.mark.parametrize("mask", range(16))
-def test_blind_spot_state_mask_uses_stable_bits(model_renderer_module, mask):
-  module = model_renderer_module
-  state = tuple(bool(mask & (1 << bit)) for bit in range(4))
-  assert module.ModelRenderer._blind_spot_state_mask_carrot(*state) == mask
-
-
-def test_blind_spot_state_valid_distinguishes_inactive_from_missing_input(model_renderer_module):
+def test_blind_spot_invalid_input_skips_draw(model_renderer_module):
   module = model_renderer_module
   renderer = object.__new__(module.ModelRenderer)
-  car_state = SimpleNamespace(leftBlindspot=False, rightBlindspot=False, vEgo=10.0)
+  renderer._carrot_lane_barrier_vertices = [np.ones((4, 2), dtype=np.float32), np.ones((4, 2), dtype=np.float32)]
+  car_state = SimpleNamespace(leftBlindspot=True, rightBlindspot=False, vEgo=10.0)
   radar_state = SimpleNamespace(
     leadLeft=SimpleNamespace(status=False, dRel=100.0),
     leadRight=SimpleNamespace(status=False, dRel=100.0),
@@ -343,7 +337,12 @@ def test_blind_spot_state_valid_distinguishes_inactive_from_missing_input(model_
       self.valid = dict.fromkeys(self, True)
 
   sm = BlindSpotSubMaster()
-  assert renderer._draw_blind_spot_carrot(sm) == (0, True)
+  draws = []
+  renderer._update_blind_spot_barriers_carrot = lambda *_args, **_kwargs: None
+  renderer._draw_blind_spot_segments_carrot = lambda *_args: draws.append("left")
+  renderer._draw_blind_spot_carrot(sm)
+  assert draws == ["left"]
 
   sm.valid["radarState"] = False
-  assert renderer._draw_blind_spot_carrot(sm) == (0, False)
+  renderer._draw_blind_spot_carrot(sm)
+  assert draws == ["left"]

--- a/openpilot/selfdrive/ui/tests/test_carrot_param_cache.py
+++ b/openpilot/selfdrive/ui/tests/test_carrot_param_cache.py
@@ -1,0 +1,372 @@
+import ast
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from openpilot.selfdrive.ui.carrot_param_cache import (
+  BorderParamSnapshot,
+  RealtimeUiParamSnapshot,
+  TimedSnapshotCache,
+  read_border_params,
+  read_realtime_ui_params,
+  read_screen_record,
+)
+
+
+UI_DIR = Path(__file__).parents[1]
+MAIN_LAYOUT_PATH = UI_DIR / "layouts" / "main.py"
+
+
+class FakeParams:
+  def __init__(self, values, failures=None):
+    self.values = values
+    self.failures = dict(failures or {})
+    self.calls = []
+    self.writes = []
+
+  def _read(self, key):
+    self.calls.append(key)
+    if self.failures.get(key, 0) > 0:
+      self.failures[key] -= 1
+      raise RuntimeError(f"failed to read {key}")
+    return self.values[key]
+
+  def get(self, key):
+    return self._read(key)
+
+  def get_bool(self, key):
+    return bool(self._read(key))
+
+  def get_float(self, key):
+    return float(self._read(key))
+
+  def get_int(self, key):
+    return int(self._read(key))
+
+  def put_bool_nonblocking(self, key, value):
+    self.writes.append((key, value))
+
+
+@pytest.fixture
+def main_layout_module(monkeypatch):
+  class Widget:
+    pass
+
+  class Placeholder:
+    pass
+
+  class FakeGuiApp:
+    def __init__(self):
+      self.recording = False
+      self.calls = []
+
+    def is_recording(self):
+      return self.recording
+
+    def start_recording(self):
+      self.calls.append("start")
+      self.recording = True
+
+    def stop_recording(self):
+      self.calls.append("stop")
+      self.recording = False
+
+    def toggle_recording(self):
+      self.calls.append("toggle")
+      self.recording = not self.recording
+
+  gui_app = FakeGuiApp()
+  fake_ui_state = SimpleNamespace(params=None, started=True, sm=None)
+  messaging = types.ModuleType("openpilot.cereal.messaging")
+  messaging.PubMaster = Placeholder
+  messaging.new_message = lambda *args, **kwargs: SimpleNamespace()
+  cereal = types.ModuleType("openpilot.cereal")
+  cereal.messaging = messaging
+
+  stubs = {
+    "pyray": SimpleNamespace(Rectangle=Placeholder),
+    "openpilot.cereal": cereal,
+    "openpilot.cereal.messaging": messaging,
+    "openpilot.selfdrive.ui.layouts.sidebar": SimpleNamespace(Sidebar=Placeholder, SIDEBAR_WIDTH=0),
+    "openpilot.selfdrive.ui.layouts.home": SimpleNamespace(HomeLayout=Placeholder),
+    "openpilot.selfdrive.ui.layouts.settings.settings": SimpleNamespace(
+      SettingsLayout=Placeholder,
+      PanelType=SimpleNamespace(TOGGLES=0, DEVICE=1, FIREHOSE=2),
+    ),
+    "openpilot.selfdrive.ui.onroad.augmented_road_view": SimpleNamespace(AugmentedRoadView=Placeholder),
+    "openpilot.selfdrive.ui.ui_state": SimpleNamespace(
+      device=SimpleNamespace(add_interactive_timeout_callback=lambda callback: None),
+      ui_state=fake_ui_state,
+    ),
+    "openpilot.system.ui.lib.application": SimpleNamespace(gui_app=gui_app),
+    "openpilot.system.ui.widgets": SimpleNamespace(Widget=Widget),
+    "openpilot.selfdrive.ui.layouts.onboarding": SimpleNamespace(OnboardingWindow=Placeholder),
+  }
+  for name, stub in stubs.items():
+    monkeypatch.setitem(sys.modules, name, stub)
+
+  module_name = f"_test_carrot_main_layout_{id(gui_app)}"
+  spec = importlib.util.spec_from_file_location(module_name, MAIN_LAYOUT_PATH)
+  assert spec is not None and spec.loader is not None
+  module = importlib.util.module_from_spec(spec)
+  monkeypatch.setitem(sys.modules, module_name, module)
+  spec.loader.exec_module(module)
+  return module, gui_app, fake_ui_state
+
+
+def make_main_layout(module, gui_app, ui_state, params):
+  ui_state.params = params
+  layout = object.__new__(module.MainLayout)
+  layout._last_carrot_cmd_idx = 0
+  layout._screen_record_param = TimedSnapshotCache(
+    gui_app.is_recording(),
+    lambda: read_screen_record(params),
+  )
+  return layout
+
+
+def carrot_command(index, arg):
+  return {
+    "carrotMan": SimpleNamespace(
+      carrotCmdIndex=index,
+      carrotCmd="RECORD",
+      carrotArg=arg,
+    ),
+  }
+
+
+def test_snapshot_refreshes_at_half_second_boundary():
+  values = iter((1, 2))
+  calls = []
+  cache = TimedSnapshotCache(0, lambda: calls.append(True) or next(values))
+
+  assert cache.refresh(0.0) == 1
+  assert cache.next_refresh_time == 0.5
+  assert cache.refresh(0.499) == 1
+  assert len(calls) == 1
+
+  assert cache.refresh(0.5) == 2
+  assert cache.next_refresh_time == 1.0
+  assert len(calls) == 2
+
+
+def test_failed_refresh_keeps_snapshot_and_retries_next_frame():
+  calls = 0
+
+  def load():
+    nonlocal calls
+    calls += 1
+    if calls == 1:
+      raise RuntimeError("temporary read failure")
+    return "complete"
+
+  cache = TimedSnapshotCache("previous", load)
+
+  assert cache.refresh(0.0) == "previous"
+  assert cache.next_refresh_time == pytest.approx(0.05)
+  assert cache.refresh(0.049) == "previous"
+  assert cache.refresh(0.1) == "complete"
+  assert cache.next_refresh_time == pytest.approx(0.6)
+
+
+def test_border_snapshot_is_atomic_when_middle_read_fails():
+  values = {
+    "CarName": "MX5",
+    "HyundaiCameraSCC": 1,
+    "NNFFModelName": "nnff",
+    "CustomSR": 180,
+    "GitBranch": "carrot-ms-ui2",
+    "NetworkAddress": "192.168.0.2",
+  }
+  params = FakeParams(values, failures={"CustomSR": 1})
+  params_memory = FakeParams(values)
+  previous = BorderParamSnapshot(top_left="previous", custom_sr=12.3)
+  cache = TimedSnapshotCache(previous, lambda: read_border_params(params, params_memory))
+
+  assert cache.refresh(0.0) is previous
+  assert params.calls == ["CarName", "HyundaiCameraSCC", "NNFFModelName", "CustomSR"]
+  assert params_memory.calls == []
+
+  snapshot = cache.refresh(0.1)
+  assert snapshot == BorderParamSnapshot(
+    top_left="MX5(CAMERA SCC),NNFF",
+    top_left_op_long="MX5(CAMERA SCC),NNFF",
+    custom_sr=18.0,
+    bottom_left="carrot-ms-ui2",
+    bottom_right="192.168.0.2",
+  )
+
+
+def test_border_snapshot_prepares_op_long_text_without_changing_order():
+  values = {
+    "CarName": "MX5",
+    "HyundaiCameraSCC": 0,
+    "NNFFModelName": "nnff",
+    "CustomSR": 180,
+    "GitBranch": "carrot-ms-ui2",
+    "NetworkAddress": "",
+  }
+
+  snapshot = read_border_params(FakeParams(values), FakeParams(values))
+
+  assert snapshot.top_left == "MX5,NNFF"
+  assert snapshot.top_left_op_long == "MX5 - OP Long,NNFF"
+  assert snapshot.bottom_left == "carrot-ms-ui2"
+
+
+def test_realtime_ui_snapshot_reads_all_values_once():
+  params = FakeParams({"RecordAudio": 1, "IsMetric": 1, "AlwaysOnDM": 0})
+
+  assert read_realtime_ui_params(params) == RealtimeUiParamSnapshot(
+    record_audio=True,
+    is_metric=True,
+    always_on_dm=False,
+  )
+  assert params.calls == ["RecordAudio", "IsMetric", "AlwaysOnDM"]
+
+
+def test_pending_store_rejects_stale_screen_record_until_acknowledged():
+  params = FakeParams({"ScreenRecord": False})
+  cache = TimedSnapshotCache(False, lambda: read_screen_record(params))
+
+  cache.store_pending(True, 3.0)
+  assert cache.refresh(3.499) is True
+  assert params.calls == []
+  assert cache.refresh(3.5) is True
+  assert params.calls == ["ScreenRecord"]
+
+  params.values["ScreenRecord"] = True
+  assert cache.refresh(4.0) is True
+  params.values["ScreenRecord"] = False
+  assert cache.refresh(4.5) is False
+
+
+def test_pending_store_expires_if_acknowledgement_is_never_observed():
+  params = FakeParams({"ScreenRecord": False})
+  cache = TimedSnapshotCache(False, lambda: read_screen_record(params))
+
+  cache.store_pending(True, 3.0)
+  assert cache.refresh(3.5) is True
+  assert cache.refresh(4.0) is False
+
+
+def test_persistent_failures_back_off_to_normal_interval():
+  calls = []
+
+  def fail():
+    calls.append(True)
+    raise RuntimeError("Params unavailable")
+
+  cache = TimedSnapshotCache("previous", fail)
+  retry_delays = (0.05, 0.1, 0.2, 0.4, 0.5, 0.5)
+  now = 0.0
+  for retry_delay in retry_delays:
+    assert cache.refresh(now) == "previous"
+    deadline = now + retry_delay
+    assert cache.next_refresh_time == pytest.approx(deadline)
+    now = deadline + 1e-6
+
+  assert len(calls) == len(retry_delays)
+
+
+def test_delayed_screen_record_write_cannot_reverse_start(main_layout_module, monkeypatch):
+  module, gui_app, ui_state = main_layout_module
+  params = FakeParams({"ScreenRecord": False})
+  layout = make_main_layout(module, gui_app, ui_state, params)
+  now = 0.0
+  monkeypatch.setattr(module.time, "monotonic", lambda: now)
+
+  assert layout._handle_carrot_record_cmd(carrot_command(1, "START")) is True
+  assert params.writes == [("ScreenRecord", True)]
+
+  # The nonblocking write is still stale at the first refresh boundary.
+  now = 0.5
+  assert layout._handle_carrot_record_cmd(carrot_command(1, "START")) is True
+  assert gui_app.is_recording() is True
+  assert params.writes == [("ScreenRecord", True)]
+
+  # Observe the acknowledgement, then accept a later external stop request.
+  params.values["ScreenRecord"] = True
+  now = 1.0
+  assert layout._handle_carrot_record_cmd(carrot_command(1, "START")) is True
+  params.values["ScreenRecord"] = False
+  now = 1.5
+  assert layout._handle_carrot_record_cmd(carrot_command(1, "START")) is False
+
+
+def test_missing_screen_record_ack_is_bounded(main_layout_module, monkeypatch):
+  module, gui_app, ui_state = main_layout_module
+  params = FakeParams({"ScreenRecord": False})
+  layout = make_main_layout(module, gui_app, ui_state, params)
+  now = 0.0
+  monkeypatch.setattr(module.time, "monotonic", lambda: now)
+
+  assert layout._handle_carrot_record_cmd(carrot_command(1, "START")) is True
+  now = 0.5
+  assert layout._handle_carrot_record_cmd(carrot_command(1, "START")) is True
+  now = 1.0
+  assert layout._handle_carrot_record_cmd(carrot_command(1, "START")) is False
+
+
+@pytest.mark.parametrize(
+  ("recording", "started", "arg", "expected"),
+  (
+    (True, True, "STOP", False),
+    (False, True, "TOGGLE", True),
+    (True, False, "START", False),
+  ),
+)
+def test_record_commands_and_offroad_clear_sync_pending_value(
+  main_layout_module, monkeypatch, recording, started, arg, expected,
+):
+  module, gui_app, ui_state = main_layout_module
+  gui_app.recording = recording
+  ui_state.started = started
+  params = FakeParams({"ScreenRecord": recording})
+  layout = make_main_layout(module, gui_app, ui_state, params)
+  monkeypatch.setattr(module.time, "monotonic", lambda: 2.0)
+
+  assert layout._handle_carrot_record_cmd(carrot_command(1, arg)) is expected
+  assert gui_app.is_recording() is expected
+  assert params.writes == [("ScreenRecord", expected)]
+  if not started:
+    assert "start" not in gui_app.calls
+
+  # A stale file value at the next boundary must not undo the local command.
+  assert layout._screen_record_param.refresh(2.5) is expected
+
+
+def test_targeted_param_reads_are_isolated_from_per_frame_paths():
+  targets = {
+    "CarName",
+    "HyundaiCameraSCC",
+    "NNFFModelName",
+    "CustomSR",
+    "GitBranch",
+    "NetworkAddress",
+    "RecordAudio",
+    "IsMetric",
+    "AlwaysOnDM",
+    "ScreenRecord",
+  }
+  production_files = (
+    UI_DIR / "onroad" / "augmented_road_view.py",
+    UI_DIR / "ui_state.py",
+    UI_DIR / "layouts" / "main.py",
+  )
+  offenders = []
+
+  for path in production_files:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    for call in (node for node in ast.walk(tree) if isinstance(node, ast.Call)):
+      if not isinstance(call.func, ast.Attribute) or call.func.attr not in {"get", "get_bool", "get_float", "get_int"}:
+        continue
+      if not call.args or not isinstance(call.args[0], ast.Constant) or call.args[0].value not in targets:
+        continue
+      offenders.append((path.name, call.lineno, call.args[0].value))
+
+  assert offenders == []

--- a/openpilot/selfdrive/ui/tests/test_carrot_ui_sched.py
+++ b/openpilot/selfdrive/ui/tests/test_carrot_ui_sched.py
@@ -1,0 +1,218 @@
+"""carrot 전용: UI 스케줄러 foundation(상시 SCHED_OTHER/core5) 회귀 테스트.
+
+기존 FIFO51/core5 UI는 planner/radar(FIFO51)와 같은 우선순위로 core5를 점유해
+20Hz cadence를 위협했다. foundation 계약:
+- UI는 상시 SCHED_OTHER (RT/FIFO 승격 프리미티브 부재, 재도입 금지)
+- 시작은 core0 부트스트랩(offroad power-save의 core4~7 offline 대응),
+  onroad에서 render loop가 cores={5}로 re-affine (실패 시 다음 프레임 재시도)
+- 시작 시 SCHED_OTHER를 명시 적용하고 readback 검증 (false success 금지,
+  검증 불가면 fail-stop), gc.disable()은 유지
+- core7은 modeld+dmonitoringmodeld 전용 — UI affinity 재도입 금지
+"""
+import ast
+import os
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+import openpilot.selfdrive.ui.carrot_ui_sched as cus
+from openpilot.selfdrive.ui.carrot_ui_sched import ensure_ui_sched_other
+
+UI_DIR = Path(cus.__file__).parent
+
+
+def _ui_py_tree():
+  # ui.py는 import 부작용(gui_app 생성, 레이아웃→msgq)이 있어 AST로 고정한다
+  return ast.parse((UI_DIR / "ui.py").read_text())
+
+
+def _call_names(tree):
+  names = []
+  for n in ast.walk(tree):
+    if isinstance(n, ast.Call):
+      if isinstance(n.func, ast.Name):
+        names.append(n.func.id)
+      elif isinstance(n.func, ast.Attribute):
+        names.append(n.func.attr)
+  return names
+
+
+def _affinity_shapes(tree):
+  """set_core_affinity 호출 인자의 구조를 수집 — 부트스트랩([0] 상수 리스트)과
+  re-affine(list(cores) 변수 연결)을 구분해 검증한다."""
+  shapes = []
+  for n in ast.walk(tree):
+    if not (isinstance(n, ast.Call) and isinstance(n.func, ast.Name)
+            and n.func.id == "set_core_affinity" and n.args):
+      continue
+    a = n.args[0]
+    if isinstance(a, ast.List) and all(isinstance(e, ast.Constant) for e in a.elts):
+      shapes.append(("const_list", tuple(e.value for e in a.elts)))
+    elif (isinstance(a, ast.Call) and isinstance(a.func, ast.Name) and a.func.id == "list"
+          and len(a.args) == 1 and isinstance(a.args[0], ast.Name)):
+      shapes.append(("list_of_var", a.args[0].id))
+    else:
+      shapes.append(("other", ast.dump(a)))
+  return shapes
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="sched_* API는 Linux 전용")
+class TestEnsureSchedOtherContract:
+  """시작 시 SCHED_OTHER 명시 적용/readback — false success 금지, bounded 재시도,
+  검증 불가면 fail-stop (RT UI가 core5의 planner/radar를 굶기며 돌면 안 된다)."""
+
+  def _run(self, monkeypatch, *, policies, drop_raises=False):
+    logs = {"info": [], "critical": []}
+    monkeypatch.setattr(cus, "PC", False)
+    monkeypatch.setattr(cus, "cloudlog", types.SimpleNamespace(
+      info=logs["info"].append, critical=logs["critical"].append))
+    drops = {"n": 0}
+
+    def fake_drop():
+      drops["n"] += 1
+      if drop_raises:
+        raise OSError("sched_setscheduler refused")
+
+    seq = list(policies)
+    monkeypatch.setattr(cus, "drop_realtime", fake_drop)
+    monkeypatch.setattr(os, "sched_getscheduler",
+                        lambda pid: seq.pop(0) if seq else (policies[-1] if policies else os.SCHED_OTHER))
+    return logs, drops
+
+  def test_verified_logs_success_once(self, monkeypatch):
+    logs, drops = self._run(monkeypatch, policies=[os.SCHED_OTHER])
+    ensure_ui_sched_other()
+    assert drops["n"] == 1
+    assert len(logs["info"]) == 1 and not logs["critical"]
+
+  def test_rt_readback_fails_stop_without_false_success(self, monkeypatch):
+    # readback이 끝내 FIFO면 성공 로그 없이 critical + fail-stop, 재시도는 bounded
+    logs, drops = self._run(monkeypatch, policies=[os.SCHED_FIFO, os.SCHED_FIFO])
+    with pytest.raises(RuntimeError):
+      ensure_ui_sched_other()
+    assert drops["n"] == 2  # _VERIFY_ATTEMPTS — 무한/매 프레임 폭주 금지
+    assert not logs["info"] and len(logs["critical"]) == 1
+
+  def test_transient_rt_recovers_on_retry(self, monkeypatch):
+    logs, _ = self._run(monkeypatch, policies=[os.SCHED_FIFO, os.SCHED_OTHER])
+    ensure_ui_sched_other()
+    assert len(logs["info"]) == 1 and not logs["critical"]
+
+  def test_oserror_bounded_then_fail_stop(self, monkeypatch):
+    logs, drops = self._run(monkeypatch, policies=[], drop_raises=True)
+    with pytest.raises(RuntimeError):
+      ensure_ui_sched_other()
+    assert drops["n"] == 2 and not logs["info"]
+
+  def test_pc_skips_all_syscalls(self, monkeypatch):
+    monkeypatch.setattr(cus, "PC", True)
+    def boom():
+      raise AssertionError("PC에서는 syscall 자체가 없어야 한다")
+    monkeypatch.setattr(cus, "drop_realtime", boom)
+    ensure_ui_sched_other()  # no-op
+
+
+class TestUiStartupAst:
+  """ui.py 시작/재affine 구조 고정 — import 부작용 때문에 AST 검증."""
+
+  def test_cores_var_assigned_literal_five(self):
+    # cores 변수에 정확히 {5}가 할당된다 (파일 어딘가의 {5}가 아니라 할당 구조)
+    tree = _ui_py_tree()
+    assigns = [n for n in ast.walk(tree) if isinstance(n, ast.Assign)
+               and any(isinstance(t, ast.Name) and t.id == "cores" for t in n.targets)]
+    assert len(assigns) == 1
+    val = assigns[0].value
+    assert isinstance(val, ast.Set) and len(val.elts) == 1
+    assert isinstance(val.elts[0], ast.Constant) and val.elts[0].value == 5
+
+  def test_bootstrap_core0_and_reaffine_linked_to_cores(self):
+    shapes = _affinity_shapes(_ui_py_tree())
+    assert ("const_list", (0,)) in shapes    # core0 부트스트랩 (상수 리스트)
+    assert ("list_of_var", "cores") in shapes  # re-affine은 cores 변수와 직접 연결
+    # 부트스트랩과 re-affine 외 다른 affinity 호출 형태는 없어야 한다
+    assert all(s in (("const_list", (0,)), ("list_of_var", "cores")) for s in shapes)
+
+  def test_gc_disable_retained(self):
+    # 스케줄러 helper 제거 과정에서 gc.disable()까지 사라지면 안 된다 —
+    # GC pause가 렌더 프레임 히치를 만든다 (기존 config_realtime_process 소관)
+    tree = _ui_py_tree()
+    assert any(isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)
+               and n.func.attr == "disable" and isinstance(n.func.value, ast.Name)
+               and n.func.value.id == "gc" for n in ast.walk(tree))
+
+  def test_startup_applies_sched_other_contract(self):
+    # 시작에서 SCHED_OTHER 명시 적용/검증 헬퍼가 호출된다
+    assert "ensure_ui_sched_other" in _call_names(_ui_py_tree())
+
+  def test_no_promotion_primitives_in_ui_py(self):
+    tree = _ui_py_tree()
+    names = _call_names(tree)
+    assert "config_realtime_process" not in names  # 재도입 금지
+    assert "sched_setscheduler" not in names
+    attrs = {n.attr for n in ast.walk(tree) if isinstance(n, ast.Attribute)}
+    assert "SCHED_FIFO" not in attrs
+    idents = {n.id for n in ast.walk(tree) if isinstance(n, ast.Name)}
+    imported = {a.name for n in ast.walk(tree) if isinstance(n, ast.ImportFrom) for a in n.names}
+    assert "Priority" not in idents and "Priority" not in imported  # CTRL_HIGH/CTRL_LOW 승격 금지
+    assert "CTRL_HIGH" not in attrs and "CTRL_LOW" not in attrs
+    # FIFO51의 숫자 직승격(config_realtime_process(0, 51) 시절)도 재도입 금지 —
+    # 승격 콜 부재로 이미 보장되지만 상수 51/53이 인자로 쓰이지 않는지도 고정
+    call_const_args = {a.value for n in ast.walk(tree) if isinstance(n, ast.Call)
+                       for a in n.args if isinstance(a, ast.Constant)}
+    assert 51 not in call_const_args and 53 not in call_const_args
+
+  def test_no_core7_ui_affinity(self):
+    # core7은 modeld(FIFO54)+dmonitoringmodeld(FIFO5) 전용 — UI 재배치 금지
+    tree = _ui_py_tree()
+    for node in ast.walk(tree):
+      if isinstance(node, (ast.Set, ast.List, ast.Tuple)):
+        consts = {e.value for e in node.elts if isinstance(e, ast.Constant)}
+        assert 7 not in consts
+
+  def test_reaffine_failure_swallowed_and_retryable(self):
+    # affinity 실패(offroad에 core5 offline 등)가 UI를 죽이면 안 된다 —
+    # try/except OSError로 삼키고, 렌더 루프 안이라 다음 프레임에 재시도된다
+    tree = _ui_py_tree()
+
+    def contains_reaffine(node):
+      return any(isinstance(n, ast.Call) and isinstance(n.func, ast.Name)
+                 and n.func.id == "set_core_affinity" and n.args
+                 and isinstance(n.args[0], ast.Call) for n in ast.walk(node))
+
+    guarded = [t for t in ast.walk(tree) if isinstance(t, ast.Try) and contains_reaffine(t)
+               and any(h.type is not None and isinstance(h.type, ast.Name)
+                       and h.type.id == "OSError" for h in t.handlers)]
+    assert guarded, "re-affine은 try/except OSError 안에 있어야 한다"
+    loops = [n for n in ast.walk(tree) if isinstance(n, (ast.For, ast.While))]
+    assert any(any(t in ast.walk(loop) for t in guarded) for loop in loops)
+
+
+class TestNoFifoAnywhereInUi:
+  """Plot ON/OFF 포함 selfdrive/ui 프로덕션 경로 어디에도 스케줄러를 FIFO로
+  올리는/복구하는 코드가 없어야 한다 (UI는 상시 SCHED_OTHER)."""
+
+  def _prod_sources(self):
+    for p in sorted((UI_DIR).rglob("*.py")):
+      if "tests" in p.parts:
+        continue
+      yield p, p.read_text()
+
+  def test_no_promotion_primitives_in_ui_tree(self):
+    offenders = []
+    for p, src in self._prod_sources():
+      tree = ast.parse(src)
+      names = _call_names(tree)
+      attrs = {n.attr for n in ast.walk(tree) if isinstance(n, ast.Attribute)}
+      if ("config_realtime_process" in names or "sched_setscheduler" in names
+          or "SCHED_FIFO" in attrs):
+        offenders.append(str(p.relative_to(UI_DIR)))
+    assert not offenders, f"FIFO 승격/복구 프리미티브 잔존: {offenders}"
+
+  def test_no_legacy_fifo_restore_logs(self):
+    # 과거 복구 로그가 남아 있으면 실기기 로그 분석이 구 설계로 오판한다
+    legacy = ("restored to SCHED_FIFO 53", "restored to SCHED_FIFO 51")
+    for p, src in self._prod_sources():
+      for s in legacy:
+        assert s not in src, f"{p.name}: 과거 로그 문자열 잔존 — {s}"

--- a/openpilot/selfdrive/ui/tests/test_text_draw_offsets.py
+++ b/openpilot/selfdrive/ui/tests/test_text_draw_offsets.py
@@ -32,7 +32,7 @@ def text_draw_module(monkeypatch):
   raylib.Vector2 = Vector2
   raylib.BLACK = Color(0, 0, 0, 255)
   raylib.draw_text_ex = lambda font, text, position, font_size, spacing, color: draw_calls.append(
-    (font, text, position, font_size, spacing, color),
+    (font, text, SimpleNamespace(x=position.x, y=position.y), font_size, spacing, color),
   )
   monkeypatch.setitem(sys.modules, "pyray", raylib)
   monkeypatch.setitem(
@@ -92,6 +92,10 @@ def test_text_outline_positions_match_legacy_geometry(text_draw_module, monkeypa
   )
 
   assert len(draw_calls) == 10
+  assert all(call[0] == "font" for call in draw_calls)
+  assert all(call[1] == "speed" for call in draw_calls)
+  assert all(call[3] == 50.0 and type(call[3]) is float for call in draw_calls)
+  assert all(call[4] == 0 for call in draw_calls)
   legacy_offsets = tuple(
     (math.cos(math.radians(deg)), math.sin(math.radians(deg)))
     for deg in range(0, 360, 45)
@@ -117,8 +121,40 @@ def test_zero_border_and_shadow_draw_only_main_text(text_draw_module, monkeypatc
   module.draw_text_ui_style("speed", 0, 0, 50, main_color, font="font", border_width=0, shadow_offset=0)
 
   assert len(draw_calls) == 1
+  assert draw_calls[0][0] == "font"
+  assert draw_calls[0][1] == "speed"
+  assert draw_calls[0][3] == 50.0 and type(draw_calls[0][3]) is float
+  assert draw_calls[0][4] == 0
   assert (draw_calls[0][2].x, draw_calls[0][2].y) == (10.0, 20.0)
   assert draw_calls[0][5] == main_color
+
+
+def test_styled_text_reuses_one_draw_position(text_draw_module, monkeypatch):
+  module, draw_calls = text_draw_module
+  monkeypatch.setattr(module, "get_text_draw_pos", lambda *args, **kwargs: (10.0, 20.0, None))
+  vector_constructions = []
+
+  class TrackingVector2:
+    def __init__(self, x, y):
+      vector_constructions.append((x, y))
+      self.x = x
+      self.y = y
+
+  monkeypatch.setattr(module.rl, "Vector2", TrackingVector2)
+
+  module.draw_text_ui_style(
+    "speed",
+    0,
+    0,
+    50,
+    module.rl.Color(1, 2, 3, 4),
+    font="font",
+    border_width=3,
+    shadow_offset=4,
+  )
+
+  assert len(draw_calls) == 10
+  assert vector_constructions == [(10.0, 20.0)]
 
 
 def test_draw_call_does_not_recompute_trigonometry(text_draw_module, monkeypatch):

--- a/openpilot/selfdrive/ui/tests/test_text_draw_offsets.py
+++ b/openpilot/selfdrive/ui/tests/test_text_draw_offsets.py
@@ -31,6 +31,7 @@ def text_draw_module(monkeypatch):
   raylib.Color = Color
   raylib.Vector2 = Vector2
   raylib.BLACK = Color(0, 0, 0, 255)
+  raylib.rl = SimpleNamespace(DrawTextEx=None)
   raylib.draw_text_ex = lambda font, text, position, font_size, spacing, color: draw_calls.append(
     (font, text, SimpleNamespace(x=position.x, y=position.y), font_size, spacing, color),
   )
@@ -39,8 +40,10 @@ def text_draw_module(monkeypatch):
     sys.modules,
     "openpilot.system.ui.lib.application",
     SimpleNamespace(
+      FONT_SCALE=1.242,
       gui_app=SimpleNamespace(font=lambda weight: ("font", weight)),
       FontWeight=SimpleNamespace(DISPLAY=1),
+      font_fallback=lambda font: font,
     ),
   )
   monkeypatch.setitem(
@@ -180,3 +183,111 @@ def test_draw_call_does_not_recompute_trigonometry(text_draw_module, monkeypatch
   )
 
   assert len(draw_calls) == 9
+
+
+@pytest.mark.parametrize(("text_value", "scale"), [("speed", 1.16), ("속도", 1.242)])
+def test_raw_draw_path_encodes_once_and_preserves_scaled_geometry(
+  text_draw_module, monkeypatch, text_value, scale,
+):
+  module, wrapper_calls = text_draw_module
+  raw_calls = []
+  fallback_calls = []
+  encode_calls = []
+  base_x, base_y = 100.0, 200.0
+
+  class TrackingText(str):
+    def encode(self, encoding="utf-8", errors="strict"):
+      encode_calls.append((encoding, errors))
+      return super().encode(encoding, errors)
+
+  def raw_draw_text_ex(font, text, position, font_size, spacing, color):
+    raw_calls.append(
+      (font, text, id(text), SimpleNamespace(x=position.x, y=position.y), font_size, spacing, color, id(position)),
+    )
+
+  def fallback(font):
+    fallback_calls.append(font)
+    return "fallback-font"
+
+  monkeypatch.setattr(module, "_RAW_DRAW_TEXT_EX", raw_draw_text_ex)
+  monkeypatch.setattr(module, "FONT_SCALE", scale)
+  monkeypatch.setattr(module, "font_fallback", fallback)
+  monkeypatch.setattr(module, "get_text_draw_pos", lambda *args, **kwargs: (base_x, base_y, None))
+
+  text = TrackingText(text_value)
+  main_color = module.rl.Color(1, 2, 3, 4)
+  border_color = module.rl.Color(5, 6, 7, 8)
+  shadow_color = module.rl.Color(9, 10, 11, 12)
+  module.draw_text_ui_style(
+    text,
+    0,
+    0,
+    50,
+    main_color,
+    font="original-font",
+    border_width=1.0,
+    shadow_offset=4.0,
+    border_color=border_color,
+    shadow_color=shadow_color,
+  )
+
+  assert wrapper_calls == []
+  assert encode_calls == [("utf-8", "strict")]
+  assert fallback_calls == ["original-font"]
+  assert len(raw_calls) == 10
+  assert all(call[0] == "fallback-font" for call in raw_calls)
+  assert all(call[1] == text_value.encode() for call in raw_calls)
+  assert len({call[2] for call in raw_calls}) == 1
+  assert len({call[7] for call in raw_calls}) == 1
+  assert all(call[4] == 50.0 * scale for call in raw_calls)
+  assert all(call[5] == 0 for call in raw_calls)
+
+  for call, (unit_x, unit_y) in zip(raw_calls[:8], module._OUTLINE_UNIT_OFFSETS, strict=True):
+    assert (call[3].x, call[3].y) == (base_x + unit_x, base_y + unit_y)
+    assert call[6] == border_color
+
+  assert (raw_calls[8][3].x, raw_calls[8][3].y) == (base_x + 4.0, base_y + 4.0)
+  assert raw_calls[8][6] == shadow_color
+  assert (raw_calls[9][3].x, raw_calls[9][3].y) == (base_x, base_y)
+  assert raw_calls[9][6] == main_color
+
+
+def test_missing_raw_symbol_keeps_pyray_wrapper_path(text_draw_module, monkeypatch):
+  module, draw_calls = text_draw_module
+  monkeypatch.setattr(module, "_RAW_DRAW_TEXT_EX", None)
+  monkeypatch.setattr(module, "font_fallback", lambda _: pytest.fail("wrapper path owns font fallback"))
+  monkeypatch.setattr(module, "get_text_draw_pos", lambda *args, **kwargs: (10.0, 20.0, None))
+
+  module.draw_text_ui_style(
+    "speed",
+    0,
+    0,
+    50,
+    module.rl.Color(1, 2, 3, 4),
+    font="font",
+    border_width=0,
+    shadow_offset=0,
+  )
+
+  assert len(draw_calls) == 1
+  assert draw_calls[0][0] == "font"
+  assert draw_calls[0][1] == "speed"
+  assert draw_calls[0][3] == 50.0
+
+
+def test_empty_text_skips_both_draw_paths(text_draw_module, monkeypatch):
+  module, wrapper_calls = text_draw_module
+  encode_calls = []
+
+  class EmptyTrackingText(str):
+    def encode(self, encoding="utf-8", errors="strict"):
+      encode_calls.append((encoding, errors))
+      return super().encode(encoding, errors)
+
+  monkeypatch.setattr(module, "_RAW_DRAW_TEXT_EX", lambda *args: pytest.fail("empty text must not draw"))
+  monkeypatch.setattr(module, "font_fallback", lambda _: pytest.fail("empty text must not select a font"))
+
+  module.draw_text_ui_style(EmptyTrackingText(""), 0, 0, 50, module.rl.Color(1, 2, 3, 4))
+
+  assert encode_calls == []
+  assert wrapper_calls == []

--- a/openpilot/selfdrive/ui/tests/test_text_draw_offsets.py
+++ b/openpilot/selfdrive/ui/tests/test_text_draw_offsets.py
@@ -1,0 +1,146 @@
+import importlib.util
+import math
+import sys
+import types
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+TEXT_DRAW_PATH = Path(__file__).parents[3] / "system" / "ui" / "lib" / "text_draw.py"
+
+
+@pytest.fixture
+def text_draw_module(monkeypatch):
+  @dataclass(frozen=True)
+  class Color:
+    r: int
+    g: int
+    b: int
+    a: int
+
+  @dataclass
+  class Vector2:
+    x: float
+    y: float
+
+  draw_calls = []
+  raylib = types.ModuleType("pyray")
+  raylib.Color = Color
+  raylib.Vector2 = Vector2
+  raylib.BLACK = Color(0, 0, 0, 255)
+  raylib.draw_text_ex = lambda font, text, position, font_size, spacing, color: draw_calls.append(
+    (font, text, position, font_size, spacing, color),
+  )
+  monkeypatch.setitem(sys.modules, "pyray", raylib)
+  monkeypatch.setitem(
+    sys.modules,
+    "openpilot.system.ui.lib.application",
+    SimpleNamespace(
+      gui_app=SimpleNamespace(font=lambda weight: ("font", weight)),
+      FontWeight=SimpleNamespace(DISPLAY=1),
+    ),
+  )
+  monkeypatch.setitem(
+    sys.modules,
+    "openpilot.system.ui.lib.text_measure",
+    SimpleNamespace(measure_text_cached=lambda font, text, size: Vector2(len(text) * size, size)),
+  )
+
+  module_name = f"_test_text_draw_{id(draw_calls)}"
+  spec = importlib.util.spec_from_file_location(module_name, TEXT_DRAW_PATH)
+  assert spec is not None and spec.loader is not None
+  module = importlib.util.module_from_spec(spec)
+  monkeypatch.setitem(sys.modules, module_name, module)
+  spec.loader.exec_module(module)
+  return module, draw_calls
+
+
+def test_outline_offsets_are_the_eight_legacy_directions(text_draw_module):
+  module, _ = text_draw_module
+  expected = tuple(
+    (math.cos(math.radians(deg)), math.sin(math.radians(deg)))
+    for deg in range(0, 360, 45)
+  )
+
+  assert module._OUTLINE_UNIT_OFFSETS == expected
+
+
+@pytest.mark.parametrize("border_width", [0.5, 1.0, 3.0, 9.0])
+def test_text_outline_positions_match_legacy_geometry(text_draw_module, monkeypatch, border_width):
+  module, draw_calls = text_draw_module
+  base_x, base_y = 100.0, 200.0
+  shadow_offset = 4.0
+  main_color = module.rl.Color(1, 2, 3, 4)
+  border_color = module.rl.Color(5, 6, 7, 8)
+  shadow_color = module.rl.Color(9, 10, 11, 12)
+  monkeypatch.setattr(module, "get_text_draw_pos", lambda *args, **kwargs: (base_x, base_y, None))
+
+  module.draw_text_ui_style(
+    "speed",
+    0,
+    0,
+    50,
+    main_color,
+    font="font",
+    border_width=border_width,
+    shadow_offset=shadow_offset,
+    border_color=border_color,
+    shadow_color=shadow_color,
+  )
+
+  assert len(draw_calls) == 10
+  legacy_offsets = tuple(
+    (math.cos(math.radians(deg)), math.sin(math.radians(deg)))
+    for deg in range(0, 360, 45)
+  )
+  for call, (unit_x, unit_y) in zip(draw_calls[:8], legacy_offsets, strict=True):
+    assert (call[2].x, call[2].y) == (
+      base_x + border_width * unit_x,
+      base_y + border_width * unit_y,
+    )
+    assert call[5] == border_color
+
+  assert (draw_calls[8][2].x, draw_calls[8][2].y) == (base_x + shadow_offset, base_y + shadow_offset)
+  assert draw_calls[8][5] == shadow_color
+  assert (draw_calls[9][2].x, draw_calls[9][2].y) == (base_x, base_y)
+  assert draw_calls[9][5] == main_color
+
+
+def test_zero_border_and_shadow_draw_only_main_text(text_draw_module, monkeypatch):
+  module, draw_calls = text_draw_module
+  main_color = module.rl.Color(1, 2, 3, 4)
+  monkeypatch.setattr(module, "get_text_draw_pos", lambda *args, **kwargs: (10.0, 20.0, None))
+
+  module.draw_text_ui_style("speed", 0, 0, 50, main_color, font="font", border_width=0, shadow_offset=0)
+
+  assert len(draw_calls) == 1
+  assert (draw_calls[0][2].x, draw_calls[0][2].y) == (10.0, 20.0)
+  assert draw_calls[0][5] == main_color
+
+
+def test_draw_call_does_not_recompute_trigonometry(text_draw_module, monkeypatch):
+  module, draw_calls = text_draw_module
+  monkeypatch.setattr(module, "get_text_draw_pos", lambda *args, **kwargs: (10.0, 20.0, None))
+
+  def fail(*args, **kwargs):
+    pytest.fail("trigonometry was recomputed during draw")
+
+  monkeypatch.setattr(module.math, "cos", fail)
+  monkeypatch.setattr(module.math, "sin", fail)
+  monkeypatch.setattr(module.math, "radians", fail)
+
+  module.draw_text_ui_style(
+    "speed",
+    0,
+    0,
+    50,
+    module.rl.Color(1, 2, 3, 4),
+    font="font",
+    border_width=3,
+    shadow_offset=0,
+  )
+
+  assert len(draw_calls) == 9

--- a/openpilot/selfdrive/ui/tests/test_ui_debug_hud_schema.py
+++ b/openpilot/selfdrive/ui/tests/test_ui_debug_hud_schema.py
@@ -18,46 +18,27 @@ EXPECTED_UI_DEBUG_FIELDS = [
   ("extrasTimeMillis", 6, "Float32"),
   ("plotMode", 7, "UInt8"),
   ("recording", 8, "Bool"),
-  ("modelPathTimeMillis", 9, "Float32"),
-  ("modelLaneTimeMillis", 10, "Float32"),
-  ("modelBlindSpotTimeMillis", 11, "Float32"),
-  ("modelRadarTimeMillis", 12, "Float32"),
-  ("modelTimingValid", 13, "Bool"),
-  ("hudHeaderTimeMillis", 14, "Float32"),
-  ("hudSpeedTimeMillis", 15, "Float32"),
-  ("hudStatusTimeMillis", 16, "Float32"),
-  ("hudNavigationTimeMillis", 17, "Float32"),
-  ("hudButtonTimeMillis", 18, "Float32"),
-  ("hudPlotTimeMillis", 19, "Float32"),
-  ("hudAuxTimeMillis", 20, "Float32"),
-  ("hudTimingValid", 21, "Bool"),
-  ("modelBlindSpotStateMask", 22, "UInt8"),
-  ("modelBlindSpotStateValid", 23, "Bool"),
+  ("modelPathTimeMillisDEPRECATED", 9, "Float32"),
+  ("modelLaneTimeMillisDEPRECATED", 10, "Float32"),
+  ("modelBlindSpotTimeMillisDEPRECATED", 11, "Float32"),
+  ("modelRadarTimeMillisDEPRECATED", 12, "Float32"),
+  ("modelTimingValidDEPRECATED", 13, "Bool"),
+  ("hudHeaderTimeMillisDEPRECATED", 14, "Float32"),
+  ("hudSpeedTimeMillisDEPRECATED", 15, "Float32"),
+  ("hudStatusTimeMillisDEPRECATED", 16, "Float32"),
+  ("hudNavigationTimeMillisDEPRECATED", 17, "Float32"),
+  ("hudButtonTimeMillisDEPRECATED", 18, "Float32"),
+  ("hudPlotTimeMillisDEPRECATED", 19, "Float32"),
+  ("hudAuxTimeMillisDEPRECATED", 20, "Float32"),
+  ("hudTimingValidDEPRECATED", 21, "Bool"),
+  ("modelBlindSpotStateMaskDEPRECATED", 22, "UInt8"),
+  ("modelBlindSpotStateValidDEPRECATED", 23, "Bool"),
 ]
 
-EXPECTED_HUD_PUBLISH_MAPPING = {
-  "hudHeaderTimeMillis": "header_time_millis",
-  "hudSpeedTimeMillis": "speed_time_millis",
-  "hudStatusTimeMillis": "status_time_millis",
-  "hudNavigationTimeMillis": "navigation_time_millis",
-  "hudButtonTimeMillis": "button_time_millis",
-  "hudPlotTimeMillis": "plot_time_millis",
-  "hudAuxTimeMillis": "aux_time_millis",
-  "hudTimingValid": "valid",
-}
-
-EXPECTED_MODEL_PUBLISH_MAPPING = {
-  "modelPathTimeMillis": "path_time_millis",
-  "modelLaneTimeMillis": "lane_time_millis",
-  "modelBlindSpotTimeMillis": "blind_spot_time_millis",
-  "modelRadarTimeMillis": "radar_time_millis",
-  "modelTimingValid": "valid",
-  "modelBlindSpotStateMask": "blind_spot_state_mask",
-  "modelBlindSpotStateValid": "blind_spot_state_valid",
-}
+EXPECTED_UI_DEBUG_PUBLISH_FIELDS = {name for name, ordinal, _ in EXPECTED_UI_DEBUG_FIELDS if ordinal <= 8}
 
 
-def test_ui_debug_schema_keeps_legacy_ordinals_and_appends_hud_fields():
+def test_ui_debug_schema_reserves_detailed_profiling_ordinals():
   source = LOG_PATH.read_text(encoding="utf-8")
   body = source.split("struct UIDebug {", 1)[1].split("}", 1)[0]
   fields = [
@@ -80,85 +61,52 @@ def _is_attribute(node, *names):
   return isinstance(node, ast.Name) and node.id == names[0]
 
 
-def test_augmented_road_view_publishes_hud_snapshot_after_render():
+def test_augmented_road_view_publishes_compact_snapshot_after_render():
   tree = ast.parse(AUGMENTED_ROAD_VIEW_PATH.read_text(encoding="utf-8"))
-  mappings = {}
-  mapping_lines = []
+  publish_fields = set()
+  publish_lines = []
   render_lines = []
-  snapshot_lines = []
+  new_message_lines = []
   send_lines = []
 
   for node in ast.walk(tree):
     if isinstance(node, ast.Assign) and len(node.targets) == 1:
       target = node.targets[0]
-      value = node.value
       if (
         isinstance(target, ast.Attribute)
         and isinstance(target.value, ast.Name)
         and target.value.id == "ud"
-        and isinstance(value, ast.Attribute)
-        and isinstance(value.value, ast.Name)
-        and value.value.id == "hud_timings"
       ):
-        assert target.attr not in mappings, f"duplicate publish assignment for {target.attr}"
-        mappings[target.attr] = value.attr
-        mapping_lines.append(node.lineno)
-      if (
-        isinstance(target, ast.Name)
-        and target.id == "hud_timings"
-        and _is_attribute(value, "self", "_hud_renderer", "render_timings")
-      ):
-        snapshot_lines.append(node.lineno)
+        assert target.attr not in publish_fields, f"duplicate publish assignment for {target.attr}"
+        publish_fields.add(target.attr)
+        publish_lines.append(node.lineno)
 
-    if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
-      if _is_attribute(node.func, "self", "_hud_renderer", "render"):
+    if isinstance(node, ast.Call):
+      if (
+        isinstance(node.func, ast.Attribute)
+        and (
+          _is_attribute(node.func, "self", "model_renderer", "render")
+          or _is_attribute(node.func, "self", "_hud_renderer", "render")
+          or _is_attribute(node.func, "self", "alert_renderer", "render")
+          or _is_attribute(node.func, "self", "driver_state_renderer", "render")
+        )
+      ):
         render_lines.append(node.lineno)
-      if _is_attribute(node.func, "self", "_pm", "send"):
+      if isinstance(node.func, ast.Attribute) and _is_attribute(node.func, "self", "_pm", "send"):
         send_lines.append(node.lineno)
-
-  assert mappings == EXPECTED_HUD_PUBLISH_MAPPING
-  assert len(snapshot_lines) == 1
-  assert render_lines and send_lines
-  assert render_lines[-1] < snapshot_lines[0] < min(mapping_lines) <= max(mapping_lines) < send_lines[-1]
-
-
-def test_augmented_road_view_publishes_model_snapshot_after_render():
-  tree = ast.parse(AUGMENTED_ROAD_VIEW_PATH.read_text(encoding="utf-8"))
-  mappings = {}
-  mapping_lines = []
-  render_lines = []
-  snapshot_lines = []
-  send_lines = []
-
-  for node in ast.walk(tree):
-    if isinstance(node, ast.Assign) and len(node.targets) == 1:
-      target = node.targets[0]
-      value = node.value
       if (
-        isinstance(target, ast.Attribute)
-        and isinstance(target.value, ast.Name)
-        and target.value.id == "ud"
-        and isinstance(value, ast.Attribute)
-        and isinstance(value.value, ast.Name)
-        and value.value.id == "model_timings"
+        isinstance(node.func, ast.Attribute)
+        and _is_attribute(node.func, "messaging", "new_message")
+        and node.args
+        and isinstance(node.args[0], ast.Constant)
+        and node.args[0].value == "uiDebug"
       ):
-        assert target.attr not in mappings, f"duplicate publish assignment for {target.attr}"
-        mappings[target.attr] = value.attr
-        mapping_lines.append(node.lineno)
-      if (
-        isinstance(target, ast.Name)
-        and target.id == "model_timings"
-        and _is_attribute(value, "self", "model_renderer", "render_timings")
-      ):
-        snapshot_lines.append(node.lineno)
+        valid_keywords = [kw.value for kw in node.keywords if kw.arg == "valid"]
+        assert len(valid_keywords) == 1
+        assert isinstance(valid_keywords[0], ast.Constant) and valid_keywords[0].value is True
+        new_message_lines.append(node.lineno)
 
-    if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
-      if _is_attribute(node.func, "self", "model_renderer", "render"):
-        render_lines.append(node.lineno)
-      if _is_attribute(node.func, "self", "_pm", "send"):
-        send_lines.append(node.lineno)
-
-  assert mappings == EXPECTED_MODEL_PUBLISH_MAPPING
-  assert len(snapshot_lines) == 1
+  assert publish_fields == EXPECTED_UI_DEBUG_PUBLISH_FIELDS
+  assert len(new_message_lines) == 1
   assert render_lines and send_lines
-  assert render_lines[-1] < snapshot_lines[0] < min(mapping_lines) <= max(mapping_lines) < send_lines[-1]
+  assert render_lines[-1] < new_message_lines[0] < min(publish_lines) <= max(publish_lines) < send_lines[-1]

--- a/openpilot/selfdrive/ui/tests/test_ui_debug_hud_schema.py
+++ b/openpilot/selfdrive/ui/tests/test_ui_debug_hud_schema.py
@@ -1,0 +1,110 @@
+import ast
+import re
+from pathlib import Path
+
+
+OPENPILOT_DIR = Path(__file__).parents[3]
+LOG_PATH = OPENPILOT_DIR / "cereal" / "log.capnp"
+AUGMENTED_ROAD_VIEW_PATH = Path(__file__).parents[1] / "onroad" / "augmented_road_view.py"
+
+
+EXPECTED_UI_DEBUG_FIELDS = [
+  ("drawTimeMillis", 0, "Float32"),
+  ("cameraTimeMillis", 1, "Float32"),
+  ("modelTimeMillis", 2, "Float32"),
+  ("driverStateTimeMillis", 3, "Float32"),
+  ("hudTimeMillis", 4, "Float32"),
+  ("alertTimeMillis", 5, "Float32"),
+  ("extrasTimeMillis", 6, "Float32"),
+  ("plotMode", 7, "UInt8"),
+  ("recording", 8, "Bool"),
+  ("modelPathTimeMillis", 9, "Float32"),
+  ("modelLaneTimeMillis", 10, "Float32"),
+  ("modelBlindSpotTimeMillis", 11, "Float32"),
+  ("modelRadarTimeMillis", 12, "Float32"),
+  ("modelTimingValid", 13, "Bool"),
+  ("hudHeaderTimeMillis", 14, "Float32"),
+  ("hudSpeedTimeMillis", 15, "Float32"),
+  ("hudStatusTimeMillis", 16, "Float32"),
+  ("hudNavigationTimeMillis", 17, "Float32"),
+  ("hudButtonTimeMillis", 18, "Float32"),
+  ("hudPlotTimeMillis", 19, "Float32"),
+  ("hudAuxTimeMillis", 20, "Float32"),
+  ("hudTimingValid", 21, "Bool"),
+]
+
+EXPECTED_HUD_PUBLISH_MAPPING = {
+  "hudHeaderTimeMillis": "header_time_millis",
+  "hudSpeedTimeMillis": "speed_time_millis",
+  "hudStatusTimeMillis": "status_time_millis",
+  "hudNavigationTimeMillis": "navigation_time_millis",
+  "hudButtonTimeMillis": "button_time_millis",
+  "hudPlotTimeMillis": "plot_time_millis",
+  "hudAuxTimeMillis": "aux_time_millis",
+  "hudTimingValid": "valid",
+}
+
+
+def test_ui_debug_schema_keeps_legacy_ordinals_and_appends_hud_fields():
+  source = LOG_PATH.read_text(encoding="utf-8")
+  body = source.split("struct UIDebug {", 1)[1].split("}", 1)[0]
+  fields = [
+    (name, int(ordinal), field_type)
+    for name, ordinal, field_type in re.findall(
+      r"^\s*(\w+)\s+@(\d+)\s*:(\w+)", body, flags=re.MULTILINE,
+    )
+  ]
+
+  assert fields == EXPECTED_UI_DEBUG_FIELDS
+  assert len({ordinal for _, ordinal, _ in fields}) == len(fields)
+  assert [ordinal for _, ordinal, _ in fields] == list(range(22))
+
+
+def _is_attribute(node, *names):
+  for name in reversed(names[1:]):
+    if not isinstance(node, ast.Attribute) or node.attr != name:
+      return False
+    node = node.value
+  return isinstance(node, ast.Name) and node.id == names[0]
+
+
+def test_augmented_road_view_publishes_hud_snapshot_after_render():
+  tree = ast.parse(AUGMENTED_ROAD_VIEW_PATH.read_text(encoding="utf-8"))
+  mappings = {}
+  mapping_lines = []
+  render_lines = []
+  snapshot_lines = []
+  send_lines = []
+
+  for node in ast.walk(tree):
+    if isinstance(node, ast.Assign) and len(node.targets) == 1:
+      target = node.targets[0]
+      value = node.value
+      if (
+        isinstance(target, ast.Attribute)
+        and isinstance(target.value, ast.Name)
+        and target.value.id == "ud"
+        and isinstance(value, ast.Attribute)
+        and isinstance(value.value, ast.Name)
+        and value.value.id == "hud_timings"
+      ):
+        assert target.attr not in mappings, f"duplicate publish assignment for {target.attr}"
+        mappings[target.attr] = value.attr
+        mapping_lines.append(node.lineno)
+      if (
+        isinstance(target, ast.Name)
+        and target.id == "hud_timings"
+        and _is_attribute(value, "self", "_hud_renderer", "render_timings")
+      ):
+        snapshot_lines.append(node.lineno)
+
+    if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+      if _is_attribute(node.func, "self", "_hud_renderer", "render"):
+        render_lines.append(node.lineno)
+      if _is_attribute(node.func, "self", "_pm", "send"):
+        send_lines.append(node.lineno)
+
+  assert mappings == EXPECTED_HUD_PUBLISH_MAPPING
+  assert len(snapshot_lines) == 1
+  assert render_lines and send_lines
+  assert render_lines[-1] < snapshot_lines[0] < min(mapping_lines) <= max(mapping_lines) < send_lines[-1]

--- a/openpilot/selfdrive/ui/tests/test_ui_debug_hud_schema.py
+++ b/openpilot/selfdrive/ui/tests/test_ui_debug_hud_schema.py
@@ -31,6 +31,8 @@ EXPECTED_UI_DEBUG_FIELDS = [
   ("hudPlotTimeMillis", 19, "Float32"),
   ("hudAuxTimeMillis", 20, "Float32"),
   ("hudTimingValid", 21, "Bool"),
+  ("modelBlindSpotStateMask", 22, "UInt8"),
+  ("modelBlindSpotStateValid", 23, "Bool"),
 ]
 
 EXPECTED_HUD_PUBLISH_MAPPING = {
@@ -42,6 +44,16 @@ EXPECTED_HUD_PUBLISH_MAPPING = {
   "hudPlotTimeMillis": "plot_time_millis",
   "hudAuxTimeMillis": "aux_time_millis",
   "hudTimingValid": "valid",
+}
+
+EXPECTED_MODEL_PUBLISH_MAPPING = {
+  "modelPathTimeMillis": "path_time_millis",
+  "modelLaneTimeMillis": "lane_time_millis",
+  "modelBlindSpotTimeMillis": "blind_spot_time_millis",
+  "modelRadarTimeMillis": "radar_time_millis",
+  "modelTimingValid": "valid",
+  "modelBlindSpotStateMask": "blind_spot_state_mask",
+  "modelBlindSpotStateValid": "blind_spot_state_valid",
 }
 
 
@@ -57,7 +69,7 @@ def test_ui_debug_schema_keeps_legacy_ordinals_and_appends_hud_fields():
 
   assert fields == EXPECTED_UI_DEBUG_FIELDS
   assert len({ordinal for _, ordinal, _ in fields}) == len(fields)
-  assert [ordinal for _, ordinal, _ in fields] == list(range(22))
+  assert [ordinal for _, ordinal, _ in fields] == list(range(24))
 
 
 def _is_attribute(node, *names):
@@ -105,6 +117,48 @@ def test_augmented_road_view_publishes_hud_snapshot_after_render():
         send_lines.append(node.lineno)
 
   assert mappings == EXPECTED_HUD_PUBLISH_MAPPING
+  assert len(snapshot_lines) == 1
+  assert render_lines and send_lines
+  assert render_lines[-1] < snapshot_lines[0] < min(mapping_lines) <= max(mapping_lines) < send_lines[-1]
+
+
+def test_augmented_road_view_publishes_model_snapshot_after_render():
+  tree = ast.parse(AUGMENTED_ROAD_VIEW_PATH.read_text(encoding="utf-8"))
+  mappings = {}
+  mapping_lines = []
+  render_lines = []
+  snapshot_lines = []
+  send_lines = []
+
+  for node in ast.walk(tree):
+    if isinstance(node, ast.Assign) and len(node.targets) == 1:
+      target = node.targets[0]
+      value = node.value
+      if (
+        isinstance(target, ast.Attribute)
+        and isinstance(target.value, ast.Name)
+        and target.value.id == "ud"
+        and isinstance(value, ast.Attribute)
+        and isinstance(value.value, ast.Name)
+        and value.value.id == "model_timings"
+      ):
+        assert target.attr not in mappings, f"duplicate publish assignment for {target.attr}"
+        mappings[target.attr] = value.attr
+        mapping_lines.append(node.lineno)
+      if (
+        isinstance(target, ast.Name)
+        and target.id == "model_timings"
+        and _is_attribute(value, "self", "model_renderer", "render_timings")
+      ):
+        snapshot_lines.append(node.lineno)
+
+    if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+      if _is_attribute(node.func, "self", "model_renderer", "render"):
+        render_lines.append(node.lineno)
+      if _is_attribute(node.func, "self", "_pm", "send"):
+        send_lines.append(node.lineno)
+
+  assert mappings == EXPECTED_MODEL_PUBLISH_MAPPING
   assert len(snapshot_lines) == 1
   assert render_lines and send_lines
   assert render_lines[-1] < snapshot_lines[0] < min(mapping_lines) <= max(mapping_lines) < send_lines[-1]

--- a/openpilot/selfdrive/ui/ui.py
+++ b/openpilot/selfdrive/ui/ui.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
+import gc
 import os
 
 from openpilot.system.hardware import TICI
-from openpilot.common.realtime import config_realtime_process, set_core_affinity
+from openpilot.common.realtime import set_core_affinity
+from openpilot.selfdrive.ui.carrot_ui_sched import ensure_ui_sched_other
 from openpilot.system.ui.lib.application import gui_app
 from openpilot.selfdrive.ui.layouts.main import MainLayout
 from openpilot.selfdrive.ui.mici.layouts.main import MiciMainLayout
@@ -13,7 +15,20 @@ BIG_UI = gui_app.big_ui()
 
 def main():
   cores = {5, }
-  config_realtime_process(0, 51)
+  # UI는 상시 SCHED_OTHER — 비RT UI는 core5의 plannerd/radard(FIFO51)를
+  # 절대 선점하지 못하므로 주행 프로세스가 항상 우선한다 (기존 FIFO51 UI는
+  # 같은 우선순위로 core5를 점유해 20Hz cadence를 위협). FIFO 승격 재도입
+  # 금지, core7은 modeld+dmonitoringmodeld 전용이라 UI 재배치도 금지.
+  # GC는 계속 끈다 — 기존 config_realtime_process가 하던 GC pause(프레임
+  # 히치) 방지는 유지해야 한다.
+  gc.disable()
+  # TICI offroad power-save는 big core4~7을 offline한다 — always_run UI는
+  # 항상 online인 core0에서 부트스트랩하고, onroad에서 core5가 online되면
+  # 아래 render loop가 best-effort로 re-affine한다 (실패는 삼키고 다음
+  # 프레임에 재시도).
+  set_core_affinity([0])
+  # SCHED_OTHER 계약 명시 적용 + readback 검증 (실패는 fail-stop)
+  ensure_ui_sched_other()
 
   gui_app.init_window("UI")
   if BIG_UI:

--- a/openpilot/selfdrive/ui/ui_state.py
+++ b/openpilot/selfdrive/ui/ui_state.py
@@ -8,6 +8,7 @@ from openpilot.cereal import messaging, car, log
 from openpilot.common.filter_simple import FirstOrderFilter
 from openpilot.common.params import Params
 from openpilot.common.swaglog import cloudlog
+from openpilot.selfdrive.ui.carrot_param_cache import RealtimeUiParamSnapshot, TimedSnapshotCache, read_realtime_ui_params
 from openpilot.selfdrive.ui.lib.prime_state import PrimeState
 from openpilot.system.ui.lib.application import gui_app
 from openpilot.system.hardware import HARDWARE, PC
@@ -75,9 +76,15 @@ class UIState:
     self._started_prev: bool = False
 
     # Core state variables
-    self.is_metric: bool = self.params.get_bool("IsMetric")
+    self._realtime_params = TimedSnapshotCache(
+      RealtimeUiParamSnapshot(),
+      lambda: read_realtime_ui_params(self.params),
+    )
+    realtime_params = self._realtime_params.refresh(time.monotonic())
+    self.is_metric: bool = realtime_params.is_metric
     self.is_release = self.params.get_bool("IsReleaseBranch")
-    self.always_on_dm: bool = self.params.get_bool("AlwaysOnDM")
+    self.always_on_dm: bool = realtime_params.always_on_dm
+    self._record_audio_param: bool = realtime_params.record_audio
     self.started: bool = False
     self.ignition: bool = False
     self.recording_audio: bool = False
@@ -148,10 +155,11 @@ class UIState:
     self.started = self.sm["deviceState"].started and self.ignition
 
     # Update recording audio state
-    self.recording_audio = self.params.get_bool("RecordAudio") and self.started
-
-    self.is_metric = self.params.get_bool("IsMetric")
-    self.always_on_dm = self.params.get_bool("AlwaysOnDM")
+    realtime_params = self._realtime_params.refresh(time.monotonic())
+    self._record_audio_param = realtime_params.record_audio
+    self.recording_audio = self._record_audio_param and self.started
+    self.is_metric = realtime_params.is_metric
+    self.always_on_dm = realtime_params.always_on_dm
 
   def _update_status(self) -> None:
     if self.started and self.sm.updated["selfdriveState"]:

--- a/openpilot/system/ui/lib/shader_polygon.py
+++ b/openpilot/system/ui/lib/shader_polygon.py
@@ -212,6 +212,7 @@ def draw_polygon(origin_rect: rl.Rectangle, points: np.ndarray,
   """
   if len(points) < 3:
     return
+  assert (color is not None) != (gradient is not None), "Either color or gradient must be provided"
 
   # Initialize shader on-demand
   state = ShaderState.get_instance()
@@ -231,6 +232,17 @@ def draw_polygon(origin_rect: rl.Rectangle, points: np.ndarray,
   rl.begin_shader_mode(state.shader)
   rl.draw_triangle_strip(tri_strip, len(tri_strip), rl.WHITE)
   rl.end_shader_mode()
+
+
+def draw_polygon_solid(points: np.ndarray, color: rl.Color):
+  """Draw a solid ribbon on the current rlgl batch; call outside custom shader mode."""
+  if len(points) < 3:
+    return
+
+  pts = np.ascontiguousarray(points, dtype=np.float32)
+  assert pts.ndim == 2 and pts.shape[1] == 2, "points must be (N,2)"
+  tri_strip = triangulate(pts)
+  rl.draw_triangle_strip(tri_strip, len(tri_strip), color)
 
 
 def cleanup_shader_resources():

--- a/openpilot/system/ui/lib/tests/test_shader_polygon.py
+++ b/openpilot/system/ui/lib/tests/test_shader_polygon.py
@@ -1,0 +1,122 @@
+import importlib.util
+import sys
+import types
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+
+SHADER_POLYGON_PATH = Path(__file__).parents[1] / "shader_polygon.py"
+
+
+@pytest.fixture
+def shader_polygon_module(monkeypatch):
+  @dataclass(frozen=True)
+  class Color:
+    r: int
+    g: int
+    b: int
+    a: int
+
+  @dataclass(frozen=True)
+  class Rectangle:
+    x: float
+    y: float
+    width: float
+    height: float
+
+  raylib = types.ModuleType("pyray")
+  raylib.Color = Color
+  raylib.Rectangle = Rectangle
+  raylib.WHITE = Color(255, 255, 255, 255)
+  raylib.ShaderUniformDataType = SimpleNamespace(
+    SHADER_UNIFORM_INT=0,
+    SHADER_UNIFORM_FLOAT=1,
+    SHADER_UNIFORM_VEC2=2,
+    SHADER_UNIFORM_VEC4=3,
+  )
+  raylib.ffi = SimpleNamespace(new=lambda *_args, **_kwargs: None)
+
+  monkeypatch.setitem(sys.modules, "pyray", raylib)
+  monkeypatch.setitem(
+    sys.modules,
+    "openpilot.system.ui.lib.application",
+    SimpleNamespace(gui_app=SimpleNamespace(width=2160, height=1080), GL_VERSION="#version 300 es\n"),
+  )
+
+  module_name = f"_test_shader_polygon_{id(raylib)}"
+  spec = importlib.util.spec_from_file_location(module_name, SHADER_POLYGON_PATH)
+  assert spec is not None and spec.loader is not None
+  module = importlib.util.module_from_spec(spec)
+  monkeypatch.setitem(sys.modules, module_name, module)
+  spec.loader.exec_module(module)
+  return module
+
+
+def test_solid_polygon_skips_custom_fill_shader(shader_polygon_module, monkeypatch):
+  module = shader_polygon_module
+  color = module.rl.Color(10, 20, 30, 120)
+  points = np.array([[1.0, 10.0], [2.0, 5.0], [8.0, 5.0], [9.0, 10.0]], dtype=np.float32)
+  calls = []
+
+  monkeypatch.setattr(module.rl, "draw_triangle_strip", lambda *args: calls.append(args), raising=False)
+  monkeypatch.setattr(
+    module.ShaderState,
+    "get_instance",
+    classmethod(lambda cls: pytest.fail("solid fills must not initialize the gradient shader")),
+  )
+
+  module.draw_polygon_solid(points, color)
+
+  assert len(calls) == 1
+  strip, count, submitted_color = calls[0]
+  assert strip == module.triangulate(points)
+  assert count == len(strip)
+  assert submitted_color is color
+
+
+def test_gradient_polygon_keeps_custom_shader_path(shader_polygon_module, monkeypatch):
+  module = shader_polygon_module
+  rect = module.rl.Rectangle(0.0, 0.0, 2160.0, 1080.0)
+  points = np.array([[1.0, 10.0], [2.0, 5.0], [8.0, 5.0], [9.0, 10.0]], dtype=np.float32)
+  gradient = module.Gradient(
+    start=(0.0, 1.0),
+    end=(0.0, 0.0),
+    colors=[module.rl.Color(255, 0, 0, 120), module.rl.Color(0, 255, 0, 120)],
+    stops=[0.0, 1.0],
+  )
+  calls = []
+  state = SimpleNamespace(shader="gradient-shader", initialize=lambda: calls.append("initialize"))
+
+  monkeypatch.setattr(module.ShaderState, "get_instance", classmethod(lambda cls: state))
+  monkeypatch.setattr(module, "_configure_shader_color", lambda *args: calls.append("configure"))
+  monkeypatch.setattr(module.rl, "begin_shader_mode", lambda shader: calls.append(("begin", shader)), raising=False)
+  monkeypatch.setattr(module.rl, "draw_triangle_strip", lambda *args: calls.append(("draw", args)), raising=False)
+  monkeypatch.setattr(module.rl, "end_shader_mode", lambda: calls.append("end"), raising=False)
+
+  module.draw_polygon(rect, points, gradient=gradient)
+
+  assert calls[0:3] == ["initialize", "configure", ("begin", "gradient-shader")]
+  assert calls[3][0] == "draw"
+  assert calls[3][1][0] == module.triangulate(points)
+  assert calls[3][1][2] is module.rl.WHITE
+  assert calls[4] == "end"
+
+
+@pytest.mark.parametrize(
+  "color, gradient",
+  [
+    (None, None),
+    ("color", "gradient"),
+  ],
+)
+def test_polygon_requires_exactly_one_fill(shader_polygon_module, color, gradient):
+  module = shader_polygon_module
+  rect = module.rl.Rectangle(0.0, 0.0, 2160.0, 1080.0)
+  points = np.ones((4, 2), dtype=np.float32)
+
+  with pytest.raises(AssertionError, match="Either color or gradient"):
+    module.draw_polygon(rect, points, color=color, gradient=gradient)

--- a/openpilot/system/ui/lib/text_draw.py
+++ b/openpilot/system/ui/lib/text_draw.py
@@ -4,6 +4,12 @@ from openpilot.system.ui.lib.application import gui_app, FontWeight
 from openpilot.system.ui.lib.text_measure import measure_text_cached
 
 
+_OUTLINE_UNIT_OFFSETS = tuple(
+  (math.cos(math.radians(deg)), math.sin(math.radians(deg)))
+  for deg in range(0, 360, 45)
+)
+
+
 def draw_text_raw(font, text, x, y, font_size, color):
   rl.draw_text_ex(
     font,
@@ -67,10 +73,9 @@ def draw_text_ui_style(text: str,
   draw_x, draw_y, _ = get_text_draw_pos(font, text, x, y, font_size, align, y_offset)
 
   if border_width > 0.0:
-    for deg in range(0, 360, 45):
-      rad = math.radians(deg)
-      ox = border_width * math.cos(rad)
-      oy = border_width * math.sin(rad)
+    for unit_x, unit_y in _OUTLINE_UNIT_OFFSETS:
+      ox = border_width * unit_x
+      oy = border_width * unit_y
       draw_text_raw(font, text, draw_x + ox, draw_y + oy, font_size, border_color)
 
   if shadow_offset != 0.0:

--- a/openpilot/system/ui/lib/text_draw.py
+++ b/openpilot/system/ui/lib/text_draw.py
@@ -1,6 +1,6 @@
 import math
 import pyray as rl
-from openpilot.system.ui.lib.application import gui_app, FontWeight
+from openpilot.system.ui.lib.application import FONT_SCALE, FontWeight, font_fallback, gui_app
 from openpilot.system.ui.lib.text_measure import measure_text_cached
 
 
@@ -8,6 +8,7 @@ _OUTLINE_UNIT_OFFSETS = tuple(
   (math.cos(math.radians(deg)), math.sin(math.radians(deg)))
   for deg in range(0, 360, 45)
 )
+_RAW_DRAW_TEXT_EX = getattr(getattr(rl, "rl", None), "DrawTextEx", None)
 
 
 def draw_text_raw(font, text, x, y, font_size, color):
@@ -74,18 +75,30 @@ def draw_text_ui_style(text: str,
   draw_size = float(font_size)
   position = rl.Vector2(float(draw_x), float(draw_y))
 
+  # The pyray wrapper encodes Python strings and converts every argument on each
+  # call. Styled text can submit the same string up to ten times, so use the raw
+  # CFFI symbol when available and prepare its immutable arguments once.
+  draw_text_ex = _RAW_DRAW_TEXT_EX
+  if draw_text_ex is not None:
+    font = font_fallback(font)
+    draw_text = text.encode("utf-8")
+    draw_size *= FONT_SCALE
+  else:
+    draw_text_ex = rl.draw_text_ex
+    draw_text = text
+
   if border_width > 0.0:
     for unit_x, unit_y in _OUTLINE_UNIT_OFFSETS:
       position.x = float(draw_x + border_width * unit_x)
       position.y = float(draw_y + border_width * unit_y)
-      rl.draw_text_ex(font, text, position, draw_size, 0, border_color)
+      draw_text_ex(font, draw_text, position, draw_size, 0, border_color)
 
   if shadow_offset != 0.0:
     position.x = float(draw_x + shadow_offset)
     position.y = float(draw_y + shadow_offset)
-    rl.draw_text_ex(font, text, position, draw_size, 0, shadow_color)
+    draw_text_ex(font, draw_text, position, draw_size, 0, shadow_color)
 
   position.x = float(draw_x)
   position.y = float(draw_y)
-  rl.draw_text_ex(font, text, position, draw_size, 0, color)
+  draw_text_ex(font, draw_text, position, draw_size, 0, color)
 

--- a/openpilot/system/ui/lib/text_draw.py
+++ b/openpilot/system/ui/lib/text_draw.py
@@ -71,15 +71,21 @@ def draw_text_ui_style(text: str,
     font = gui_app.font(FontWeight.DISPLAY)
 
   draw_x, draw_y, _ = get_text_draw_pos(font, text, x, y, font_size, align, y_offset)
+  draw_size = float(font_size)
+  position = rl.Vector2(float(draw_x), float(draw_y))
 
   if border_width > 0.0:
     for unit_x, unit_y in _OUTLINE_UNIT_OFFSETS:
-      ox = border_width * unit_x
-      oy = border_width * unit_y
-      draw_text_raw(font, text, draw_x + ox, draw_y + oy, font_size, border_color)
+      position.x = float(draw_x + border_width * unit_x)
+      position.y = float(draw_y + border_width * unit_y)
+      rl.draw_text_ex(font, text, position, draw_size, 0, border_color)
 
   if shadow_offset != 0.0:
-    draw_text_raw(font, text, draw_x + shadow_offset, draw_y + shadow_offset, font_size, shadow_color)
+    position.x = float(draw_x + shadow_offset)
+    position.y = float(draw_y + shadow_offset)
+    rl.draw_text_ex(font, text, position, draw_size, 0, shadow_color)
 
-  draw_text_raw(font, text, draw_x, draw_y, font_size, color)
+  position.x = float(draw_x)
+  position.y = float(draw_y)
+  rl.draw_text_ex(font, text, position, draw_size, 0, color)
 


### PR DESCRIPTION
## 요약

- UI를 `SCHED_OTHER`로 유지하고 TICI에서 offroad core0 부트스트랩 → onroad core5로 전환해, 같은 core의 `plannerd`/`radard` FIFO51 우선권을 보장합니다.
- 사용하지 않는 legacy model projection을 건너뛰고 path/lane/blind-spot/HUD/styled-text의 allocation과 draw submission을 줄였습니다.
- UI Params 조회를 0.5초 snapshot cache로 통합했습니다. ScreenRecord의 nonblocking write는 로컬 pending 값을 즉시 유지하며, `carrot-wip`에 등록된 Params 키만 사용합니다.
- 상위 `uiDebug` 구간 계측(`@0`~`@8`)은 유지하고 상세 renderer 계측(`@9`~`@23`)은 deprecated 필드로 보존해 schema 호환성을 유지했습니다.
- 최신 `carrot-wip`에서 이미 제거된 legacy lane-center/CarrotTireTrajectory 경로는 재도입하지 않았습니다.

## 실차 확인

차량: HYUNDAI_SANTAFE_MX5_HEV / TICI 계열, `carrot-ms-ui2`

초기 Route 429의 보존된 point estimate와 최종 Route 44d 전체 valid 표본 비교:

| 항목 | Route 429 | Route 44d | 누적 변화 |
|---|---:|---:|---:|
| UI FPS | 15.8523 | 18.7176 | +18.08% |
| draw 평균 | 41.595 ms | 23.1809 ms | -44.27% |
| UI CPU 평균 | 49.826% | 33.591% | -32.58% |

Route 429 원본이 로컬에 남아 있지 않아 위 비교는 동일 조건 bootstrap이 아닌 point estimate 비교입니다. 최종 상세 계측 제거 전후(Route 448 → Route 44d)는 draw/UI CPU가 통계적으로 동급이어서 cleanup 자체의 추가 성능 향상으로 계산하지 않았습니다.

Route 44d에서 UI PID 단일 유지, manager required-not-running/nonzero exit 0, critical onroad/radar error 0, main UI crash/restart/GL error 0을 확인했습니다.

## 검증

- focused pytest: 70 passed
  - model lane visibility/vector, HUD, styled text, param cache, uiDebug schema, solid polygon, scheduler AST
- Linux scheduler syscall 테스트 5개는 Windows 로컬 환경에서 skip
- 변경 Python 19파일 `py_compile` 통과
- `git diff --check` 통과
- target Params registry 대비 누락 키 0

Windows 로컬 환경에서는 native `msgq`가 필요한 전체-import renderer 테스트를 수집하지 못했습니다. 실제 AGNOS 주행 로그로 렌더 안정성과 coarse telemetry를 별도로 확인했습니다.