### PR TITLE
Fix JotPluggler resource paths

### DIFF
--- a/openpilot/tools/jotpluggler/app.cc
+++ b/openpilot/tools/jotpluggler/app.cc
@@ -49,7 +49,7 @@ std::string layout_name_from_arg(const std::string &layout_arg) {
 }
 
 fs::path layouts_dir() {
-  return repo_root() / "tools" / "jotpluggler" / "layouts";
+  return repo_root() / "openpilot" / "tools" / "jotpluggler" / "layouts";
 }
 
 std::string sanitize_layout_stem(std::string_view name) {
@@ -249,7 +249,7 @@ void configure_style() {
   g_ui_font = nullptr;
   g_ui_bold_font = nullptr;
   g_mono_font = nullptr;
-  const fs::path fonts_dir = repo_root() / "selfdrive" / "assets" / "fonts";
+  const fs::path fonts_dir = repo_root() / "openpilot" / "selfdrive" / "assets" / "fonts";
   ImFontConfig font_cfg;
   font_cfg.OversampleH = 2;
   font_cfg.OversampleV = 2;

--- a/openpilot/tools/jotpluggler/custom_series.cc
+++ b/openpilot/tools/jotpluggler/custom_series.cc
@@ -189,7 +189,7 @@ PythonEvalResult evaluate_custom_python_series(const AppSession &session,
 
     const CommandResult process = run_process_capture_output({
       "python3",
-      (repo_root() / "tools" / "jotpluggler" / "math_eval.py").string(),
+      (repo_root() / "openpilot" / "tools" / "jotpluggler" / "math_eval.py").string(),
       manifest_path.string(),
       globals_path.string(),
       code_path.string(),

--- a/openpilot/tools/jotpluggler/layout.cc
+++ b/openpilot/tools/jotpluggler/layout.cc
@@ -274,9 +274,9 @@ std::string default_dbc_template() {
 }
 
 DbcEditorSource resolve_dbc_editor_source(const std::string &dbc_name) {
-  const fs::path generated_dbc_dir = repo_root() / "tools" / "jotpluggler" / "generated_dbcs";
+  const fs::path generated_dbc_dir = repo_root() / "openpilot" / "tools" / "jotpluggler" / "generated_dbcs";
   const std::array<DbcEditorSource, 2> candidates = {{
-    {.path = repo_root() / "opendbc" / "dbc" / (dbc_name + ".dbc"), .kind = DbcEditorState::SourceKind::Opendbc},
+    {.path = repo_root() / "opendbc_repo" / "opendbc" / "dbc" / (dbc_name + ".dbc"), .kind = DbcEditorState::SourceKind::Opendbc},
     {.path = generated_dbc_dir / (dbc_name + ".dbc"), .kind = DbcEditorState::SourceKind::Generated},
   }};
   for (const DbcEditorSource &candidate : candidates) {
@@ -334,7 +334,7 @@ bool save_dbc_editor_contents(AppSession *session, UiState *state) {
   }
   try {
     dbc::Database::fromContent(editor.text, editor.save_name + ".dbc");
-    const fs::path generated_dbc_dir = repo_root() / "tools" / "jotpluggler" / "generated_dbcs";
+    const fs::path generated_dbc_dir = repo_root() / "openpilot" / "tools" / "jotpluggler" / "generated_dbcs";
     fs::create_directories(generated_dbc_dir);
     const fs::path output = generated_dbc_dir / (editor.save_name + ".dbc");
     write_file_or_throw(output, editor.text);

--- a/openpilot/tools/jotpluggler/sketch_layout.cc
+++ b/openpilot/tools/jotpluggler/sketch_layout.cc
@@ -391,8 +391,8 @@ std::string detect_dbc_for_fingerprint(std::string_view car_fingerprint) {
 std::vector<std::string> available_dbc_names_impl() {
   std::set<std::string> names;
   for (const fs::path &dbc_dir : {
-         repo_root() / "opendbc" / "dbc",
-         repo_root() / "tools" / "jotpluggler" / "generated_dbcs",
+         repo_root() / "opendbc_repo" / "opendbc" / "dbc",
+         repo_root() / "openpilot" / "tools" / "jotpluggler" / "generated_dbcs",
        }) {
     if (fs::exists(dbc_dir) && fs::is_directory(dbc_dir)) {
       for (const auto &entry : fs::directory_iterator(dbc_dir)) {
@@ -413,8 +413,8 @@ std::vector<std::string> available_dbc_names_impl() {
 
 fs::path resolve_dbc_path(const std::string &dbc_name) {
   for (const fs::path &candidate : {
-         repo_root() / "opendbc" / "dbc" / (dbc_name + ".dbc"),
-         repo_root() / "tools" / "jotpluggler" / "generated_dbcs" / (dbc_name + ".dbc"),
+         repo_root() / "opendbc_repo" / "opendbc" / "dbc" / (dbc_name + ".dbc"),
+         repo_root() / "openpilot" / "tools" / "jotpluggler" / "generated_dbcs" / (dbc_name + ".dbc"),
        }) {
     if (fs::exists(candidate)) return candidate;
   }


### PR DESCRIPTION
## Summary

- resolve JotPluggler layouts, fonts, and the custom-series Python evaluator below the nested `openpilot/` source directory
- resolve generated DBC files below `openpilot/tools/jotpluggler`
- resolve source DBC files through `opendbc_repo/opendbc/dbc`

## Root cause

`JOTP_REPO_ROOT` points to the repository root, but several runtime paths were copied without the repository's nested `openpilot/` prefix. JotPluggler therefore tried to load `selfdrive/assets/fonts/Inter-Regular.ttf` from the wrong location and aborted in ImGui font loading.

## Reference

These path expressions match the current upstream comma4 checkout at `commaai/openpilot@08fd57127` after updating its submodules.

## Impact

JotPluggler can load its fonts and layouts at startup, run custom Python series, and find/edit source and generated DBC files. Only the desktop JotPluggler C++ tool changes; vehicle runtime and `larch64` builds are unaffected.

## Checks

- verified every resolved resource directory/file exists in this checkout
- verified no stale `repo_root()/tools`, `repo_root()/selfdrive`, or `repo_root()/opendbc` JotPluggler paths remain
- compared all changed path expressions with current upstream comma4
- `git diff --check`
- native runtime launch was not run because the current workspace is Windows

Docs-Not-Needed: This fixes desktop developer-tool resource lookup and does not change device or user-visible behavior.
