### PR TITLE
Use vehicle navi availability for CAN-FD nav icon

### DIFF
--- a/opendbc_repo/opendbc/car/hyundai/hyundaicanfd.py
+++ b/opendbc_repo/opendbc/car/hyundai/hyundaicanfd.py
@@ -783,6 +783,8 @@ def create_ccnc_messages(CP, packer, CAN, frame, CC, CS, hud_control,
         cruise_enabled = CC.enabled
         lat_enabled = CS.out.latEnabled
         nav_active = hud_control.activeCarrot > 1
+        vehicle_navi_available = CS.out.vehicleNaviAvailable
+        nav_icon_available = nav_active or vehicle_navi_available
 
         # hdpuse carrot
         hdp_use = int(Params().get("HDPuse"))
@@ -813,7 +815,7 @@ def create_ccnc_messages(CP, packer, CAN, frame, CC, CS, hud_control,
         values["CENTERLINE"] = 1 if HDA_CntrlModSta > 0 else 0
         values["CAR_CIRCLE"] = 2 if hdp_active else 1 if cruise_enabled else 0
 
-        values["NAV_ICON"] = 2 if nav_active and cruise_enabled else 1 if main_enabled and nav_active else 0
+        values["NAV_ICON"] = 2 if nav_icon_available and cruise_enabled else 1 if main_enabled and nav_icon_available else 0
         values["HDA_ICON"] = 5 if hdp_active else 2 if cruise_enabled else 1 if main_enabled else 0
         values["LFA_ICON"] = 5 if hdp_active else 2 if lat_active else 1 if lat_enabled else 0
         values["LKA_ICON"] = 4 if lat_active else 3 if lat_enabled else 0


### PR DESCRIPTION
## 변경 내용

vNavi 값을 ccNc 클러스터 NAVI 아이콘에 추가 적용
기존 activeCarrot과 같이 사용됨
