### PR TITLE
Revert "feat(steer): 수동조향 개입 후 해제 대기시간 및 토크 복구시간 설정 파라미터 추가"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-pvenv/
+venv/
 .venv/
 .ci_cache
 .env

--- a/opendbc_repo/opendbc/car/hyundai/carcontroller.py
+++ b/opendbc_repo/opendbc/car/hyundai/carcontroller.py
@@ -109,8 +109,7 @@ def apply_steer_angle_limits_physics(desired_sw_deg: float,
                                      wheelbase_m: float,
                                      steer_ratio: float,
                                      steer_sw_max_deg: float,
-                                     model_v2=None,
-                                     driver_override: bool=False) -> float:
+                                     model_v2=None) -> float:
   max_lat_accel = 8.5   # m/s^2
   max_lat_jerk  = 4.0   # m/s^3
   y_std_1s = 0.1
@@ -159,7 +158,7 @@ def apply_steer_angle_limits_physics(desired_sw_deg: float,
   # --- accel clip ---
   cmd_rw = float(np.clip(cmd_rw, -rw_max, rw_max))
 
-  if not lat_active or driver_override:
+  if not lat_active:
     cmd_rw = float(steering_sw_deg) / steer_ratio
 
   cmd_sw = cmd_rw * steer_ratio
@@ -219,8 +218,6 @@ class CarController(CarControllerBase):
     self.camera_scc_params = Params().get_int("HyundaiCameraSCC")
     self.is_ldws_car = Params().get_bool("IsLdwsCar")
     self.enable_corner_radar = 0
-    self.steer_override_release_sec = 0.20
-    self.steer_override_recovery_sec = 0.50
 
     self.steerDeltaUpOrg = self.steerDeltaUp = self.steerDeltaUpLC = self.params.STEER_DELTA_UP
     self.steerDeltaDownOrg = self.steerDeltaDown = self.steerDeltaDownLC = self.params.STEER_DELTA_DOWN
@@ -230,8 +227,6 @@ class CarController(CarControllerBase):
     if self.frame % 50 == 0:
       params = Params()
       self.max_angle_frames = params.get_int("MaxAngleFrames")
-      self.steer_override_release_sec = params.get_int("SteerOverrideReleaseSec") * 0.01
-      self.steer_override_recovery_sec = params.get_int("SteerOverrideRecoverySec") * 0.01
       steerMax = params.get_int("CustomSteerMax")
       steerDeltaUp = params.get_int("CustomSteerDeltaUp")
       steerDeltaDown = params.get_int("CustomSteerDeltaDown")
@@ -305,7 +300,6 @@ class CarController(CarControllerBase):
       self.CP.steerRatio,
       self.params.ANGLE_LIMITS.STEER_ANGLE_MAX,
       CS.modelV2,
-      driver_override=CS.out.steeringPressed,
     )
 
 
@@ -373,9 +367,9 @@ class CarController(CarControllerBase):
       # Once fully recovered, hold full authority until the next driver override.
       torque_delta = 0.0
     elif self.override_latched:
-      # Hold reduced authority until driver torque stays below 60% for configured release delay.
+      # Hold reduced authority until driver torque stays below 60% for 0.2 seconds.
       self.override_release_frames = self.override_release_frames + 1 if torque_ratio < 0.6 else 0
-      if self.override_release_frames >= int(self.steer_override_release_sec / DT_CTRL):
+      if self.override_release_frames >= int(0.2 / DT_CTRL):
         self.override_latched = False
         self.override_release_frames = 0
         recovery_allowed = True
@@ -385,24 +379,21 @@ class CarController(CarControllerBase):
       recovery_allowed = True
 
     if recovery_allowed:
-      if self.steer_override_recovery_sec > 0:
-        recovery_time = self.steer_override_recovery_sec
-      else:
-        # Use one-second model uncertainty to set the base torque recovery time.
-        # Missing or invalid model data falls back to a moderate 1.5-second recovery.
-        y_std_1s = 0.2
-        if CS.modelV2 is not None and len(CS.modelV2.position.yStd) > 10:
-          model_y_std_1s = float(CS.modelV2.position.yStd[10])
-          if np.isfinite(model_y_std_1s) and model_y_std_1s >= 0.0:
-            y_std_1s = model_y_std_1s
+      # Use one-second model uncertainty to set the base torque recovery time.
+      # Missing or invalid model data falls back to a moderate 1.5-second recovery.
+      y_std_1s = 0.2
+      if CS.modelV2 is not None and len(CS.modelV2.position.yStd) > 10:
+        model_y_std_1s = float(CS.modelV2.position.yStd[10])
+        if np.isfinite(model_y_std_1s) and model_y_std_1s >= 0.0:
+          y_std_1s = model_y_std_1s
 
-        recovery_time = float(np.interp(y_std_1s, [0.1, 0.2, 0.3, 0.4], [0.5, 0.8, 1.5, 3.0]))
-        recovery_time = max(recovery_time, float(np.interp(
-          self.repeated_override_count,
-          [0, 1, 2, 3],
-          [0.1, 1.0, 2.0, 3.0],
-        )))
-      base_rate_up = (self.angle_max_torque - self.params.ANGLE_MIN_TORQUE) * DT_CTRL / max(0.01, recovery_time)
+      recovery_time = float(np.interp(y_std_1s, [0.1, 0.2, 0.3, 0.4], [0.5, 0.8, 1.5, 3.0]))
+      recovery_time = max(recovery_time, float(np.interp(
+        self.repeated_override_count,
+        [0, 1, 2, 3],
+        [0.1, 1.0, 2.0, 3.0],
+      )))
+      base_rate_up = (self.angle_max_torque - self.params.ANGLE_MIN_TORQUE) * DT_CTRL / recovery_time
 
       # During recovery, taper the rate to zero. Only steeringPressed can reduce authority.
       torque_delta = base_rate_up * float(np.interp(torque_ratio, [0.6, 0.8], [1.0, 0.0]))

--- a/openpilot/common/params_keys.h
+++ b/openpilot/common/params_keys.h
@@ -273,8 +273,6 @@ inline static std::unordered_map<std::string, ParamKeyAttributes> keys = {
     {"SteerActuatorDelay", {PERSISTENT, INT, "0"}},
     {"LatSmoothSec", {PERSISTENT, INT, "13"}},
     {"LatSuspendAngleDeg", {PERSISTENT, INT, "300"}},
-    {"SteerOverrideReleaseSec", {PERSISTENT, INT, "20"}},
-    {"SteerOverrideRecoverySec", {PERSISTENT, INT, "0"}},
     {"CruiseOnDist", {PERSISTENT, INT, "400"}},
 
     {"CruiseMaxVals0", {PERSISTENT, INT, "160"}},

--- a/openpilot/selfdrive/carrot_settings.json
+++ b/openpilot/selfdrive/carrot_settings.json
@@ -119,8 +119,6 @@
                 "SteerActuatorDelay",
                 "LatSmoothSec",
                 "LatSuspendAngleDeg",
-                "SteerOverrideReleaseSec",
-                "SteerOverrideRecoverySec",
                 "CustomSR",
                 "SteerRatioRate"
               ]
@@ -995,38 +993,6 @@
       "max": 300,
       "default": 300,
       "unit": 10
-    },
-    {
-      "group": "조향튜닝",
-      "name": "SteerOverrideReleaseSec",
-      "title": "수동조향해제대기시간(20)",
-      "descr": "수동 조향 개입 후 손을 뗐을 때 자동 조향 토크 복구를 시작하기까지의 대기시간 (단위: 0.01초, 20 = 0.20초). 값을 낮추면 손을 떼자마자 복구가 바로 시작됩니다.",
-      "egroup": "LAT",
-      "etitle": "Steer Override Release Delay(20)",
-      "edescr": "Delay before starting steering torque recovery after releasing the wheel (unit: 0.01s, 20 = 0.20s). Lower values start recovery immediately.",
-      "cgroup": "转向",
-      "ctitle": "Steer Override Release Delay(20)",
-      "cdescr": "Delay before starting steering torque recovery after releasing the wheel (unit: 0.01s, 20 = 0.20s). Lower values start recovery immediately.",
-      "min": 0,
-      "max": 100,
-      "default": 20,
-      "unit": 1
-    },
-    {
-      "group": "조향튜닝",
-      "name": "SteerOverrideRecoverySec",
-      "title": "수동조향복구시간(0)",
-      "descr": "수동 조향 후 자동 조향 토크가 100%까지 회복되는 시간입니다. 0은 도로 인식 상태에 따른 자동복구이며, 고정 복구를 원하면 50(0.50초)처럼 설정하세요.",
-      "egroup": "LAT",
-      "etitle": "Steer Override Recovery Time(0)",
-      "edescr": "Time for steering torque to recover fully after driver override. 0 uses automatic recovery based on road confidence; set 50 for a fixed 0.50-second recovery.",
-      "cgroup": "转向",
-      "ctitle": "Steer Override Recovery Time(0)",
-      "cdescr": "Time for steering torque to recover fully after driver override. 0 uses automatic recovery based on road confidence; set 50 for a fixed 0.50-second recovery.",
-      "min": 0,
-      "max": 300,
-      "default": 0,
-      "unit": 5
     },
     {
       "group": "크루즈",


### PR DESCRIPTION
## 요약
커밋 668249e8 (`feat(steer): 수동조향 개입 후 해제 대기시간 및 토크 복구시간 설정 파라미터 추가`)에 대한 Revert(롤백) 요청 PR입니다.

## 롤백 사유
1. **실차 주행 테스트 결과**:
   수동 조향 개입 후 토크 복구 시간을 파라미터로 고정(0.5초 등)할 경우, 교차로 선회나 급커브에서 운전자가 핸들을 풀고 있는 도중에 모터가 조기에 풀 토크로 개입하여 핸들을 억지로 감거나 운전자와 힘겨루기를 하는 부자연스러운 현상이 발생합니다.
2. **순정 로직의 우수성**:
   기존 오파 순정의 모델 불확실성(`y_std_1s`) 기반 동적 복구 로직(급커브/교차로에서는 자동으로 2.5~3초에 걸쳐 부드럽게 복구, 직선에서는 빠르게 복구)이 실주행에서 훨씬 자연스럽고 안전하게 동작하므로 순정 로직으로 복원합니다.