### PR TITLE
Meb opendbc sync

### DIFF
--- a/opendbc_repo/opendbc/car/volkswagen/carcontroller.py
+++ b/opendbc_repo/opendbc/car/volkswagen/carcontroller.py
@@ -200,8 +200,12 @@ class CarController(CarControllerBase):
           long_override = CC.cruiseControl.override or CS.out.gasPressed
           self.long_override_counter = min(self.long_override_counter + 1, 5) if long_override else 0
           long_override_begin = long_override and self.long_override_counter < 5
-          self.long_disabled_counter = min(self.long_disabled_counter + 1, 5) if not CC.enabled else 0
-          long_disabling = not CC.enabled and self.long_disabled_counter < 5
+          # accFaulted 도 비활성과 동일하게 램프를 태운다. CC.enabled 가 아직 살아있는 폴트 첫
+          # 프레임들에 HALTEN/ANFAHREN -> 0 직행이 나가는 구멍 방지 (commaai/opendbc 는 faulted 를
+          # long_active 에 포함시켜 항상 disengage 램프 경유. 램프 5스텝 = 100ms 동일).
+          long_inactive = not CC.enabled or CS.out.accFaulted
+          self.long_disabled_counter = min(self.long_disabled_counter + 1, 5) if long_inactive else 0
+          long_disabling = long_inactive and self.long_disabled_counter < 5
 
           acc_control = self.CCS.acc_control_value(CS.out.cruiseState.available, CS.out.accFaulted, CC.enabled, long_override)
           # HALTEN(1)/ANFAHREN(4) -> KEINE_ANFORDERUNG(0) 직행은 차가 P 로 폴트난다 (commaai/opendbc).

--- a/opendbc_repo/opendbc/car/volkswagen/carcontroller.py
+++ b/opendbc_repo/opendbc/car/volkswagen/carcontroller.py
@@ -48,6 +48,7 @@ class CarController(CarControllerBase):
     self.lead_limit_disp = False
     self.lead_limit_cnt = 0
 
+    self.acc_hold_type_last = mebcan.ACC_HMS_NO_REQUEST  # last ACC_Anforderung_HMS sent (hold-release ramp)
 
   def update(self, CC, CS, now_nanos):
     actuators = CC.actuators
@@ -68,11 +69,13 @@ class CarController(CarControllerBase):
                                                        CS.out.vEgoRaw, CS.curvature,
                                                        self.CCP.STEER_STEP, CC.latActive,
                                                        self.CCP.CURVATURE_LIMITS)
-          # 조향 파워 계산 (운전자 개입 감지 시 감소). infiniteCable2와 동일하게 '부호 있는'
-          # steeringTorque 사용(abs 아님) -> 양(+) 방향 개입에서만 파워 감소하는 원본 거동 유지.
+          # 조향 파워 계산 (운전자 개입 감지 시 감소).
+          # infiniteCable2는 '부호 있는' steeringTorque를 그대로 np.interp에 넣어 음(-) 방향 개입에서는
+          # 항상 POWER_MAX로 클램프됐다 (한쪽 방향만 파워가 빠지는 좌우 비대칭).
+          # commaai/opendbc는 abs()를 쓴다 -> 양쪽 개입에 동일하게 반응하도록 수정.
           min_power = max(self.steering_power_last - self.CCP.STEERING_POWER_STEP, self.CCP.STEERING_POWER_MIN)
           max_power = min(self.steering_power_last + self.CCP.STEERING_POWER_STEP, self.CCP.STEERING_POWER_MAX)
-          target_power_driver = int(np.interp(CS.out.steeringTorque,
+          target_power_driver = int(np.interp(abs(CS.out.steeringTorque),
                                               [self.CCP.STEER_DRIVER_ALLOWANCE, self.CCP.STEER_DRIVER_MAX],
                                               [self.CCP.STEERING_POWER_MAX, self.CCP.STEERING_POWER_MIN]))
           target_power = int(np.interp(CS.out.vEgo, [0., 0.5], [self.CCP.STEERING_POWER_MIN, target_power_driver]))
@@ -176,6 +179,11 @@ class CarController(CarControllerBase):
           # and let the car roll back on a hill (normal launch uses startAccel 0.8, no delay).
           begin_release = (actuators.longControlState == LongCtrlState.pid
                            and CS.esp_hold_confirmation and accel >= 0.2)
+          # The car refuses longitudinal control right after the driver brakes hard at low speed
+          # (VMM_02.Long_Control_Inhibit); requesting a drive-off there faults TSK (commaai/opendbc).
+          if CS.long_control_inhibit:
+            begin_release = False
+
           # Hold the request until the car is actually moving. Do NOT keep esp_hold_confirmation
           # in the sustain condition: it goes false the moment the car acknowledges the release,
           # which cancels our own request mid-handshake. The car then falls back to the EPB and
@@ -186,7 +194,7 @@ class CarController(CarControllerBase):
             self.hold_release_frames -= 1
           if not CC.enabled or stopping or accel <= 0.0 or CS.out.vEgo > self.CCP.HOLD_RELEASE_DONE_SPEED:
             self.hold_release_frames = 0
-          starting = starting_planner or self.hold_release_frames > 0
+          starting = (starting_planner or self.hold_release_frames > 0) and not CS.long_control_inhibit
 
           # override / disable ramp handling to avoid EPB error at low speed (infiniteCable2)
           long_override = CC.cruiseControl.override or CS.out.gasPressed
@@ -196,8 +204,15 @@ class CarController(CarControllerBase):
           long_disabling = not CC.enabled and self.long_disabled_counter < 5
 
           acc_control = self.CCS.acc_control_value(CS.out.cruiseState.available, CS.out.accFaulted, CC.enabled, long_override)
+          # HALTEN(1)/ANFAHREN(4) -> KEINE_ANFORDERUNG(0) 직행은 차가 P 로 폴트난다 (commaai/opendbc).
+          # 직전에 홀드 계열을 보냈고 아직 HOLD_RELEASE_SPEED 미만이면 LOESEN_UEBER_RAMPE(5)를 거쳐 나간다.
+          releasing = (self.acc_hold_type_last in (self.CCS.ACC_HMS_HOLD, self.CCS.ACC_HMS_RELEASE,
+                                                   self.CCS.ACC_HMS_RAMP_RELEASE)
+                       and CS.out.vEgo < self.CCP.HOLD_RELEASE_SPEED)
           acc_hold = self.CCS.acc_hold_type(CS.out.cruiseState.available, CS.out.accFaulted, CC.enabled, starting, stopping,
-                                            CS.esp_hold_confirmation, long_override, long_override_begin, long_disabling)
+                                            CS.esp_hold_confirmation, long_override, long_override_begin, long_disabling,
+                                            releasing)
+          self.acc_hold_type_last = acc_hold
           # jerk/제어한계는 infiniteCable2 기본값(comfort OFF: jerk 4.0, 한계 0) 고정 - 실차 검증값.
           # (if2의 동적 comfort 모드는 출발 가속이 느려져 미채택; 필요 시 if2 mebutils에서 재이식)
           can_sends.extend(self.CCS.create_acc_accel_control(self.packer_pt, CANBUS.pt, self.CP, CS.acc_type, CC.enabled,

--- a/opendbc_repo/opendbc/car/volkswagen/carstate.py
+++ b/opendbc_repo/opendbc/car/volkswagen/carstate.py
@@ -194,7 +194,9 @@ class CarState(CarStateBase):
     ret.steeringAngleDeg = pt_cp.vl["LWI_01"]["LWI_Lenkradwinkel"] * (1, -1)[int(pt_cp.vl["LWI_01"]["LWI_VZ_Lenkradwinkel"])]
     ret.steeringRateDeg  = pt_cp.vl["LWI_01"]["LWI_Lenkradw_Geschw"] * (1, -1)[int(pt_cp.vl["LWI_01"]["LWI_VZ_Lenkradw_Geschw"])]
     ret.steeringTorque   = pt_cp.vl["LH_EPS_03"]["EPS_Lenkmoment"] * (1, -1)[int(pt_cp.vl["LH_EPS_03"]["EPS_VZ_Lenkmoment"])]
-    ret.steeringPressed  = abs(ret.steeringTorque) > self.CCP.STEER_DRIVER_ALLOWANCE
+    # 5프레임(50ms) 연속일 때만 개입 판정 (commaai/opendbc 동일). 임계값(0.6Nm)은 실차 검증값 유지.
+    # 즉시 판정은 노면 요철 한 방에도 개입으로 오인해 곡률 PID unwind/override가 튈 수 있음.
+    ret.steeringPressed  = self.update_steering_pressed(abs(ret.steeringTorque) > self.CCP.STEER_DRIVER_ALLOWANCE, 5)
 
     # MEB curvature 피드백: QFK_01.Curvature(40비트) + Curvature_VZ(55비트)
     # QFK_01 곡률은 openpilot 곡률 부호 관례와 반대 -> 음수화 (infiniteCable2: ret.steeringCurvature = -QFK...)
@@ -234,12 +236,15 @@ class CarState(CarStateBase):
     # 매 정차마다 오인되지 않음. 실제 전자식 주차브레이크 작동 시에만 True.
     ret.parkingBrake = pt_cp.vl["ESC_50"]["EPB_Status"] in (1, 4)
 
-    # 도어
-    ret.doorOpen = any([pt_cp.vl["Gateway_72"]["ZV_FT_offen"],
-                        pt_cp.vl["Gateway_72"]["ZV_BT_offen"],
-                        pt_cp.vl["Gateway_72"]["ZV_HFS_offen"],
-                        pt_cp.vl["Gateway_72"]["ZV_HBFS_offen"],
-                        pt_cp.vl["Gateway_72"]["ZV_HD_offen"]])
+    # 도어: Gateway_72.ZV_02_alt 가 서 있으면 도어의 실제 소스는 ZV_02 (commaai/opendbc 동일).
+    # 실차 검증: MK1/MK2 모두 ZV_02_alt=1 고정 -> 기존 Gateway_72 도어비트는 죽은 릴레이였음
+    # (문 열림이 아예 감지되지 않던 상태). 두 메시지의 도어 신호명은 동일.
+    doors = pt_cp.vl["ZV_02"] if bool(pt_cp.vl["Gateway_72"]["ZV_02_alt"]) else pt_cp.vl["Gateway_72"]
+    ret.doorOpen = any([doors["ZV_FT_offen"],
+                        doors["ZV_BT_offen"],
+                        doors["ZV_HFS_offen"],
+                        doors["ZV_HBFS_offen"],
+                        doors["ZV_HD_offen"]])
 
     # 안전벨트
     ret.seatbeltUnlatched = pt_cp.vl["Airbag_02"]["AB_Gurtschloss_FA"] != 3
@@ -267,7 +272,17 @@ class CarState(CarStateBase):
     ret.stockFcw = False
     ret.stockAeb = False
 
-    self.acc_type = 2  # ACC stop and go
+    # Report EA as a non-critical fault while it is actively intervening (phases 3-6, commaai/opendbc).
+    # Reads 2 (STANDBY) in normal driving. EA_01 is only parsed when STOCK_EA_PRESENT.
+    if self.CP.flags & VolkswagenFlags.STOCK_EA_PRESENT:
+      ret.carFaultedNonCritical = cam_cp.vl["EA_01"]["EA_Funktionsstatus"] in (3, 4, 5, 6)
+
+    # ACC type: on the gateway harness read it from the stock radar's ACC_18 (commaai/opendbc;
+    # RX CRC verified on MK1/MK2 logs). Camera harness keeps the radar silent, keep 2.
+    if self.CP.networkLocation == NetworkLocation.gateway:
+      self.acc_type = ext_cp.vl["ACC_18"]["ACC_Typ"]
+    else:
+      self.acc_type = 2  # ACC stop and go
     self.eps_stock_values = pt_cp.vl["LH_EPS_03"]
     # 정전식 핸들 터치(KLR_01) stock 값 - Emergency Assist 핸즈온 pacification용
     self.klr_stock_values = pt_cp.vl["KLR_01"] if self.CP.flags & VolkswagenFlags.STOCK_KLR_PRESENT else {}
@@ -319,9 +334,9 @@ class CarState(CarStateBase):
     ret.cruiseSpeedBigStep = bool(pt_cp.vl["GRA_ACC_01"]["GRA_Tip_Stufe_2"])
     self.gra_stock_values = pt_cp.vl["GRA_ACC_01"]
 
-    # ESP 상태
-    ret.espDisabled = False
-    ret.espActive   = False
+    # ESP 상태 (commaai/opendbc 동일): ESC 수동 off / ESC 개입 중. 평시 둘 다 0 (실차 확인).
+    ret.espDisabled = bool(pt_cp.vl["ESP_21"]["ESP_Tastung_passiv"])
+    ret.espActive   = bool(pt_cp.vl["ESP_21"]["ESP_Eingriff"])
 
     self.frame += 1
     return ret
@@ -498,6 +513,7 @@ class CarState(CarStateBase):
       pt_messages += [("Getriebe_11", 50)]  # 기어
 
     pt_messages += [("VMM_02", 50)]  # 종방향 제어 일시 거부 (Long_Control_Inhibit), MK1/MK2 실측 50Hz
+    pt_messages += [("ZV_02", 5)]    # 도어 실소스 (ZV_02_alt=1), MK1/MK2 실측 5Hz
 
     if CP.flags & VolkswagenFlags.STOCK_KLR_PRESENT:
       pt_messages += [("KLR_01", 10 if gen2 else 50)]  # 정전식 핸들 터치 (EA 핸즈온, GEN2 실측 ~16Hz)
@@ -512,6 +528,7 @@ class CarState(CarStateBase):
     if CP.networkLocation == NetworkLocation.gateway:
       cam_messages += [
         ("MEB_ACC_01", 10 if gen2 else 50),   # From 레이더 (ACC 설정속도, GEN2 실측 ~16Hz)
+        ("ACC_18", 50),                       # From 레이더 (ACC_Typ 실측), MK1/MK2 실측 50Hz
       ]
       if CP.enableBsm:
         # GEN2(2024+)는 BSM이 PT 버스로 옴 (infiniteCable2 동일)

--- a/opendbc_repo/opendbc/car/volkswagen/carstate.py
+++ b/opendbc_repo/opendbc/car/volkswagen/carstate.py
@@ -16,6 +16,7 @@ class CarState(CarStateBase):
     self.CCP = CarControllerParams(CP)
     self.button_states = {button.event_type: False for button in self.CCP.BUTTONS}
     self.esp_hold_confirmation = False
+    self.long_control_inhibit = False  # MEB: 차가 종방향 제어를 일시 거부 중 (VMM_02)
     self.upscale_lead_car_signal = False
     self.eps_stock_values = False
     # MEB (VW ID.4/ID.5) state - ported from infiniteCable2 via id4-meb branch
@@ -28,12 +29,19 @@ class CarState(CarStateBase):
     self.curvature = 0.
     self.cruise_recovery_timer = 0  # update_acc_fault 디바운스용 (infiniteCable2)
 
-  def update_acc_fault(self, acc_fault, parking_brake=False, drive_mode=True, recovery_frames_max=100):
+  def update_acc_fault(self, acc_fault, parking_brake=False, drive_mode=True, recovery_frames_max=100,
+                       long_inhibit=False):
     # infiniteCable2 포팅: 주차 중(EPB+비주행)엔 TSK fault를 무시하고, 주행 전환 직후
     # recovery_frames_max(100) 동안 grace를 줘서 출발 직후 일시적 TSK 글리치로 인한
     # 불필요한 Cruise Fault 해제를 막는다.
+    # long_inhibit: 운전자가 저속에서 세게 제동하면 TSK가 잠시 폴트로 떨어지는데, 차가
+    # VMM_02.Long_Control_Inhibit 으로 미리 알려준다. 예정된 폴트이므로 오해제하지 않는다.
+    # (commaai/opendbc: "TSK temporarily faults ... shortly after driver harshly brakes")
     fault = acc_fault
-    if parking_brake and not drive_mode:
+    if long_inhibit:
+      self.cruise_recovery_timer = self.frame
+      fault = False
+    elif parking_brake and not drive_mode:
       fault = False
       self.cruise_recovery_timer = self.frame
     elif self.frame - self.cruise_recovery_timer < recovery_frames_max:
@@ -204,8 +212,9 @@ class CarState(CarStateBase):
     # HCA 상태 (QFK_01) - vw_meb.dbc는 소문자 값 정의, update_hca_state는 대문자 비교 → 변환
     hca_status_raw = self.CCP.hca_status_values.get(pt_cp.vl["QFK_01"]["LatCon_HCA_Status"])
     hca_status = hca_status_raw.upper() if hca_status_raw else hca_status_raw
-    # GEN2(2024+): Getriebe_11이 PT버스에 안 옴 -> Gateway_73에서 기어 읽기 (infiniteCable2 동일, 실차 rlog 확인)
-    if self.CP.flags & VolkswagenFlags.MEB_GEN2:
+    # 기어 소스: Getriebe_11이 PT버스에 안 오는 차(MK2 등)는 Gateway_73에서 읽는다.
+    # 차종 플래그가 아니라 interface.py가 핑거프린트(0x3DC)로 세운 ALT_GEAR를 본다.
+    if self.CP.flags & VolkswagenFlags.ALT_GEAR:
       gear_raw = pt_cp.vl["Gateway_73"]["GE_Fahrstufe"]
     else:
       gear_raw = pt_cp.vl["Getriebe_11"]["GE_Fahrstufe"]
@@ -270,6 +279,11 @@ class CarState(CarStateBase):
     # 어긋났음 -> EPB 홀드/릴리스 타이밍 불일치로 재출발이 막힐 수 있었음.
     self.esp_hold_confirmation = pt_cp.vl["ESC_50"]["Motion_State"] == 3
 
+    # 저속에서 운전자가 세게 제동한 직후 차가 종방향 제어를 일시 거부하는 구간.
+    # 이 상태에서 출발요청(ACC_Anfahren)을 넣으면 TSK가 폴트난다 (commaai/opendbc).
+    # 2 = inhibited. 실차 rlog 검증: MK1/MK2 모두 평시 1(not_inhibited)로 안정적으로 읽힘.
+    self.long_control_inhibit = pt_cp.vl["VMM_02"]["Long_Control_Inhibit"] == 2
+
     # ACC/크루즈 상태
     ret.cruiseState.available  = pt_cp.vl["Motor_51"]["TSK_Status"] in (2, 3, 4, 5)
     ret.cruiseState.enabled    = pt_cp.vl["Motor_51"]["TSK_Status"] in (3, 4, 5)
@@ -277,7 +291,8 @@ class CarState(CarStateBase):
     # 주행 전환 직후 100프레임 grace -> 출발 직후 일시적 TSK 글리치로 인한 오해제 방지. (infiniteCable2)
     acc_drive_mode = ret.gearShifter == GearShifter.drive
     ret.accFaulted = self.update_acc_fault(pt_cp.vl["Motor_51"]["TSK_Status"] in (6, 7),
-                                           parking_brake=ret.parkingBrake, drive_mode=acc_drive_mode)
+                                           parking_brake=ret.parkingBrake, drive_mode=acc_drive_mode,
+                                           long_inhibit=self.long_control_inhibit)
     ret.cruiseState.standstill = self.CP.pcmCruise and self.esp_hold_confirmation
     ret.cruiseState.nonAdaptive = bool(pt_cp.vl["Motor_51"]["TSK_Limiter_ausgewaehlt"])
 
@@ -474,12 +489,15 @@ class CarState(CarStateBase):
       ("SMLS_01", 1),       # From 스탈크 컨트롤
     ]
 
-    # GEN2(2024+, ID.4 MK2): 기어는 Gateway_73으로 오고, 일부 메시지 주기가 낮음 (실차 rlog 실측)
+    # GEN2(2024+, ID.4 MK2): 일부 메시지 주기가 낮음 (실차 rlog 실측)
     gen2 = bool(CP.flags & VolkswagenFlags.MEB_GEN2)
-    if gen2:
-      pt_messages += [("Gateway_73", 10)]   # 기어 (GE_Fahrstufe)
+    # 기어: ALT_GEAR(핑거프린트에 Gateway_73 존재)면 Gateway_73, 아니면 Getriebe_11
+    if CP.flags & VolkswagenFlags.ALT_GEAR:
+      pt_messages += [("Gateway_73", 10)]   # 기어 (GE_Fahrstufe, 실측 20Hz - 여유 두고 10 선언)
     else:
       pt_messages += [("Getriebe_11", 50)]  # 기어
+
+    pt_messages += [("VMM_02", 50)]  # 종방향 제어 일시 거부 (Long_Control_Inhibit), MK1/MK2 실측 50Hz
 
     if CP.flags & VolkswagenFlags.STOCK_KLR_PRESENT:
       pt_messages += [("KLR_01", 10 if gen2 else 50)]  # 정전식 핸들 터치 (EA 핸즈온, GEN2 실측 ~16Hz)

--- a/opendbc_repo/opendbc/car/volkswagen/interface.py
+++ b/opendbc_repo/opendbc/car/volkswagen/interface.py
@@ -57,6 +57,12 @@ class CarInterface(CarInterfaceBase):
       if 0x25D in fingerprint[0]:  # KLR_01 - capacitive steering wheel module (Emergency Assist hands-on)
         ret.flags |= VolkswagenFlags.STOCK_KLR_PRESENT.value
 
+      # 기어(GE_Fahrstufe) 소스: MK2(GEN2)는 Getriebe_11이 PT버스에 안 오고 Gateway_73으로만 온다.
+      # 차종 플래그 대신 실제 메시지 유무로 판정 (commaai/opendbc 방식).
+      # MK1 실차 rlog 검증: 두 메시지 모두 존재하며 GE_Fahrstufe 값이 1205/1205 프레임 완전 일치.
+      if 0x3DC in fingerprint[0]:  # Gateway_73
+        ret.flags |= VolkswagenFlags.ALT_GEAR.value
+
       if all(msg in fingerprint[2] for msg in (0x1A4, 0x1F0)):  # EA_01, EA_02 - Emergency Assist HUD
         ret.flags |= VolkswagenFlags.STOCK_EA_PRESENT.value
 

--- a/opendbc_repo/opendbc/car/volkswagen/mebcan.py
+++ b/opendbc_repo/opendbc/car/volkswagen/mebcan.py
@@ -165,10 +165,14 @@ def acc_control_value(main_switch_on, acc_faulted, long_active, override):
   return acc_control
 
 
-def acc_hold_type(main_switch_on, acc_faulted, long_active, starting, stopping, esp_hold, override, override_begin, long_disabling):
-  if acc_faulted:
-    acc_hold_type = ACC_HMS_NO_REQUEST
-  elif not long_active:
+def acc_hold_type(main_switch_on, acc_faulted, long_active, starting, stopping, esp_hold, override, override_begin, long_disabling,
+                  releasing=False):
+  # releasing: 직전에 HALTEN(1)/ANFAHREN(4)/LOESEN_UEBER_RAMPE(5)를 보냈고 아직 저속인 상태.
+  # HALTEN/ANFAHREN -> KEINE_ANFORDERUNG(0) 직행은 차가 P로 폴트나므로 (commaai/opendbc 확인)
+  # 사이에 LOESEN_UEBER_RAMPE(5)를 끼워 넣는다.
+  # acc_faulted도 해제 경로를 탄다: 홀드 중 폴트가 나도 0으로 직행하지 않고 램프를 거치게 한다
+  # (commaai/opendbc는 accFaulted를 long_active에 포함시켜 항상 disengage 램프를 태운다).
+  if acc_faulted or not long_active:
     if long_disabling:
       acc_hold_type = ACC_HMS_RAMP_RELEASE  # ramp release right after disabling (prevents car error with EPB at low speed)
     else:
@@ -182,6 +186,8 @@ def acc_hold_type(main_switch_on, acc_faulted, long_active, starting, stopping, 
     acc_hold_type = ACC_HMS_RELEASE
   elif stopping or esp_hold:
     acc_hold_type = ACC_HMS_HOLD
+  elif releasing:
+    acc_hold_type = ACC_HMS_RAMP_RELEASE
   else:
     acc_hold_type = ACC_HMS_NO_REQUEST
   return acc_hold_type

--- a/opendbc_repo/opendbc/car/volkswagen/radar_interface.py
+++ b/opendbc_repo/opendbc/car/volkswagen/radar_interface.py
@@ -75,6 +75,11 @@ class RadarInterface(RadarInterfaceBase):
     msg = self.rcp.vl["Strukturen_01"]
     get = msg.__getitem__
 
+    # 레이더 가림/이용불가 (commaai/opendbc 동일): Distance_Status != 0 이면 센서가 가려진 상태
+    # (3 = obstructed 실측). 눈/진흙으로 가려져도 "앞차 없음"으로 오인하지 않게 오류로 올린다.
+    if msg["Distance_Status"] != 0:
+      ret.errors.radarUnavailableTemporary = True
+
     active_objects: dict[int, tuple[float, float, float]] = {}
     for obj_id_sig, long_sig, lat_sig, vel_sig in SIGNAL_SETS:
       obj_id = get(obj_id_sig)
@@ -86,7 +91,7 @@ class RadarInterface(RadarInterfaceBase):
       v_rel = get(vel_sig)
 
       # 유효성 게이트 (safety): 전방 리드만 통과시킨다.
-      # Long_Distance는 offset -6m라 raw가 낮으면 0 근처/음수로 디코딩됨 -> 노이즈/유령 객체가
+      # Long_Distance는 offset -3.75m라 raw가 낮으면 0 근처/음수로 디코딩됨 -> 노이즈/유령 객체가
       # "코앞에 차"로 잡혀 인게이지 순간 오탐 FCW/급제동을 유발. 비현실적 근접(<=1m)·범위 밖은 제외.
       if not (1.0 < d_rel < 250.0):
         continue

--- a/opendbc_repo/opendbc/car/volkswagen/values.py
+++ b/opendbc_repo/opendbc/car/volkswagen/values.py
@@ -94,6 +94,9 @@ class CarControllerParams:
       self.STEERING_POWER_STEP     = 2     # HCA_03 steering power counter steps
       self.HOLD_RELEASE_MAX_STEPS  = 100   # sustain ACC_Anfahren up to ~2s (ACC_CONTROL_STEP based)
       self.HOLD_RELEASE_DONE_SPEED = 0.3   # m/s, above this the car has actually launched
+      # Dropping ACC_Anforderung_HMS straight from HALTEN(1)/ANFAHREN(4) to KEINE_ANFORDERUNG(0)
+      # can fault the car into park (commaai/opendbc). Pass through LOESEN_UEBER_RAMPE(5) below this speed.
+      self.HOLD_RELEASE_SPEED      = 5 * CV.KPH_TO_MS  # m/s
 
       self.CURVATURE_LIMITS: CurvatureSteeringLimits = CurvatureSteeringLimits(0.195)
 
@@ -193,6 +196,7 @@ class VolkswagenSafetyFlags(IntFlag):
 class VolkswagenFlags(IntFlag):
   # Detected flags
   STOCK_HCA_PRESENT = 1
+  ALT_GEAR = 32  # 기어(GE_Fahrstufe)가 Getriebe_11 대신 Gateway_73(0x3DC)로 오는 차 (commaai/opendbc 동일 값)
   STOCK_KLR_PRESENT = 64  # capacitive steering wheel module present (KLR_01) -> EA hands-on pacification
   STOCK_EA_PRESENT = 16384  # Emergency Assist module present (EA_01/EA_02) -> relay EA HUD (wheel icon)
 

--- a/opendbc_repo/opendbc/dbc/vw_meb.dbc
+++ b/opendbc_repo/opendbc/dbc/vw_meb.dbc
@@ -404,7 +404,7 @@ BO_ 333 ACC_18: 32 XXX
  SG_ ACC_AKTIV_regelt : 90|1@0+ (1,0) [0|1] "" XXX
  SG_ SET_ME_0X1 : 92|1@0+ (1,0) [0|1] "" XXX
  SG_ SET_ME_0X9 : 232|4@1+ (1,0) [0|15] "" XXX
- SG_ Speed : 236|11@1+ (0.1,0) [0|15] "" XXX
+ SG_ Speed : 236|12@1+ (0.1,0) [0|15] "" XXX
  SG_ Accel_Boost : 248|6@1+ (1,0) [0|3] "" XXX
  SG_ Reversing : 254|1@0+ (1,0) [0|1] "" XXX
 

--- a/opendbc_repo/opendbc/dbc/vw_meb.dbc
+++ b/opendbc_repo/opendbc/dbc/vw_meb.dbc
@@ -327,6 +327,7 @@ BO_ 313 VMM_02: 32 XXX
  SG_ AEB_Active : 31|1@0+ (1,0) [0|1] "" XXX
  SG_ ESP_Hold : 35|1@0+ (1,0) [0|1] "" XXX
  SG_ Brake_Pressed_3 : 48|1@0+ (1,0) [0|1] "" XXX
+ SG_ Long_Control_Inhibit : 52|2@1+ (1,0) [0|3] "" XXX
  SG_ FCW_Active : 56|1@1+ (1,0) [0|1] "" XXX
  SG_ Brake_Pressure : 76|11@1+ (1,0) [0|100] "" XXX
 
@@ -2158,6 +2159,7 @@ CM_ BO_ 522 "Steuergerät für Fahrzeugbewegung";
 CM_ BO_ 1622 "Steuergerät für Lenkungsverriegelung";
 CM_ BO_ 316495165 "Steuergerät ICAS1";
 CM_ BO_ 441800001 "Steuergerät für Fahrzeugbewegung";
+VAL_ 313 Long_Control_Inhibit 1 "not_inhibited" 2 "inhibited";
 VAL_ 64 AB_RGS_Anst 4 "aktiv_Niveau_1" 5 "aktiv_Niveau_2" 6 "aktiv_Niveau_3" 7 "aktiv_Niveau_4" 8 "deaktiviert";
 VAL_ 64 AB_Front_Crash 0 "kein_Front_Crash" 1 "Front_Crash";
 VAL_ 64 AB_Heck_Crash 0 "kein_Heck_Crash" 1 "Heck_Crash";

--- a/opendbc_repo/opendbc/dbc/vw_meb.dbc
+++ b/opendbc_repo/opendbc/dbc/vw_meb.dbc
@@ -524,41 +524,6 @@ BO_ 589 MEB_Side_Assist_02: 64 XXX
  SG_ Unknown_01 : 100|3@0+ (1,0) [0|7] "" XXX
  SG_ Unknown_02 : 108|3@0+ (1,0) [0|7] "" XXX
 
-BO_ 591 MEB_Distance_01: 64 XXX
- SG_ Unknown_01 : 12|1@0+ (1,0) [0|1] "" XXX
- SG_ Distance_Status : 13|2@1+ (1,0) [0|3] "" XXX
- SG_ Same_Lane_01_ObjectID : 16|6@1+ (1,0) [0|63] "Unit_ObjectID" XXX
- SG_ Left_Lane_01_ObjectID : 22|6@1+ (1,0) [0|63] "Unit_ObjectID" XXX
- SG_ Right_Lane_01_ObjectID : 28|6@1+ (1,0) [0|63] "Unit_ObjectID" XXX
- SG_ Same_Lane_02_ObjectID : 34|6@1+ (1,0) [0|63] "Unit_ObjectID" XXX
- SG_ Left_Lane_02_ObjectID : 40|6@1+ (1,0) [0|63] "Unit_ObjectID" XXX
- SG_ Right_Lane_02_ObjectID : 46|6@1+ (1,0) [0|63] "Unit_ObjectID" XXX
- SG_ Unknown_02 : 52|2@1+ (1,0) [0|3] "" XXX
- SG_ Unknown_03 : 54|10@1+ (1,0) [0|3] "" XXX
- SG_ Same_Lane_01_Long_Distance : 64|12@1+ (0.07,-6) [0|300] "Unit_Meter" XXX
- SG_ Same_Lane_01_Lat_Distance : 76|10@1+ (0.065,-33.28) [-50|50] "Unit_Meter" XXX
- SG_ Same_Lane_01_Rel_Velo : 86|10@1+ (0.25,-128) [-100|100] "Unit_MeterPerSecond" XXX
- SG_ Left_Lane_01_Long_Distance : 96|12@1+ (0.07,-6) [0|300] "Unit_Meter" XXX
- SG_ Left_Lane_01_Lat_Distance : 108|10@1+ (0.065,-33.28) [-50|50] "Unit_Meter" XXX
- SG_ Left_Lane_01_Rel_Velo : 118|10@1+ (0.25,-128) [-100|100] "Unit_MeterPerSecond" XXX
- SG_ Right_Lane_01_Long_Distance : 128|12@1+ (0.07,-6) [0|300] "Unit_Meter" XXX
- SG_ Right_Lane_01_Lat_Distance : 140|10@1+ (0.065,-33.28) [-50|50] "Unit_Meter" XXX
- SG_ Right_Lane_01_Rel_Velo : 150|10@1+ (0.25,-128) [-100|100] "Unit_MeterPerSecond" XXX
- SG_ Same_Lane_02_Long_Distance : 160|12@1+ (0.07,-6) [0|300] "Unit_Meter" XXX
- SG_ Same_Lane_02_Lat_Distance : 172|10@1+ (0.065,-33.28) [-50|50] "Unit_Meter" XXX
- SG_ Same_Lane_02_Rel_Velo : 182|10@1+ (0.25,-128) [-100|100] "Unit_MeterPerSecond" XXX
- SG_ Left_Lane_02_Long_Distance : 192|12@1+ (0.07,-6) [0|300] "Unit_Meter" XXX
- SG_ Left_Lane_02_Lat_Distance : 204|10@1+ (0.065,-33.28) [-50|50] "Unit_Meter" XXX
- SG_ Left_Lane_02_Rel_Velo : 214|10@1+ (0.25,-128) [-100|100] "Unit_MeterPerSecond" XXX
- SG_ Right_Lane_02_Long_Distance : 224|12@1+ (0.07,-6) [0|300] "Unit_Meter" XXX
- SG_ Right_Lane_02_Lat_Distance : 236|10@1+ (0.065,-33.28) [-50|50] "Unit_Meter" XXX
- SG_ Right_Lane_02_Rel_Velo : 246|10@1+ (0.25,-128) [-100|100] "Unit_MeterPerSecond" XXX
- SG_ Unknown_04 : 256|8@1+ (1,-128) [0|31] "" XXX
- SG_ Unknown_05 : 264|6@1+ (1,-15) [0|31] "" XXX
- SG_ Unknown_06 : 270|6@1+ (1,0) [0|127] "" XXX
- SG_ Unknown_07 : 277|6@1+ (1,0) [0|7] "" XXX
- SG_ Unknown_08 : 284|6@1+ (1,0) [0|1] "" XXX
-
 BO_ 605 KLR_01: 8 Gateway
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" Vector__XXX
  SG_ COUNTER : 8|4@1+ (1,0) [0|15] "" Vector__XXX
@@ -586,24 +551,24 @@ BO_ 591 Strukturen_01: 64 XXX
  SG_ Same_Lane_02_ObjectID : 34|6@1+ (1,0) [0|63] "Unit_ObjectID" XXX
  SG_ Left_Lane_02_ObjectID : 40|6@1+ (1,0) [0|63] "Unit_ObjectID" XXX
  SG_ Right_Lane_02_ObjectID : 46|6@1+ (1,0) [0|63] "Unit_ObjectID" XXX
- SG_ Same_Lane_01_Long_Distance : 64|12@1+ (0.07,-6) [0|300] "Unit_Meter" XXX
+ SG_ Same_Lane_01_Long_Distance : 64|12@1+ (0.0625,-3.75) [0|300] "Unit_Meter" XXX
  SG_ Same_Lane_01_Lat_Distance : 76|10@1+ (0.065,-33.28) [-50|50] "Unit_Meter" XXX
- SG_ Same_Lane_01_Rel_Velo : 86|10@1+ (0.28,-143.36) [-150|150] "Unit_MeterPerSecond" XXX
- SG_ Left_Lane_01_Long_Distance : 96|12@1+ (0.07,-6) [0|300] "Unit_Meter" XXX
+ SG_ Same_Lane_01_Rel_Velo : 86|10@1+ (0.25,-128) [-150|150] "Unit_MeterPerSecond" XXX
+ SG_ Left_Lane_01_Long_Distance : 96|12@1+ (0.0625,-3.75) [0|300] "Unit_Meter" XXX
  SG_ Left_Lane_01_Lat_Distance : 108|10@1+ (0.065,-33.28) [-50|50] "Unit_Meter" XXX
- SG_ Left_Lane_01_Rel_Velo : 118|10@1+ (0.28,-143.36) [-150|150] "Unit_MeterPerSecond" XXX
- SG_ Right_Lane_01_Long_Distance : 128|12@1+ (0.07,-6) [0|300] "Unit_Meter" XXX
+ SG_ Left_Lane_01_Rel_Velo : 118|10@1+ (0.25,-128) [-150|150] "Unit_MeterPerSecond" XXX
+ SG_ Right_Lane_01_Long_Distance : 128|12@1+ (0.0625,-3.75) [0|300] "Unit_Meter" XXX
  SG_ Right_Lane_01_Lat_Distance : 140|10@1+ (0.065,-33.28) [-50|50] "Unit_Meter" XXX
- SG_ Right_Lane_01_Rel_Velo : 150|10@1+ (0.28,-143.36) [-150|150] "Unit_MeterPerSecond" XXX
- SG_ Same_Lane_02_Long_Distance : 160|12@1+ (0.07,-6) [0|300] "Unit_Meter" XXX
+ SG_ Right_Lane_01_Rel_Velo : 150|10@1+ (0.25,-128) [-150|150] "Unit_MeterPerSecond" XXX
+ SG_ Same_Lane_02_Long_Distance : 160|12@1+ (0.0625,-3.75) [0|300] "Unit_Meter" XXX
  SG_ Same_Lane_02_Lat_Distance : 172|10@1+ (0.065,-33.28) [-50|50] "Unit_Meter" XXX
- SG_ Same_Lane_02_Rel_Velo : 182|10@1+ (0.28,-143.36) [-150|150] "Unit_MeterPerSecond" XXX
- SG_ Left_Lane_02_Long_Distance : 192|12@1+ (0.07,-6) [0|300] "Unit_Meter" XXX
+ SG_ Same_Lane_02_Rel_Velo : 182|10@1+ (0.25,-128) [-150|150] "Unit_MeterPerSecond" XXX
+ SG_ Left_Lane_02_Long_Distance : 192|12@1+ (0.0625,-3.75) [0|300] "Unit_Meter" XXX
  SG_ Left_Lane_02_Lat_Distance : 204|10@1+ (0.065,-33.28) [-50|50] "Unit_Meter" XXX
- SG_ Left_Lane_02_Rel_Velo : 214|10@1+ (0.28,-143.36) [-150|150] "Unit_MeterPerSecond" XXX
- SG_ Right_Lane_02_Long_Distance : 224|12@1+ (0.07,-6) [0|300] "Unit_Meter" XXX
+ SG_ Left_Lane_02_Rel_Velo : 214|10@1+ (0.25,-128) [-150|150] "Unit_MeterPerSecond" XXX
+ SG_ Right_Lane_02_Long_Distance : 224|12@1+ (0.0625,-3.75) [0|300] "Unit_Meter" XXX
  SG_ Right_Lane_02_Lat_Distance : 236|10@1+ (0.065,-33.28) [-50|50] "Unit_Meter" XXX
- SG_ Right_Lane_02_Rel_Velo : 246|10@1+ (0.28,-143.36) [-150|150] "Unit_MeterPerSecond" XXX
+ SG_ Right_Lane_02_Rel_Velo : 246|10@1+ (0.25,-128) [-150|150] "Unit_MeterPerSecond" XXX
 
 BO_ 695 RCTA_01: 8 XXX
  SG_ RCTA_01_CRC : 0|8@1+ (1,0) [0|255] "" XXX

--- a/opendbc_repo/opendbc/dbc/vw_meb_2024.dbc
+++ b/opendbc_repo/opendbc/dbc/vw_meb_2024.dbc
@@ -436,24 +436,24 @@ BO_ 591 Strukturen_01: 64 XXX
  SG_ Right_Lane_02_ObjectID : 46|6@1+ (1,0) [0|63] "Unit_ObjectID" XXX
  SG_ Unknown_02 : 52|2@1+ (1,0) [0|3] "" XXX
  SG_ Unknown_03 : 54|10@1+ (1,0) [0|3] "" XXX
- SG_ Same_Lane_01_Long_Distance : 64|12@1+ (0.07,-6) [0|300] "Unit_Meter" XXX
+ SG_ Same_Lane_01_Long_Distance : 64|12@1+ (0.0625,-3.75) [0|300] "Unit_Meter" XXX
  SG_ Same_Lane_01_Lat_Distance : 76|10@1+ (0.065,-33.28) [-50|50] "Unit_Meter" XXX
- SG_ Same_Lane_01_Rel_Velo : 86|10@1+ (0.28,-143.36) [-150|150] "Unit_MeterPerSecond" XXX
- SG_ Left_Lane_01_Long_Distance : 96|12@1+ (0.07,-6) [0|300] "Unit_Meter" XXX
+ SG_ Same_Lane_01_Rel_Velo : 86|10@1+ (0.25,-128) [-150|150] "Unit_MeterPerSecond" XXX
+ SG_ Left_Lane_01_Long_Distance : 96|12@1+ (0.0625,-3.75) [0|300] "Unit_Meter" XXX
  SG_ Left_Lane_01_Lat_Distance : 108|10@1+ (0.065,-33.28) [-50|50] "Unit_Meter" XXX
- SG_ Left_Lane_01_Rel_Velo : 118|10@1+ (0.28,-143.36) [-150|150] "Unit_MeterPerSecond" XXX
- SG_ Right_Lane_01_Long_Distance : 128|12@1+ (0.07,-6) [0|300] "Unit_Meter" XXX
+ SG_ Left_Lane_01_Rel_Velo : 118|10@1+ (0.25,-128) [-150|150] "Unit_MeterPerSecond" XXX
+ SG_ Right_Lane_01_Long_Distance : 128|12@1+ (0.0625,-3.75) [0|300] "Unit_Meter" XXX
  SG_ Right_Lane_01_Lat_Distance : 140|10@1+ (0.065,-33.28) [-50|50] "Unit_Meter" XXX
- SG_ Right_Lane_01_Rel_Velo : 150|10@1+ (0.28,-143.36) [-150|150] "Unit_MeterPerSecond" XXX
- SG_ Same_Lane_02_Long_Distance : 160|12@1+ (0.07,-6) [0|300] "Unit_Meter" XXX
+ SG_ Right_Lane_01_Rel_Velo : 150|10@1+ (0.25,-128) [-150|150] "Unit_MeterPerSecond" XXX
+ SG_ Same_Lane_02_Long_Distance : 160|12@1+ (0.0625,-3.75) [0|300] "Unit_Meter" XXX
  SG_ Same_Lane_02_Lat_Distance : 172|10@1+ (0.065,-33.28) [-50|50] "Unit_Meter" XXX
- SG_ Same_Lane_02_Rel_Velo : 182|10@1+ (0.28,-143.36) [-150|150] "Unit_MeterPerSecond" XXX
- SG_ Left_Lane_02_Long_Distance : 192|12@1+ (0.07,-6) [0|300] "Unit_Meter" XXX
+ SG_ Same_Lane_02_Rel_Velo : 182|10@1+ (0.25,-128) [-150|150] "Unit_MeterPerSecond" XXX
+ SG_ Left_Lane_02_Long_Distance : 192|12@1+ (0.0625,-3.75) [0|300] "Unit_Meter" XXX
  SG_ Left_Lane_02_Lat_Distance : 204|10@1+ (0.065,-33.28) [-50|50] "Unit_Meter" XXX
- SG_ Left_Lane_02_Rel_Velo : 214|10@1+ (0.28,-143.36) [-150|150] "Unit_MeterPerSecond" XXX
- SG_ Right_Lane_02_Long_Distance : 224|12@1+ (0.07,-6) [0|300] "Unit_Meter" XXX
+ SG_ Left_Lane_02_Rel_Velo : 214|10@1+ (0.25,-128) [-150|150] "Unit_MeterPerSecond" XXX
+ SG_ Right_Lane_02_Long_Distance : 224|12@1+ (0.0625,-3.75) [0|300] "Unit_Meter" XXX
  SG_ Right_Lane_02_Lat_Distance : 236|10@1+ (0.065,-33.28) [-50|50] "Unit_Meter" XXX
- SG_ Right_Lane_02_Rel_Velo : 246|10@1+ (0.28,-143.36) [-150|150] "Unit_MeterPerSecond" XXX
+ SG_ Right_Lane_02_Rel_Velo : 246|10@1+ (0.25,-128) [-150|150] "Unit_MeterPerSecond" XXX
  SG_ Same_Lane_01_Unknown_01 : 256|8@1+ (1,-128) [0|31] "" XXX
  SG_ Same_Lane_01_Unknown_02 : 264|6@1+ (1,-15) [0|31] "" XXX
  SG_ Same_Lane_01_Unknown_03 : 270|6@1+ (1,0) [0|127] "" XXX

--- a/opendbc_repo/opendbc/dbc/vw_meb_2024.dbc
+++ b/opendbc_repo/opendbc/dbc/vw_meb_2024.dbc
@@ -2109,6 +2109,7 @@ CM_ BO_ 522 "Steuergerät für Fahrzeugbewegung";
 CM_ BO_ 1622 "Steuergerät für Lenkungsverriegelung";
 CM_ BO_ 316495165 "Steuergerät ICAS1";
 CM_ BO_ 441800001 "Steuergerät für Fahrzeugbewegung";
+VAL_ 313 Long_Control_Inhibit 1 "not_inhibited" 2 "inhibited";
 VAL_ 64 AB_RGS_Anst 4 "aktiv_Niveau_1" 5 "aktiv_Niveau_2" 6 "aktiv_Niveau_3" 7 "aktiv_Niveau_4" 8 "deaktiviert";
 VAL_ 64 AB_Front_Crash 0 "kein_Front_Crash" 1 "Front_Crash";
 VAL_ 64 AB_Heck_Crash 0 "kein_Heck_Crash" 1 "Heck_Crash";
@@ -3503,6 +3504,7 @@ BO_ 313 VMM_02: 32 XXX
  SG_ AEB_Active : 31|1@0+ (1,0) [0|1] "" XXX
  SG_ ESP_Hold : 35|1@0+ (1,0) [0|1] "" XXX
  SG_ Brake_Pressed_3 : 48|1@0+ (1,0) [0|1] "" XXX
+ SG_ Long_Control_Inhibit : 52|2@1+ (1,0) [0|3] "" XXX
  SG_ FCW_Reaction_2 : 56|1@1+ (1,0) [0|1] "" XXX
  SG_ Brake_Pressure : 76|11@1+ (1,0) [0|100] "" XXX
  SG_ FCW_Reaction_3 : 88|5@1+ (1,0) [0|31] "" XXX


### PR DESCRIPTION
## 변경 내용

이번에 ID.4가 commaai/opendbc에 공식 포팅되어 (`b4ef5e1` 기준, CARS.md Upstream 등급), 공식 코드와 carrot MEB 포트를 파일 단위로 대조했습니다. 확인된 개선점을 이식하고, 대조 과정에서 발견한 기존 결함도 함께 수정했습니다. 전 항목 ID.4 MK1/MK2 실차 rlog로 검증했습니다.

**1. 레이더 거리/상대속도 스케일 12% 오차 수정 (체감 변화 있음)**
- `Strukturen_01`의 `Long_Distance` (0.07,-6) → (0.0625,-3.75), `Rel_Velo` (0.28,-143.36) → (0.25,-128)
- 순정 계기판 절대거리(`MEB_ACC_01.Lead_Distance`)와 rlog 3개 전수 대조: 신규 스케일 잔차 RMS 0.56m, 기존 스케일 2.1m (8~86m 구간)
- 기존에는 리드 거리·상대속도를 약 12% 크게 읽어 추종 간격이 목표에 수렴하지 못하고 가까워졌다 멀어졌다 반복했습니다. 수정 후 실주행에서 추종 간격 개선 확인.

**2. 정차 홀드 해제 시 램프 상태(LOESEN_UEBER_RAMPE) 경유**
- `ACC_Anforderung_HMS`를 HALTEN(1)/ANFAHREN(4)에서 KEINE_ANFORDERUNG(0)으로 직행시키면 차가 P로 폴트날 수 있습니다 (commaai/opendbc #3626에서 확인된 내용, #501의 근본 원인과 동일 계열)
- 직전에 홀드 계열을 보냈고 5km/h 미만이면 5(램프)를 거쳐 해제하도록 수정
- accFaulted 첫 프레임(CC.enabled가 아직 살아있는 구간)에도 같은 직행이 나갈 수 있어 disengage 램프를 타도록 수정

**3. `VMM_02.Long_Control_Inhibit` 반영 (신규 신호)**
- 저속 급제동 직후 차가 종방향 제어를 일시 거부하는 구간. 이때 출발요청을 넣으면 TSK가 폴트납니다
- 해당 구간에는 출발요청 차단 + 예정된 TSK 폴트로 보고 크루즈 오해제 방지
- DBC에 시그널 추가 (52|2@1+). MK1/MK2 로그 모두 평시 1(not_inhibited)로 안정 수신 확인

**4. 도어 열림 감지 수정 (기존에 동작하지 않던 기능)**
- 실차 검증 결과 MK1/MK2 모두 `Gateway_72.ZV_02_alt=1` 고정, 즉 도어의 실제 소스는 `ZV_02`(0x583)이고 기존에 읽던 `Gateway_72` 도어비트는 항상 0 → 문 열림이 감지되지 않던 상태였습니다
- commaai/opendbc 방식으로 `ZV_02_alt` 분기 추가

**5. 조향 파워 운전자 개입 반응 좌우 비대칭 수정**
- 부호 있는 `steeringTorque`를 `np.interp`에 넣어 음(-) 방향 개입에서는 파워가 감소하지 않던 문제. `abs()`로 수정 (commaai/opendbc 동일)

**6. steeringPressed 5프레임(50ms) 디바운스**
- 노면 요철 한 방에 개입 판정되어 곡률 PID unwind/override가 튀는 것 방지. 임계값(0.6Nm)은 실차 검증값 유지

**7. 기어 소스 판정을 핑거프린트 기반으로 (`ALT_GEAR`)**
- MEB_GEN2 플래그 하드코딩 대신 `Gateway_73`(0x3DC) 존재 여부로 판정 (commaai/opendbc 동일, 플래그 값 32 동일)
- MK1 실측: 두 기어 소스 1205/1205 프레임 완전 일치 확인 후 전환

**8. 기타**
- `vw_meb.dbc`의 BO_ 591 이중 정의(MEB_Distance_01/Strukturen_01) 제거
- 레이더 가림 감지: `Distance_Status != 0` → `radarUnavailableTemporary`
- ESP 상태 실측 (`espDisabled`/`espActive` ← ESP_21), EA 활성 개입(3~6) → `carFaultedNonCritical`
- `acc_type`을 순정 레이더 `ACC_18.ACC_Typ`에서 실측 (RX CRC MK1/MK2 각 3000프레임 전수 통과 확인, 카메라 하네스는 기존 2 고정 유지)
- `ACC_18.Speed` 11→12비트 (vw_meb_2024/commaai와 통일)

## 검증

- [V] 관련 테스트를 실행했습니다.
- [] 사용자에게 보이는 동작이 바뀌면 `docs/user/ko`와 `docs/user/en`의 연결된 문서 쌍을 함께 수정했습니다.

- 파이썬 전 파일 컴파일 통과, DBC 파싱/비트 중복 검사 통과
- 레이더 스케일: 순정 계기판 절대거리와 rlog 3개 전수 대조 (위 수치)
- 홀드 램프: P 폴트 발생 rlog로 기존/신규 로직 시뮬레이션 대조 (기존: 4→0 직행 재현, 신규: 4→5→0)
- ACC_18 RX CRC: MK1/MK2 각 3000프레임 전수 통과
- ID.4 MK1 실차 주행 확인 (추종 간격 개선 체감 보고)

Docs-Not-Needed: 차량 내부 CAN 신호 처리 및 제어 로직 수정으로, 사용자 설정/UI/사용법 변화가 없습니다.
