### PR TITLE
Build JotPluggler with desktop tools

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -278,6 +278,7 @@ if arch != "larch64":
   SConscript([
     'openpilot/tools/replay/SConscript',
     'openpilot/tools/cabana/SConscript',
+    'openpilot/tools/jotpluggler/SConscript',
   ])
 
 


### PR DESCRIPTION
## Summary

- register `openpilot/tools/jotpluggler/SConscript` with the desktop tool build
- keep JotPluggler excluded from `larch64` device builds

## Why

The JotPluggler sources and SCons target were present, but the root `SConstruct` did not load its `SConscript`. As a result, targeting the directory only reported it as up to date and no `jotpluggler` executable was generated.

## Impact

Desktop Linux and macOS builds can now discover and build `openpilot/tools/jotpluggler/jotpluggler` together with the other development tools. Device builds remain unchanged.

## Checks

- `git diff --check`
- `python -m py_compile SConstruct`
- native JotPluggler link was not run because the current workspace is Windows; the target supports Linux/macOS

Docs-Not-Needed: This only restores a developer-only desktop build target and does not change user-visible vehicle behavior.
