### PR TITLE
feat(steer): 수동조향 개입 후 해제 대기시간 및 토크 복구시간 설정 파라미터 추가

### DIFF
--- a/opendbc_repo/opendbc/car/hyundai/carcontroller.py
+++ b/opendbc_repo/opendbc/car/hyundai/carcontroller.py
@@ -367,9 +367,10 @@ class CarController(CarControllerBase):
       # Once fully recovered, hold full authority until the next driver override.
       torque_delta = 0.0
     elif self.override_latched:
-      # Hold reduced authority until driver torque stays below 60% for 0.2 seconds.
+      # Hold reduced authority until driver torque stays below 60% for configured release delay.
+      override_release_sec = self.params.get_int("SteerOverrideReleaseSec") * 0.01
       self.override_release_frames = self.override_release_frames + 1 if torque_ratio < 0.6 else 0
-      if self.override_release_frames >= int(0.2 / DT_CTRL):
+      if self.override_release_frames >= int(override_release_sec / DT_CTRL):
         self.override_latched = False
         self.override_release_frames = 0
         recovery_allowed = True
@@ -379,21 +380,25 @@ class CarController(CarControllerBase):
       recovery_allowed = True
 
     if recovery_allowed:
-      # Use one-second model uncertainty to set the base torque recovery time.
-      # Missing or invalid model data falls back to a moderate 1.5-second recovery.
-      y_std_1s = 0.2
-      if CS.modelV2 is not None and len(CS.modelV2.position.yStd) > 10:
-        model_y_std_1s = float(CS.modelV2.position.yStd[10])
-        if np.isfinite(model_y_std_1s) and model_y_std_1s >= 0.0:
-          y_std_1s = model_y_std_1s
+      override_recovery_sec = self.params.get_int("SteerOverrideRecoverySec") * 0.01
+      if override_recovery_sec > 0:
+        recovery_time = override_recovery_sec
+      else:
+        # Use one-second model uncertainty to set the base torque recovery time.
+        # Missing or invalid model data falls back to a moderate 1.5-second recovery.
+        y_std_1s = 0.2
+        if CS.modelV2 is not None and len(CS.modelV2.position.yStd) > 10:
+          model_y_std_1s = float(CS.modelV2.position.yStd[10])
+          if np.isfinite(model_y_std_1s) and model_y_std_1s >= 0.0:
+            y_std_1s = model_y_std_1s
 
-      recovery_time = float(np.interp(y_std_1s, [0.1, 0.2, 0.3, 0.4], [0.5, 0.8, 1.5, 3.0]))
-      recovery_time = max(recovery_time, float(np.interp(
-        self.repeated_override_count,
-        [0, 1, 2, 3],
-        [0.1, 1.0, 2.0, 3.0],
-      )))
-      base_rate_up = (self.angle_max_torque - self.params.ANGLE_MIN_TORQUE) * DT_CTRL / recovery_time
+        recovery_time = float(np.interp(y_std_1s, [0.1, 0.2, 0.3, 0.4], [0.5, 0.8, 1.5, 3.0]))
+        recovery_time = max(recovery_time, float(np.interp(
+          self.repeated_override_count,
+          [0, 1, 2, 3],
+          [0.1, 1.0, 2.0, 3.0],
+        )))
+      base_rate_up = (self.angle_max_torque - self.params.ANGLE_MIN_TORQUE) * DT_CTRL / max(0.01, recovery_time)
 
       # During recovery, taper the rate to zero. Only steeringPressed can reduce authority.
       torque_delta = base_rate_up * float(np.interp(torque_ratio, [0.6, 0.8], [1.0, 0.0]))

--- a/openpilot/common/params_keys.h
+++ b/openpilot/common/params_keys.h
@@ -271,6 +271,8 @@ inline static std::unordered_map<std::string, ParamKeyAttributes> keys = {
     {"SteerActuatorDelay", {PERSISTENT, INT, "0"}},
     {"LatSmoothSec", {PERSISTENT, INT, "13"}},
     {"LatSuspendAngleDeg", {PERSISTENT, INT, "300"}},
+    {"SteerOverrideReleaseSec", {PERSISTENT, INT, "20"}},
+    {"SteerOverrideRecoverySec", {PERSISTENT, INT, "50"}},
     {"CruiseOnDist", {PERSISTENT, INT, "400"}},
 
     {"CruiseMaxVals0", {PERSISTENT, INT, "160"}},

--- a/openpilot/selfdrive/carrot_settings.json
+++ b/openpilot/selfdrive/carrot_settings.json
@@ -119,6 +119,8 @@
                 "SteerActuatorDelay",
                 "LatSmoothSec",
                 "LatSuspendAngleDeg",
+                "SteerOverrideReleaseSec",
+                "SteerOverrideRecoverySec",
                 "CustomSR",
                 "SteerRatioRate"
               ]
@@ -991,6 +993,38 @@
       "max": 300,
       "default": 300,
       "unit": 10
+    },
+    {
+      "group": "조향튜닝",
+      "name": "SteerOverrideReleaseSec",
+      "title": "수동조향해제대기시간(20)",
+      "descr": "수동 조향 개입 후 손을 뗐을 때 자동 조향 토크 복구를 시작하기까지의 대기시간 (단위: 0.01초, 20 = 0.20초). 값을 낮추면 손을 떼자마자 복구가 바로 시작됩니다.",
+      "egroup": "LAT",
+      "etitle": "Steer Override Release Delay(20)",
+      "edescr": "Delay before starting steering torque recovery after releasing the wheel (unit: 0.01s, 20 = 0.20s). Lower values start recovery immediately.",
+      "cgroup": "转向",
+      "ctitle": "Steer Override Release Delay(20)",
+      "cdescr": "Delay before starting steering torque recovery after releasing the wheel (unit: 0.01s, 20 = 0.20s). Lower values start recovery immediately.",
+      "min": 0,
+      "max": 100,
+      "default": 20,
+      "unit": 1
+    },
+    {
+      "group": "조향튜닝",
+      "name": "SteerOverrideRecoverySec",
+      "title": "수동조향복구시간(50)",
+      "descr": "수동 조향 후 손을 뗐을 때 자동 조향 토크가 100%까지 램프업되는 복구시간 (단위: 0.01초, 50 = 0.50초). 낮출수록 커브길에서 손을 뗀 직후 토크가 멍하지 않고 빠르게 회복됩니다.",
+      "egroup": "LAT",
+      "etitle": "Steer Override Recovery Time(50)",
+      "edescr": "Ramp-up time for steering torque to reach 100% after releasing the wheel (unit: 0.01s, 50 = 0.50s). Lower values recover full torque faster in curves.",
+      "cgroup": "转向",
+      "ctitle": "Steer Override Recovery Time(50)",
+      "cdescr": "Ramp-up time for steering torque to reach 100% after releasing the wheel (unit: 0.01s, 50 = 0.50s). Lower values recover full torque faster in curves.",
+      "min": 0,
+      "max": 300,
+      "default": 50,
+      "unit": 5
     },
     {
       "group": "크루즈",


### PR DESCRIPTION
## 요약
운전자가 자동조향 중 수동 조향을 가미(개입)했을 때, 손을 뗀 후 토크 복구를 시작하기까지의 대기시간(`SteerOverrideReleaseSec`)과 100% 토크로 램프업되는 복구시간(`SteerOverrideRecoverySec`)을 당근웹에서 조절할 수 있도록 파라미터화하였습니다.

## 주요 변경 사항
1. **`SteerOverrideReleaseSec`** (기본값: `20` = 0.20초, 범위: 0 ~ 100):
   수동 조향 개입 후 손을 뗐을 때 토크 복구 시작까지의 대기시간 (0.01초 단위). 낮출수록 손을 떼자마자 즉시 복구가 시작됩니다.
2. **`SteerOverrideRecoverySec`** (기본값: `50` = 0.50초, 범위: 0 ~ 300):
   수동 조향 후 토크가 100%까지 복구되는 램프업 시간. 낮출수록 커브길에서 손을 뗀 직후 조향 토크가 멍하지 않고 빠르게 회복됩니다. (0 설정 시 기존 모델 불확실성 기반 동적 계산 복원)
3. `params_keys.h`, `carrot_settings.json` [조향튜닝] 등록 및 `carcontroller.py` 연동 완료.