### PR TITLE
VW MEB: request a start when the car latches its own ESP hold

### DIFF
--- a/opendbc_repo/opendbc/car/volkswagen/carcontroller.py
+++ b/opendbc_repo/opendbc/car/volkswagen/carcontroller.py
@@ -34,6 +34,7 @@ class CarController(CarControllerBase):
     self.hca_frame_same_torque = 0
     # MEB longitudinal (ported from infiniteCable2): EPB-error mitigation ramp counters
     self.long_override_counter = 0
+    self.hold_release_frames = 0
     self.long_disabled_counter = 0
     self.klr_counter_last = None  # capacitive wheel touch (EA hands-on pacification)
 
@@ -165,8 +166,27 @@ class CarController(CarControllerBase):
       if self.frame % self.CCP.ACC_CONTROL_STEP == 0:
         if self.CP.flags & VolkswagenFlags.MEB:
           stopping = actuators.longControlState == LongCtrlState.stopping
-          starting = actuators.longControlState == LongCtrlState.starting and CS.out.vEgo <= self.CP.vEgoStarting
           accel = float(np.clip(actuators.accel, self.CCP.ACCEL_MIN, self.CCP.ACCEL_MAX) if CC.enabled else 0)
+          # Creeping to a stop behind a lead keeps the planner in "pid" instead of "stopping".
+          # If the car then latches its own ESP hold, ACC_Anfahren is never sent with the
+          # (lcs == starting) condition alone and the car stays stuck in hold even after the
+          # lead pulls away. Request a start whenever openpilot wants to accelerate out of hold.
+          starting_planner = actuators.longControlState == LongCtrlState.starting and CS.out.vEgo <= self.CP.vEgoStarting
+          # Only begin the release above 0.2 m/s^2 so tiny accel values can't unlatch the hold
+          # and let the car roll back on a hill (normal launch uses startAccel 0.8, no delay).
+          begin_release = (actuators.longControlState == LongCtrlState.pid
+                           and CS.esp_hold_confirmation and accel >= 0.2)
+          # Hold the request until the car is actually moving. Do NOT keep esp_hold_confirmation
+          # in the sustain condition: it goes false the moment the car acknowledges the release,
+          # which cancels our own request mid-handshake. The car then falls back to the EPB and
+          # escalates to P (measured: parkingBrake 0.06s after hold released, gear=park 0.8s later).
+          if begin_release:
+            self.hold_release_frames = self.CCP.HOLD_RELEASE_MAX_STEPS
+          elif self.hold_release_frames > 0:
+            self.hold_release_frames -= 1
+          if not CC.enabled or stopping or accel <= 0.0 or CS.out.vEgo > self.CCP.HOLD_RELEASE_DONE_SPEED:
+            self.hold_release_frames = 0
+          starting = starting_planner or self.hold_release_frames > 0
 
           # override / disable ramp handling to avoid EPB error at low speed (infiniteCable2)
           long_override = CC.cruiseControl.override or CS.out.gasPressed

--- a/opendbc_repo/opendbc/car/volkswagen/values.py
+++ b/opendbc_repo/opendbc/car/volkswagen/values.py
@@ -92,6 +92,8 @@ class CarControllerParams:
       self.STEERING_POWER_MAX      = 50    # HCA_03 maximum steering power %
       self.STEERING_POWER_MIN      = 4     # HCA_03 minimum steering power %
       self.STEERING_POWER_STEP     = 2     # HCA_03 steering power counter steps
+      self.HOLD_RELEASE_MAX_STEPS  = 100   # sustain ACC_Anfahren up to ~2s (ACC_CONTROL_STEP based)
+      self.HOLD_RELEASE_DONE_SPEED = 0.3   # m/s, above this the car has actually launched
 
       self.CURVATURE_LIMITS: CurvatureSteeringLimits = CurvatureSteeringLimits(0.195)
 


### PR DESCRIPTION
Creeping to a stop behind a lead keeps the planner in "pid" rather than "stopping". When the car then latches its own ESP hold, ACC_Anfahren is never sent with the (longControlState == starting) condition alone, so the car stays stuck in hold even after the lead pulls away.

Request a start whenever openpilot wants to accelerate out of hold, gated at accel >= 0.2 m/s^2 so tiny accel values can't unlatch the hold and let the car roll back on a hill.

The sustain condition deliberately does NOT include esp_hold_confirmation. That flag goes false the moment the car acknowledges the release, which cancels our own request mid-handshake; the car then falls back to the EPB and escalates to P. Measured on an ID.4 MK1 (gateway harness):

  46.57  ESC_50.Motion_State=3 (full stop), accel already +0.17
  46.75  accel >= 0.2 -> ACC_Anfahren=1, ACC_Anforderung_HMS=4 (RELEASE)
  47.41  Motion_State 3->1 (car acknowledges) and request withdrawn same frame
  47.47  parkingBrake=True, openpilot disengaged (parkBrake event)
  48.24  gearShifter=park

Instead the request is sustained by a frame counter until the car actually launches (vEgo > 0.3 m/s), the planner asks to stop, accel drops to zero, or longitudinal control goes inactive.

acc_hold_type maps starting=True to ACC_HMS_RELEASE only, and full_stop_no_start = esp_hold and not starting, so sustaining the request after the hold clears has no side effect.

MEB-only branch; MQB/PQ unaffected.

## 변경 내용

-- MEB 정차잠금(ESP 홀드)에서 빠져나오지 못하던 문제를 수정했습니다. 앞차를 따라 스르륵
  정차하면 플래너가 `stopping`을 잡지 못하고 `pid`에 머무는데, 이때 차가 스스로 홀드를
  걸면 `ACC_Anfahren`(출발요청)이 나가지 않아 앞차가 출발해도 차가 멈춰 있습니다.
- 홀드 중 openpilot이 가속하려 하면 출발요청을 보냅니다. 경사로 롤백 방지를 위해
  `accel >= 0.2 m/s^2`에서만 해제를 시작합니다.
- 요청 유지 조건에 `esp_hold_confirmation`을 넣지 않았습니다. 넣으면 차가 해제에
  응답하는 순간 요청이 스스로 취소되고, 차는 핸드셰이크 도중 요청을 잃어 EPB로 폴백한 뒤
  P까지 진입합니다(위 표의 실측 타임라인).
- 변경 파일은 `carcontroller.py`(+22), `values.py`(+2) 두 개이며 MEB 분기 안에서만
  동작합니다. MQB/PQ는 영향이 없습니다.

## 검증

- [x] 관련 테스트를 실행했습니다.
- [x] 사용자에게 보이는 동작이 바뀌면 `docs/user/ko`와 `docs/user/en`의 연결된 문서 쌍을 함께 수정했습니다.

사용자 설명서 수정이 필요하지 않다면 아래에 구체적인 이유를 적으세요. 빈 값, `N/A`, `없음`은 문서 누락 검사 예외로 인정하지 않습니다.

Docs-Not-Needed:
