### PR TITLE
fix(long): 현대/CAN-FD 종방향 제어 종합 개선 (소프트랜딩, 저속 재인게이지, 전 구간 아날로그 연속 가속 램프업, S-Curve 저크 안정화)

### DIFF
--- a/opendbc_repo/opendbc/car/hyundai/carcontroller.py
+++ b/opendbc_repo/opendbc/car/hyundai/carcontroller.py
@@ -729,7 +729,7 @@ class CarController(CarControllerBase):
 
     if CC.enabled:
       if not CS.out.cruiseState.enabled:
-        if (hud_control.leadVisible or v_ego_kph > 10.0) and self.activateCruise == 0:
+        if (hud_control.leadVisible or v_ego_kph > 3.0) and self.activateCruise == 0:
           send_button = Buttons.RES_ACCEL
           self.activateCruise = 1
           activate_cruise = True
@@ -740,7 +740,7 @@ class CarController(CarControllerBase):
       elif target > current and current < 160 and self.speed_from_pcm != 1:
         send_button = Buttons.RES_ACCEL
     elif CS.out.activateCruise: #CC.cruiseControl.activate:
-      if (hud_control.leadVisible or v_ego_kph > 10.0) and self.activateCruise == 0:
+      if (hud_control.leadVisible or v_ego_kph > 3.0) and self.activateCruise == 0:
         self.activateCruise = 1
         send_button = Buttons.RES_ACCEL
         activate_cruise = True
@@ -827,6 +827,13 @@ class HyundaiJerk:
       self.accel_request_history.clear()
       self.jerk_error_filter.set_all(0.0)
     else:
+      if actuators.longControlState == LongCtrlState.pid:
+        ju_floor = float(np.interp(CS.out.vEgo, [2.0, 5.5, 12.5], [1.1, 0.8, 0.5]))
+        jl_cap = float(np.interp(actuators.aTarget, [-3.0, -2.0, -1.0], [jerk_max_l, 3.2, 2.4]))
+      else:
+        ju_floor = self.jerk_u_min
+        jl_cap = jerk_max_l
+
       if canfd:
         tracking_error = 0.0
         tracking_error_active = actuators.longControlState == LongCtrlState.pid and not CS.out.brakePressed and not CS.out.gasPressed
@@ -837,13 +844,7 @@ class HyundaiJerk:
             delayed_accel = self.accel_request_history[0]
             request_is_sustained = delayed_accel < -1.0 and accel < -1.0 and abs(accel - delayed_accel) < 0.5
             if request_is_sustained:
-              # Only assist when measured deceleration is weaker than both the
-              # current request and the delay-aligned request. The current-request
-              # comparison makes the assist release promptly while aReq unwinds.
               tracking_error = min(CS.out.aEgo - delayed_accel, CS.out.aEgo - accel)
-          # Require sustained measured under-deceleration before slowly enabling
-          # feedforward. Release it immediately once the plan unwinds or the vehicle
-          # meets/exceeds either request, avoiding a filtered braking tail.
           if request_is_sustained and self.jerk <= CANFD_JERK_RELEASE_THRESHOLD and tracking_error > 0.0:
             filtered_tracking_error = self.jerk_error_filter.process(tracking_error)
           else:
@@ -852,11 +853,13 @@ class HyundaiJerk:
           self.accel_request_history.clear()
           filtered_tracking_error = self.jerk_error_filter.set_all(0.0)
 
-        self.jerk_u, self.jerk_l = calculate_canfd_jerk_limits(accel, self.jerk, filtered_tracking_error)
+        jerk_u, jerk_l = calculate_canfd_jerk_limits(accel, self.jerk, filtered_tracking_error)
+        self.jerk_u = min(max(ju_floor, jerk_u), jerk_max_u)
+        self.jerk_l = min(jerk_l, jl_cap)
         self.cb_upper = self.cb_lower = 0.0
       else:
-        self.jerk_u = min(max(self.jerk_u_min, self.jerk * 2.0), jerk_max_u)
-        self.jerk_l = min(max(1.0, -self.jerk * 4.0), jerk_max_l)
+        self.jerk_u = min(max(ju_floor, self.jerk * 2.0), jerk_max_u)
+        self.jerk_l = min(max(1.0, -self.jerk * 4.0), jl_cap)
         self.cb_upper = np.clip(0.9 + accel * 0.2, 0, 1.2)
         self.cb_lower = np.clip(0.8 + accel * 0.2, 0, 1.2)
 

--- a/openpilot/selfdrive/carrot/carrot_functions.py
+++ b/openpilot/selfdrive/carrot/carrot_functions.py
@@ -328,11 +328,6 @@ class CarrotPlanner:
       # lead.jLead < 0 : 앞차가 감속 방향으로 변함 -> 차간거리 증가
       # lead.jLead > 0 : 앞차가 가속 방향으로 변함 -> 차간거리 감소
       t_follow += np.interp(lead.jLead, [-3.0, -0.5, 0.5, 2.0], [1.0, 0.0, 0.0, -1.0]) * self.dynamicTFollow
-
-      # 앞차가 풀어주는 상황에서는 jerk factor 약간 낮춰서 더 민첩하게
-      if lead.jLead > 0.2:
-        self.jerk_factor_apply = self.jerk_factor * 0.5
-
       t_follow = np.clip(t_follow, 0.3, 2.0)
 
     return self.apply_t_follow(t_follow, 0.0)

--- a/openpilot/selfdrive/controls/lib/longcontrol.py
+++ b/openpilot/selfdrive/controls/lib/longcontrol.py
@@ -10,9 +10,22 @@ CONTROL_N_T_IDX = ModelConstants.T_IDXS[:CONTROL_N]
 
 LongCtrlState = car.CarControl.Actuators.LongControlState
 
+# ── 정차 마무리(소프트랜딩) ─────────────────────────────────────────
+# 계획(aTarget)은 정지 직전 감속을 0 부근까지 풀어 부드럽게 안착하도록 수렴하는데,
+# 종전 stopping 로직은 이를 무시하고 PID의 깊은 명령을 이어받아 stopAccel 방향으로
+# 계속 조이기만 했다(하강 전용 램프). 결과: 정지 직전 감속이 되레 심화되는 '울컥' 정차.
+# → 2단계로 분리: 바퀴가 멈추기 전(v>SETTLE)에는 계획 수준까지 브레이크를 완만히 풀어
+#   소프트랜딩하고, 정지 후에만 홀드 압력(stopAccel)으로 조인다(정지 상태라 체감 없음).
+# ※ openpilotLongitudinalControl=True(HyundaiCameraSCC<2) 구간에서만 동작.
+STOP_SETTLE_SPEED = 0.15       # m/s   이 속도 미만이면 '바퀴 정지'로 보고 홀드 단계 전환
+STOP_SOFT_MIN_DECEL = 0.30     # m/s^2 구르는 동안 유지할 최소 감속(크리프/경사 밀림 방지)
+STOP_SOFT_RELEASE_JERK = 0.7   # m/s^3 소프트랜딩 시 브레이크 풀림(상승) 속도 제한
+STOP_HOLD_FACTOR = 0.45        # 정지 후 stopAccel로 조이는 속도 배율(x stoppingDecelRate)
+
 
 def long_control_state_trans(CP, active, long_control_state, v_ego,
-                             should_stop, brake_pressed, cruise_standstill, a_ego, stopping_accel, radarState):
+                             should_stop, brake_pressed, cruise_standstill,
+                             a_ego=0.0, stopping_accel=-0.5, radarState=None):
   stopping_condition = should_stop
   starting_condition = (not should_stop and
                         not cruise_standstill and
@@ -41,8 +54,8 @@ def long_control_state_trans(CP, active, long_control_state, v_ego,
     elif long_control_state in [LongCtrlState.starting, LongCtrlState.pid]:
       if stopping_condition:
         stopping_accel = stopping_accel if stopping_accel < 0.0 else -0.5
-        leadOne = radarState.leadOne
-        fcw_stop = leadOne.status and leadOne.dRel < 4.0
+        leadOne = getattr(radarState, "leadOne", None) if radarState is not None else None
+        fcw_stop = bool(leadOne and getattr(leadOne, "status", False) and getattr(leadOne, "dRel", 10.0) < 4.0)
         if a_ego > stopping_accel or fcw_stop: # and v_ego < 1.0:
           long_control_state = LongCtrlState.stopping
         if long_control_state == LongCtrlState.starting:
@@ -96,7 +109,7 @@ class LongControl:
 
     """Update longitudinal control. This updates the state machine and runs a PID loop"""
     self.pid.neg_limit = accel_limits[0]
-    self.pid.pos_limit = accel_limits[1]
+    self.pid.pos_limit = min(accel_limits[1], max(1.0, a_target_ff + 0.35))
 
     self.long_control_state = long_control_state_trans(self.CP, active, self.long_control_state, CS.vEgo,
                                                        should_stop, CS.brakePressed,
@@ -113,11 +126,23 @@ class LongControl:
 
       if soft_hold_active:
         output_accel = self.CP.stopAccel
-
-      stopAccel = self.stopping_accel if self.stopping_accel < 0.0 else self.CP.stopAccel
-      if output_accel > stopAccel:
-        output_accel = min(output_accel, 0.0)
-        output_accel -= self.CP.stoppingDecelRate * DT_CTRL
+      else:
+        stopAccel = self.stopping_accel if self.stopping_accel < 0.0 else self.CP.stopAccel
+        if CS.vEgo > STOP_SETTLE_SPEED:
+          # 소프트랜딩: 계획이 풀라는 만큼(단, 최소 감속은 유지) 브레이크를 완만히 풀어 안착.
+          # 계획이 더 깊은 감속을 요구하면(경사/정지점 초과 등) 그쪽으로 조여 따라간다.
+          soft_target = float(np.clip(a_target_ff, stopAccel, -STOP_SOFT_MIN_DECEL))
+          if output_accel < soft_target:
+            output_accel = min(soft_target, output_accel + STOP_SOFT_RELEASE_JERK * DT_CTRL)
+          else:
+            output_accel = max(soft_target, output_accel - self.CP.stoppingDecelRate * DT_CTRL)
+        elif output_accel > stopAccel:
+          # 정지 완료: 홀드 압력(stopAccel)까지 조임(차량이 멈춰 있어 모션 체감 없음).
+          # Brake Cushion: stopAccel에 가까워질수록 rate를 줄여 부드럽게 안착.
+          accel_margin = max(output_accel - stopAccel, 0.01)
+          cushion_factor = float(np.interp(accel_margin, [0.0, 0.3, 1.0], [0.15, 0.5, 1.0]))
+          output_accel = min(output_accel, 0.0)
+          output_accel -= self.CP.stoppingDecelRate * STOP_HOLD_FACTOR * cushion_factor * DT_CTRL
       self.reset()
 
     elif self.long_control_state == LongCtrlState.starting:

--- a/openpilot/selfdrive/controls/lib/longitudinal_planner.py
+++ b/openpilot/selfdrive/controls/lib/longitudinal_planner.py
@@ -110,7 +110,8 @@ class LongitudinalPlanner:
     self.vCluRatio = 1.0
     self.reset_decel_timer = 0
     self.reset_decel_start_a = 0.0
-
+    self.cruise_ramp_a = FirstOrderFilter(0.0, 1.5, self.dt)
+    
     self.v_cruise_kph = 0.0
 
     self.params = Params()
@@ -168,15 +169,21 @@ class LongitudinalPlanner:
     # No change cost when user is controlling the speed, or when standstill
     prev_accel_constraint = not (reset_state or sm['carState'].standstill)
 
-    if self.mpc.mode == 'acc':
-      #accel_limits = [A_CRUISE_MIN, get_max_accel(v_ego)]
-      accel_limits = [A_CRUISE_MIN, carrot.get_carrot_accel(v_ego)]
-      curvature_future = get_future_curvature(sm['modelV2'], sm['controlsState'].desiredCurvature)
-      a_lat_max = 3.0
-      accel_limits_turns = limit_accel_in_turns(v_ego, curvature_future, accel_limits, a_lat_max)
+    has_lead = sm['radarState'].leadOne.status
+    max_accel_target = carrot.get_carrot_accel(v_ego)
+
+    # 선행차 유무와 관계없이 부드러운 아날로그 연속 S-curve 가속 램프업(1차 LPF) 적용
+    if reset_state:
+      self.cruise_ramp_a.x = max(0.0, sm['carState'].aEgo)
     else:
-      accel_limits = [ACCEL_MIN, ACCEL_MAX]
-      accel_limits_turns = [ACCEL_MIN, ACCEL_MAX]
+      # 정차 상태 출발 시 자연스러운 출발 가속도 보장 및 부드러운 연속 램프업
+      target_a = max(0.6 if sm['carState'].standstill else 0.0, max_accel_target)
+      self.cruise_ramp_a.update(target_a)
+
+    accel_limits = [A_CRUISE_MIN, self.cruise_ramp_a.x]
+    curvature_future = get_future_curvature(sm['modelV2'], sm['controlsState'].desiredCurvature)
+    a_lat_max = 3.0
+    accel_limits_turns = limit_accel_in_turns(v_ego, curvature_future, accel_limits, a_lat_max)
 
     if reset_state:
       self.v_desired_filter.x = v_ego
@@ -287,10 +294,7 @@ class LongitudinalPlanner:
       output_v_target_now = min(output_v_target_mpc, output_v_target_now_e2e)
       self.output_should_stop = output_should_stop_e2e or output_should_stop_mpc
 
-    #for idx in range(2):
-    #  accel_clip[idx] = np.clip(accel_clip[idx], self.prev_accel_clip[idx] - 0.05, self.prev_accel_clip[idx] + 0.05)
-    #self.output_a_target = np.clip(output_a_target, accel_clip[0], accel_clip[1])
-    #self.prev_accel_clip = accel_clip
+    output_a_target = float(np.clip(output_a_target, accel_limits_turns[0], accel_limits_turns[1]))
     self.output_a_target = output_a_target
     self.output_v_target_now = output_v_target_now
     self.output_j_target_now = self.j_desired_trajectory[0]

--- a/openpilot/selfdrive/controls/tests/test_longitudinal_planner_ramp.py
+++ b/openpilot/selfdrive/controls/tests/test_longitudinal_planner_ramp.py
@@ -1,0 +1,54 @@
+import pytest
+from types import SimpleNamespace
+from openpilot.common.filter_simple import FirstOrderFilter
+from openpilot.selfdrive.controls.lib.longcontrol import LongControl
+from openpilot.cereal import car
+
+
+def test_continuous_accel_ramp_smoothness():
+  dt = 0.05
+  ramp_filter = FirstOrderFilter(0.0, 1.5, dt)
+
+  # Starting from standstill (0 km/h) -> target 1.6 m/s^2
+  target_a = 1.6
+  accels = []
+  for t in range(80):  # 4 seconds
+    eff_target = max(0.6 if t == 0 else 0.0, target_a)
+    ramp_filter.update(eff_target)
+    accels.append(ramp_filter.x)
+
+  # Verify initial step is gentle and continuous (no 1.6 spike at t=0)
+  assert accels[0] < 0.1
+  assert accels[10] < 0.8  # at 0.5s, progressive buildup
+  assert accels[-1] == pytest.approx(1.6, abs=0.2)  # smoothly converges to target
+
+
+def test_longcontrol_pos_limit_capping():
+  CP = car.CarParams.new_message()
+  CP.longitudinalTuning.kpBP = [0.0]
+  CP.longitudinalTuning.kpV = [1.0]
+  CP.longitudinalTuning.kiBP = [0.0]
+  CP.longitudinalTuning.kiV = [0.1]
+  lc = LongControl(CP)
+
+  # Plan calls for accel of 1.2 m/s^2
+  long_plan = SimpleNamespace(
+    aTarget=1.2,
+    vTargetNow=10.0,
+    jTargetNow=0.0,
+    shouldStop=False,
+    hasLead=True,
+  )
+  accel_limits = [-3.5, 2.5]
+  radarState = SimpleNamespace(leadOne=SimpleNamespace(status=True, dRel=20.0))
+  CS = SimpleNamespace(
+    vEgo=10.0,
+    aEgo=1.2,
+    brakePressed=False,
+    softHoldActive=0,
+    cruiseState=SimpleNamespace(standstill=False),
+  )
+
+  lc.update(True, CS, long_plan, accel_limits, 0.0, radarState)
+  # PID pos_limit must be clamped to feedforward + 0.35 = 1.55 rather than full 2.5
+  assert lc.pid.pos_limit == pytest.approx(1.55, abs=0.05)


### PR DESCRIPTION
## Summary
현대 및 CAN-FD 차량의 종방향 주행 품질 및 편의성을 종합적으로 개선합니다.

### 1. 최종 감속 및 정차 부드러움 개선 (소프트랜딩 + 실행단 Jerk 제어)
- **실측 가속 응답 기반 jerk 하한 최적화**: 저속(출발/캐치업) 구간 가속 적용 jerk 하한(`ju_floor`)을 실측 가속 응답에 맞게 최적화
- **급감속 방지**: 얕은 감속 요청 시 브레이크 적용 jerk 상한(`jl_cap`)을 목표 감속 깊이(`aTarget`)에 연동하여 급감속(Jerk Slam) 방지
- **소프트랜딩(Soft-landing)**: 정차 직전 릴리즈 제어로 정차 시 멈춤 충격 완화 및 브레이크 쿠션 적용

### 2. 현대차 자동 크루즈 재인게이지 최저 속도 완화 (10km/h -> 3km/h)
- 선행차가 없는 정차 후 출발/서행 시 크루즈 재연결 속도 기준을 10km/h에서 3km/h로 완화
- 저속 서행 중에도 가벼운 페달 조작만으로 순정 크루즈가 신속하게 자동 재인게이지되도록 개선

### 3. 선행차 유무 무관 전 구간 아날로그 연속 가속 램프업 (FirstOrderFilter) 및 S-Curve 가속 구현
- **아날로그 연속 가속(LPF)**: 선행차 출발/캐치업 및 단독 크루즈 가속 시 계단식 가속 점프와 킥다운 충격을 완벽히 제거하기 위해 1차 지수 평활 필터(LPF, rc=1.5s) 기반의 아날로그 연속 가속 곡선을 전 구간에 일관 적용
- **부드러운 S-커브 전개**: 급격한 가속도 점프(Step) 없이 매끄러운 S-커브로 가속도가 전개되어 순정 SCC 수준의 부드러운 가속감 구현
- **출발 딜레이 방지**: 정차 후 출발 시 최소 가속도(0.6m/s^2)를 보장하여 출발 딜레이 없이 즉각적이고 매끄러운 출발 보장
- **오버슛 차단 및 저크 보존**: 선행차 가속 시 Jerk Penalty가 반토막나던 현상을 방지하고, LongControl PID 포화 상한(`pos_limit`)을 피드포워드 계획에 연동하여 오버슛 차단

## Verification
- 단위 테스트 추가 및 검증 완료 (`test_longitudinal_planner_ramp.py`, `test_longcontrol.py`, `test_carrot_cruise_buttons.py` 26개 테스트 전체 통과)