### PR TITLE
Support legacy DBC generation in JotPluggler

### DIFF
--- a/openpilot/tools/jotpluggler/SConscript
+++ b/openpilot/tools/jotpluggler/SConscript
@@ -1,11 +1,11 @@
 import os
 import imgui
 import libusb
-from opendbc import get_generated_dbcs
 from opendbc.car import Bus
 from opendbc.car.fingerprints import MIGRATION
 from opendbc.car.values import PLATFORMS
 from openpilot.common.basedir import BASEDIR
+from openpilot.tools.jotpluggler.dbc_generation import get_jotpluggler_generated_dbcs
 
 Import('env', 'arch', 'common', 'messaging', 'visionipc', 'cereal', 'replay_lib')
 
@@ -25,7 +25,7 @@ def materialize_generated_dbcs(target, source, env):
     if name.endswith('.dbc'):
       os.unlink(os.path.join(out_dir, name))
 
-  for name, content in sorted(get_generated_dbcs().items()):
+  for name, content in sorted(get_jotpluggler_generated_dbcs().items()):
     with open(os.path.join(out_dir, f"{name}.dbc"), "w") as f:
       f.write(content)
 

--- a/openpilot/tools/jotpluggler/dbc_generation.py
+++ b/openpilot/tools/jotpluggler/dbc_generation.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+from opendbc import DBC_PATH, get_generated_dbcs
+from opendbc.dbc.generator import generator
+
+
+def get_jotpluggler_generated_dbcs() -> dict[str, str]:
+  """Load generated DBCs from either the current or legacy opendbc layout."""
+  if hasattr(generator, "generate_all"):
+    return get_generated_dbcs()
+
+  # This fork's older opendbc snapshot materializes generated DBCs on disk.
+  return {
+    path.stem: path.read_text(encoding="utf-8")
+    for path in sorted(Path(DBC_PATH).glob("*_generated.dbc"))
+  }

--- a/openpilot/tools/jotpluggler/tests/test_generated_dbcs.py
+++ b/openpilot/tools/jotpluggler/tests/test_generated_dbcs.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+from opendbc import DBC_PATH
+from opendbc.dbc.generator import generator
+from openpilot.tools.jotpluggler.dbc_generation import get_jotpluggler_generated_dbcs
+
+
+def test_generated_dbcs_are_available():
+  generated_dbcs = get_jotpluggler_generated_dbcs()
+
+  assert generated_dbcs
+  assert all(name.endswith("_generated") for name in generated_dbcs)
+  assert all(content.strip() for content in generated_dbcs.values())
+  assert "hyundai_canfd_generated" in generated_dbcs
+
+  if not hasattr(generator, "generate_all"):
+    on_disk_dbcs = {path.stem for path in Path(DBC_PATH).glob("*_generated.dbc")}
+    assert generated_dbcs.keys() == on_disk_dbcs


### PR DESCRIPTION
## Summary

- add a JotPluggler-only compatibility loader for generated DBCs
- use the newer in-memory `generate_all()` API when available
- fall back to the committed `*_generated.dbc` files used by this fork's older opendbc snapshot
- add a focused compatibility test

## Root cause

The fork imported `get_generated_dbcs()` from a newer opendbc revision, but its vendored DBC generator still only exposes the older `create_all()` API. JotPluggler therefore failed while materializing its generated DBC directory because `generate_all` could not be imported.

## Impact

JotPluggler can build against both the current fork and the newer comma4 opendbc layout. The compatibility code is contained under `openpilot/tools/jotpluggler`; `larch64` device builds do not load the JotPluggler SConscript, and no vehicle runtime or global opendbc behavior changes.

## Checks

- focused generated-DBC test: passed
- current fork legacy layout: loaded 45 generated DBCs
- comma4 current layout: loaded 37 generated DBCs through `generate_all()`
- `ruff check` on the new helper and test
- `python -m py_compile` on the new helper and test
- `git diff --check`

Docs-Not-Needed: This fixes a desktop developer tool build and does not change device or user-visible behavior.
